### PR TITLE
fix(analysis): classify .markdown as docs and extensionless dotfile configs as config (subtractive pruning works for config/docs-only PRs)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -451,6 +451,14 @@ The decision is a pure, deterministic, fail-closed seam — `resolveAngleCarryFo
 
 **Fail-closed defaults (carry forward = false unless proven safe).** Must-re-run whenever: the prior verdict is not `clean`; the prior findings-log is missing / not clean; the delta is empty or unavailable; any changed file is unclassifiable (`unknown` kind); the angle has no declared surface (unmapped); the angle is a configured mandatory angle (the CLI loads the gate's angle entries with `mandatory: true` and forces every one to re-run, never carried); or any changed file's kind is in the angle's surface.
 
+**A dev-loop config-source delta re-runs EVERY angle.** `.devloops` (and its
+`.devloops.yaml/.yml/.json` and `.pi/dev-loop/settings.*`/`defaults.*` siblings)
+defines the gate's angle pool, mandatory floor, and reviewer personas/prompts —
+a clean verdict produced under the OLD config has no valid provenance across a
+change to it, regardless of the angle's declared surface. `classifyFile`
+correctly reports these files as `config`; the carry-forward seam overrides
+that via `isDevLoopConfigSourcePath` and forces a full re-run (fail-closed).
+
 **Renames force the RENAME_ONLY angles to re-run.** A rename records only its destination path, so classifying that path alone would miss what the move itself implicates (a relocated doc breaking a link, a moved test/code file shifting scope/contract-surface). When the delta `git diff A..B` contains ANY rename/copy row, the CLI forces the RENAME_ONLY-mapped angles (`CATEGORY_ANGLE_MAP[RENAME_ONLY]`: `scope`, `correctness`, `contract-surface`, `docs`, `link-check`) to re-run for that run; the remaining angles still follow the surface rule above.
 
 **Provenance — carried, not fabricated.** A carried verdict preserves the fail-closed evidence contract. The new head's findings-log records the carried angle in `provenance.perAngle` with `carriedFromHead: <A>` and the SAME `reviewer` identity that reviewed it at head A (honest attribution — that reviewer genuinely reviewed this angle's surface, which the delta did not change). `distinctReviewers` still counts real reviewer identities and the mandatory-angle / distinct-reviewer consistency checks in `write-gate-findings-log.mjs` are unchanged; carry-forward never invents a reviewer or a fresh review.

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -14,8 +14,12 @@
 // ---------------------------------------------------------------------------
 
 // Extensionless dotfile configs: static allowlist, no content sniffing. Matched
-// against the basename only (e.g. `foo/.nvmrc`), never a prefix/suffix guess.
-const DOTFILE_CONFIG_BASENAMES = new Set([".devloops", ".nvmrc", ".ruby-version"]);
+// against the basename only, never a prefix/suffix guess. Deliberately just
+// .devloops (the reported consumer shape): runtime-version files like .nvmrc
+// were considered and REJECTED — classifying them config would let ci-guard/
+// determinism carry stale clean verdicts across a runtime bump; unknown
+// fails closed toward a full re-review, which is what a version bump needs.
+const DOTFILE_CONFIG_BASENAMES = new Set([".devloops"]);
 
 /**
  * @typedef {object} T0Result

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -252,7 +252,9 @@ export function diffHasSecuritySeam(diffOutput) {
  *
  * Detects:
  * - COMMENT_ONLY: only comment lines changed
- * - DOCS_ONLY: every changed file classifies as docs (docs extensions .md/.markdown, or prose under docs/)
+ * - DOCS_ONLY: emitted when docs files are PRESENT in the diff (docs extensions
+ *   .md/.markdown, or prose under docs/) — presence-based via
+ *   t0PresentSurfaceCategories, not exclusivity
  * - CONFIG_ONLY: only config files changed
  * - TEST_ONLY: only test files changed
  * - RENAME_ONLY: all renames, no content changes

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -23,7 +23,7 @@ const DOTFILE_CONFIG_BASENAMES = new Set([".devloops", ".nvmrc", ".ruby-version"
  * @property {string[]} extensions — unique file extensions (lowercase, with dot)
  * @property {string[]} directories — unique top-level path segments
  * @property {boolean} renameOnly — true when all entries are renames (no adds/deletes/modifies)
- * @property {boolean} allDocs — true when all files are under docs/ or are .md
+ * @property {boolean} allDocs — true when all files are under docs/ or have a docs extension (.md/.markdown)
  */
 
 /**
@@ -252,7 +252,7 @@ export function diffHasSecuritySeam(diffOutput) {
  *
  * Detects:
  * - COMMENT_ONLY: only comment lines changed
- * - DOCS_ONLY: only .md files changed (from extensions)
+ * - DOCS_ONLY: only docs-extension files changed (.md/.markdown, from extensions)
  * - CONFIG_ONLY: only config files changed
  * - TEST_ONLY: only test files changed
  * - RENAME_ONLY: all renames, no content changes

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -252,7 +252,7 @@ export function diffHasSecuritySeam(diffOutput) {
  *
  * Detects:
  * - COMMENT_ONLY: only comment lines changed
- * - DOCS_ONLY: only docs-extension files changed (.md/.markdown, from extensions)
+ * - DOCS_ONLY: every changed file classifies as docs (docs extensions .md/.markdown, or prose under docs/)
  * - CONFIG_ONLY: only config files changed
  * - TEST_ONLY: only test files changed
  * - RENAME_ONLY: all renames, no content changes

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -13,6 +13,10 @@
 // T0: File-level analysis
 // ---------------------------------------------------------------------------
 
+// Extensionless dotfile configs: static allowlist, no content sniffing. Matched
+// against the basename only (e.g. `foo/.nvmrc`), never a prefix/suffix guess.
+const DOTFILE_CONFIG_BASENAMES = new Set([".devloops", ".nvmrc", ".ruby-version"]);
+
 /**
  * @typedef {object} T0Result
  * @property {string[]} files — flat file paths
@@ -106,6 +110,9 @@ export function classifyFile(filePath) {
   ) {
     return "config";
   }
+  if (DOTFILE_CONFIG_BASENAMES.has(fp.split("/").pop())) {
+    return "config";
+  }
   if (fp.includes(".test.") || fp.startsWith("test/")) {
     return "test";
   }
@@ -115,7 +122,10 @@ export function classifyFile(filePath) {
   ) {
     return "code";
   }
-  if (fp.startsWith("docs/") || fp.endsWith(".md") || fp === "README.md") {
+  if (
+    fp.startsWith("docs/") || fp.endsWith(".md") || fp.endsWith(".markdown") ||
+    fp === "README.md"
+  ) {
     return "docs";
   }
   return "unknown";

--- a/packages/core/src/loop/gate-carry-forward.mjs
+++ b/packages/core/src/loop/gate-carry-forward.mjs
@@ -149,6 +149,19 @@ export function angleReviewSurface(angle, { alwaysRerun } = {}) {
  *   is carry-forward-eligible.
  * @returns {{ carryForward: boolean, reason: string }}
  */
+
+// A path whose change rewrites the dev-loop review system itself — the angle
+// pool, mandatory floor, and reviewer personas/prompts — rather than a
+// reviewed surface. A clean verdict produced under the OLD config cannot
+// carry across such a delta, and a converged Copilot round cannot be treated
+// as still-converged either. classifyFile correctly reports these as
+// "config"; this predicate is the carry-forward-specific override.
+const DEV_LOOP_CONFIG_SOURCE_RE = /(^|\/)(\.devloops(\.(ya?ml|json))?|\.pi\/dev-loop\/(settings|defaults)\.[^/]+)$/;
+export function isDevLoopConfigSourcePath(filePath) {
+  if (typeof filePath !== "string") return false;
+  return DEV_LOOP_CONFIG_SOURCE_RE.test(filePath.trim());
+}
+
 export function resolveAngleCarryForward({ angle, angleSurface, changedFiles, prevVerdict }) {
   if (prevVerdict !== "clean") {
     return { carryForward: false, reason: `prior verdict is ${JSON.stringify(prevVerdict ?? null)}, not "clean"` };
@@ -164,6 +177,9 @@ export function resolveAngleCarryForward({ angle, angleSurface, changedFiles, pr
     return { carryForward: false, reason: "delta is empty or unavailable (fail-closed)" };
   }
   for (const file of changedFiles) {
+    if (isDevLoopConfigSourcePath(file)) {
+      return { carryForward: false, reason: `delta rewrites the dev-loop config source (reviewer pool/prompts): ${file}` };
+    }
     const kind = classifyFile(file);
     if (kind === "unknown") {
       return { carryForward: false, reason: `delta contains an unclassifiable file (fail-closed): ${file}` };

--- a/packages/core/src/loop/gate-carry-forward.mjs
+++ b/packages/core/src/loop/gate-carry-forward.mjs
@@ -159,7 +159,9 @@ export function angleReviewSurface(angle, { alwaysRerun } = {}) {
 const DEV_LOOP_CONFIG_SOURCE_RE = /(^|\/)(\.devloops(\.(ya?ml|json))?|\.pi\/dev-loop\/(settings|defaults)\.[^/]+)$/;
 export function isDevLoopConfigSourcePath(filePath) {
   if (typeof filePath !== "string") return false;
-  return DEV_LOOP_CONFIG_SOURCE_RE.test(filePath.trim());
+  // Normalize Windows separators like classifyFile does, so a
+  // ".pi\\dev-loop\\settings.yaml" delta is still detected on Windows.
+  return DEV_LOOP_CONFIG_SOURCE_RE.test(filePath.trim().replace(/\\/g, "/"));
 }
 
 export function resolveAngleCarryForward({ angle, angleSurface, changedFiles, prevVerdict }) {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -67,9 +67,11 @@ test("classifyFile: docs for .markdown files", () => {
 
 test("classifyFile: config for allowlisted extensionless dotfiles", () => {
   assert.equal(classifyFile(".devloops"), "config");
-  assert.equal(classifyFile(".nvmrc"), "config");
-  assert.equal(classifyFile(".ruby-version"), "config");
-  assert.equal(classifyFile("packages/core/.nvmrc"), "config");
+  // Runtime-version dotfiles stay unknown (fail-closed): a .nvmrc bump must
+  // re-run ci-guard/determinism, not carry their stale clean verdicts.
+  assert.equal(classifyFile(".nvmrc"), "unknown");
+  assert.equal(classifyFile(".ruby-version"), "unknown");
+  assert.equal(classifyFile("packages/core/.nvmrc"), "unknown");
 });
 
 test("classifyFile: unrecognized extensionless dotfile stays unknown (no content sniffing)", () => {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -60,6 +60,22 @@ test("classifyFile: unknown for unrecognized", () => {
   assert.equal(classifyFile("assets/logo.png"), "unknown");
 });
 
+test("classifyFile: docs for .markdown files", () => {
+  assert.equal(classifyFile("docs/guide.markdown"), "docs");
+  assert.equal(classifyFile("CHANGELOG.markdown"), "docs");
+});
+
+test("classifyFile: config for allowlisted extensionless dotfiles", () => {
+  assert.equal(classifyFile(".devloops"), "config");
+  assert.equal(classifyFile(".nvmrc"), "config");
+  assert.equal(classifyFile(".ruby-version"), "config");
+  assert.equal(classifyFile("packages/core/.nvmrc"), "config");
+});
+
+test("classifyFile: unrecognized extensionless dotfile stays unknown (no content sniffing)", () => {
+  assert.equal(classifyFile(".env"), "unknown");
+});
+
 // ---------------------------------------------------------------------------
 // analyzeT0
 // ---------------------------------------------------------------------------
@@ -393,4 +409,37 @@ test("analyzeDiff: pure single-surface diffs keep exclusive semantics (no over-u
     analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md" }).t1.changeCategories,
     ["DOCS_ONLY"],
   );
+});
+
+test("analyzeDiff: .markdown-only diff → DOCS_ONLY", () => {
+  const result = analyzeDiff({ nameStatusOutput: "M\tdocs/guide.markdown" });
+  assert.equal(result.t0.allDocs, true);
+  assert.deepEqual(result.t1.changeCategories, ["DOCS_ONLY"]);
+});
+
+test("analyzeDiff: .devloops-only diff → CONFIG_ONLY", () => {
+  const result = analyzeDiff({ nameStatusOutput: "M\t.devloops" });
+  assert.deepEqual(result.t1.changeCategories, ["CONFIG_ONLY"]);
+});
+
+test("analyzeDiff → resolveDynamicAngles: .devloops + .markdown repro classifies docs+config, no fallback (#1450)", () => {
+  const result = analyzeDiff({
+    nameStatusOutput: "M\t.devloops\nA\tfoo.markdown",
+    diffOutput:
+      "--- a/.devloops\n+++ b/.devloops\n@@ -1,1 +1,1 @@\n-old\n+new\n" +
+      "--- /dev/null\n+++ b/foo.markdown\n@@ -0,0 +1,1 @@\n+# hi\n",
+  });
+  assert.equal(result.ambiguous, false);
+  assert.ok(result.t1.changeCategories.includes("DOCS_ONLY"));
+  assert.ok(result.t1.changeCategories.includes("CONFIG_ONLY"));
+
+  const dyn = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES,
+    changeCategories: result.t1.changeCategories,
+    ambiguous: result.ambiguous,
+  });
+  assert.equal(dyn.fallbackToAll, false);
+  assert.ok(dyn.recommendedAngles.includes("link-check"), "docs file must pull link-check");
+  assert.ok(dyn.recommendedAngles.includes("config-drift"), "config file must pull config-drift");
+  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length);
 });

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -412,7 +412,9 @@ test("analyzeDiff: pure single-surface diffs keep exclusive semantics (no over-u
 });
 
 test("analyzeDiff: .markdown-only diff → DOCS_ONLY", () => {
-  const result = analyzeDiff({ nameStatusOutput: "M\tdocs/guide.markdown" });
+  // Root-level, NOT under docs/ — the extension rule alone must classify it
+  // (the reported consumer shape is a root-level <branch>.markdown changelog).
+  const result = analyzeDiff({ nameStatusOutput: "M\tCHANGELOG.markdown" });
   assert.equal(result.t0.allDocs, true);
   assert.deepEqual(result.t1.changeCategories, ["DOCS_ONLY"]);
 });
@@ -441,5 +443,23 @@ test("analyzeDiff → resolveDynamicAngles: .devloops + .markdown repro classifi
   assert.equal(dyn.fallbackToAll, false);
   assert.ok(dyn.recommendedAngles.includes("link-check"), "docs file must pull link-check");
   assert.ok(dyn.recommendedAngles.includes("config-drift"), "config file must pull config-drift");
-  assert.ok(dyn.recommendedAngles.length < DRAFT_ANGLES.length);
+  // Pin the exact pruned set: a loose length check hid that the .devloops
+  // hunk's -old/+new lines also emit LOGIC_CHANGE (analyzeT1's hasLogicChange
+  // is not file-kind-gated), which pulls the code-review core alongside the
+  // docs/config lenses. Any change to that behavior must surface here.
+  assert.deepEqual(
+    [...dyn.recommendedAngles].sort(),
+    [
+      "config-drift",
+      "contract-surface",
+      "correctness",
+      "coverage",
+      "determinism",
+      "gate-evidence",
+      "input-validation",
+      "link-check",
+      "pr-description",
+      "scope",
+    ],
+  );
 });

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import test, { describe } from "node:test";
 
-import { CATEGORY_ANGLE_MAP } from "../src/analysis/change-classifier.mjs";
+import {
+  CATEGORY_ANGLE_MAP } from "../src/analysis/change-classifier.mjs";
 import {
   RENAME_ONLY_ANGLES,
   angleReviewSurface,
+  isDevLoopConfigSourcePath,
   resolveAngleCarryForward,
   resolveCarryForwardAngles,
   resolveConvergenceCarryForward,
@@ -60,7 +62,7 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
     assert.equal(decision.carryForward, true);
   });
 
-  test(".markdown-only delta carries a clean code angle like .md (post-convergence suppression parity)", () => {
+  test(".markdown-only delta carries a clean code angle like .md", () => {
     const decision = resolveAngleCarryForward({
       angle: "correctness",
       changedFiles: ["changes.markdown"],
@@ -69,22 +71,46 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
     assert.equal(decision.carryForward, true);
   });
 
-  test(".devloops-only delta carries clean non-config angles but re-runs config-surface ones (classifier reclassification pinned)", () => {
-    // Previously .devloops classified unknown → fail-closed re-run of every
-    // angle. Now it is config: coverage/link-check may carry a clean verdict,
-    // while config-drift (a config-surface angle) must still re-run.
-    const carried = resolveAngleCarryForward({
+  test(".devloops-only delta re-runs EVERY angle — it rewrites the reviewer pool/prompts (config-source override)", () => {
+    // classifyFile now calls .devloops "config", but a dev-loop config-source
+    // delta invalidates every prior verdict's provenance (the angle pool,
+    // mandatory floor, and reviewer prompts live there), so no angle may
+    // carry a clean verdict across it — not even one whose declared surface
+    // excludes config.
+    for (const angle of ["coverage", "link-check", "config-drift"]) {
+      const decision = resolveAngleCarryForward({
+        angle,
+        changedFiles: [".devloops"],
+        prevVerdict: "clean",
+      });
+      assert.equal(decision.carryForward, false, angle);
+      assert.match(decision.reason, /dev-loop config source/);
+    }
+    // Ordinary config (not a dev-loop config source) keeps surface semantics:
+    const ordinary = resolveAngleCarryForward({
       angle: "coverage",
-      changedFiles: [".devloops"],
+      changedFiles: ["package.json"],
       prevVerdict: "clean",
     });
-    assert.equal(carried.carryForward, true);
-    const rerun = resolveAngleCarryForward({
-      angle: "config-drift",
-      changedFiles: [".devloops"],
-      prevVerdict: "clean",
-    });
-    assert.equal(rerun.carryForward, false);
+    assert.equal(ordinary.carryForward, true);
+  });
+
+  test(".markdown-only post-convergence delta suppresses a fresh Copilot round like .md (resolveConvergenceCarryForward)", () => {
+    const md = resolveConvergenceCarryForward({ changedFiles: ["notes.md"] });
+    const markdown = resolveConvergenceCarryForward({ changedFiles: ["changes.markdown"] });
+    assert.equal(md.carryForward, true);
+    assert.equal(markdown.carryForward, true);
+    // .devloops stays a fresh-round trigger (config is in Copilot's surface):
+    assert.equal(resolveConvergenceCarryForward({ changedFiles: [".devloops"] }).carryForward, false);
+  });
+
+  test("isDevLoopConfigSourcePath matches the config-source family and nothing else", () => {
+    for (const p of [".devloops", ".devloops.yaml", ".devloops.yml", ".devloops.json", "sub/.devloops", ".pi/dev-loop/settings.yaml", ".pi/dev-loop/defaults.json"]) {
+      assert.equal(isDevLoopConfigSourcePath(p), true, p);
+    }
+    for (const p of ["package.json", "my.devloops", "docs/devloops.md", ".devloopsx", null]) {
+      assert.equal(isDevLoopConfigSourcePath(p), false, String(p));
+    }
   });
 
   test("code delta + code angle -> false", () => {

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import test, { describe } from "node:test";
 
-import {
-  CATEGORY_ANGLE_MAP } from "../src/analysis/change-classifier.mjs";
+import { CATEGORY_ANGLE_MAP } from "../src/analysis/change-classifier.mjs";
 import {
   RENAME_ONLY_ANGLES,
   angleReviewSurface,
@@ -105,7 +104,7 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
   });
 
   test("isDevLoopConfigSourcePath matches the config-source family and nothing else", () => {
-    for (const p of [".devloops", ".devloops.yaml", ".devloops.yml", ".devloops.json", "sub/.devloops", ".pi/dev-loop/settings.yaml", ".pi/dev-loop/defaults.json"]) {
+    for (const p of [".devloops", ".devloops.yaml", ".devloops.yml", ".devloops.json", "sub/.devloops", ".pi/dev-loop/settings.yaml", ".pi/dev-loop/defaults.json", ".pi\\dev-loop\\settings.yaml"]) {
       assert.equal(isDevLoopConfigSourcePath(p), true, p);
     }
     for (const p of ["package.json", "my.devloops", "docs/devloops.md", ".devloopsx", null]) {

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -60,6 +60,15 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
     assert.equal(decision.carryForward, true);
   });
 
+  test(".markdown-only delta carries a clean code angle like .md (post-convergence suppression parity)", () => {
+    const decision = resolveAngleCarryForward({
+      angle: "correctness",
+      changedFiles: ["changes.markdown"],
+      prevVerdict: "clean",
+    });
+    assert.equal(decision.carryForward, true);
+  });
+
   test("code delta + code angle -> false", () => {
     const decision = resolveAngleCarryForward({
       angle: "correctness",

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -69,6 +69,24 @@ describe("resolveAngleCarryForward — fail-closed decision", () => {
     assert.equal(decision.carryForward, true);
   });
 
+  test(".devloops-only delta carries clean non-config angles but re-runs config-surface ones (classifier reclassification pinned)", () => {
+    // Previously .devloops classified unknown → fail-closed re-run of every
+    // angle. Now it is config: coverage/link-check may carry a clean verdict,
+    // while config-drift (a config-surface angle) must still re-run.
+    const carried = resolveAngleCarryForward({
+      angle: "coverage",
+      changedFiles: [".devloops"],
+      prevVerdict: "clean",
+    });
+    assert.equal(carried.carryForward, true);
+    const rerun = resolveAngleCarryForward({
+      angle: "config-drift",
+      changedFiles: [".devloops"],
+      prevVerdict: "clean",
+    });
+    assert.equal(rerun.carryForward, false);
+  });
+
   test("code delta + code angle -> false", () => {
     const decision = resolveAngleCarryForward({
       angle: "correctness",

--- a/scripts/loop/_post-convergence-change.mjs
+++ b/scripts/loop/_post-convergence-change.mjs
@@ -50,6 +50,7 @@ export function isTrivialDocumentationOnlyPath(filePath) {
   // case/whitespace-sensitive, so classifying the raw input could disagree.
   if (normalized.startsWith("docs/")) return classifyFile(normalized) === "docs";
   return normalized.endsWith(".md")
+    || normalized.endsWith(".markdown")
     || normalized.endsWith(".mdx")
     || normalized.endsWith(".txt")
     || normalized.endsWith(".rst")

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -451,6 +451,14 @@ The decision is a pure, deterministic, fail-closed seam — `resolveAngleCarryFo
 
 **Fail-closed defaults (carry forward = false unless proven safe).** Must-re-run whenever: the prior verdict is not `clean`; the prior findings-log is missing / not clean; the delta is empty or unavailable; any changed file is unclassifiable (`unknown` kind); the angle has no declared surface (unmapped); the angle is a configured mandatory angle (the CLI loads the gate's angle entries with `mandatory: true` and forces every one to re-run, never carried); or any changed file's kind is in the angle's surface.
 
+**A dev-loop config-source delta re-runs EVERY angle.** `.devloops` (and its
+`.devloops.yaml/.yml/.json` and `.pi/dev-loop/settings.*`/`defaults.*` siblings)
+defines the gate's angle pool, mandatory floor, and reviewer personas/prompts —
+a clean verdict produced under the OLD config has no valid provenance across a
+change to it, regardless of the angle's declared surface. `classifyFile`
+correctly reports these files as `config`; the carry-forward seam overrides
+that via `isDevLoopConfigSourcePath` and forces a full re-run (fail-closed).
+
 **Renames force the RENAME_ONLY angles to re-run.** A rename records only its destination path, so classifying that path alone would miss what the move itself implicates (a relocated doc breaking a link, a moved test/code file shifting scope/contract-surface). When the delta `git diff A..B` contains ANY rename/copy row, the CLI forces the RENAME_ONLY-mapped angles (`CATEGORY_ANGLE_MAP[RENAME_ONLY]`: `scope`, `correctness`, `contract-surface`, `docs`, `link-check`) to re-run for that run; the remaining angles still follow the surface rule above.
 
 **Provenance — carried, not fabricated.** A carried verdict preserves the fail-closed evidence contract. The new head's findings-log records the carried angle in `provenance.perAngle` with `carriedFromHead: <A>` and the SAME `reviewer` identity that reviewed it at head A (honest attribution — that reviewer genuinely reviewed this angle's surface, which the delta did not change). `distinctReviewers` still counts real reviewer identities and the mandatory-angle / distinct-reviewer consistency checks in `write-gate-findings-log.mjs` are unchanged; carry-forward never invents a reviewer or a fresh review.

--- a/test/loop/_post-convergence-change.test.mjs
+++ b/test/loop/_post-convergence-change.test.mjs
@@ -278,7 +278,7 @@ test("getLatestSubmittedCopilotReviewHeadSha tie-break: a valid timestamp beats 
 
 test("isTrivialDocumentationOnlyPath classifies prose docs as trivial but a docs/-hosted code/config/test file as non-trivial", () => {
   // Prose under docs/ (any case / surrounding whitespace) stays trivial.
-  for (const p of ["docs/guide.md", "docs/notes.rst", "DOCS/Guide.md", " docs/guide.md ", "README.md", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
+  for (const p of ["docs/guide.md", "docs/notes.rst", "DOCS/Guide.md", " docs/guide.md ", "README.md", "changes.markdown", "a.mdx", "notes.txt", "x.rst", "y.adoc", "", null, undefined]) {
     assert.equal(isTrivialDocumentationOnlyPath(p), true, `${p} should be trivial`);
   }
   // A code/config/test file hosted under docs/ is NOT trivial — it routes through


### PR DESCRIPTION
Two T0 extension-rule gaps in `classifyFile()` made `dynamic.subtractive` pruning fail safe to the full angle set for exactly the low-risk PRs it should help most:

- `.markdown` now classifies as docs alongside `.md` (a `.markdown`-only diff emits `DOCS_ONLY`).
- A static allowlist of extensionless dotfile configs — `.devloops` only — classifies as config (a `.devloops`-only diff emits `CONFIG_ONLY`). Review dropped `.nvmrc`/`.ruby-version` from the originally locked list: classifying runtime-version files as config would have let `ci-guard`/`determinism` carry stale clean verdicts across a runtime bump, so they deliberately stay `unknown` (fail-closed, pinned by tests). No content sniffing; the fail-safe default for genuinely unrecognized files is unchanged.

The same `.markdown` gap existed in a sibling list: `isTrivialDocumentationOnlyPath()` (the post-convergence Copilot trivial-docs suppression gate in `scripts/loop/_post-convergence-change.mjs`) now treats `.markdown` as prose too, so a consumer changelog push no longer re-opens a converged review round — and the gate carry-forward path (`gate-carry-forward.mjs`, a second `classifyFile` consumer) now treats a `.markdown`-only delta like `.md`, letting clean angles carry forward across such a bump (regression-tested at both the per-angle and the post-convergence `resolveConvergenceCarryForward` seams). One deliberate exception landed with review: a `.devloops` delta re-runs EVERY angle — it rewrites the reviewer pool/prompts themselves, so no prior verdict's provenance survives it (`isDevLoopConfigSourcePath` override, fail-closed). Stale analyzer doc comments (.md-only wording) updated alongside.

With `dynamic.subtractive`, the issue's repro diff (`.devloops` MODIFIED + `foo.markdown` ADDED) now resolves with `fallbackToAll: false` to 10 of 15 draft angles instead of the whole pool — the docs/config lenses plus the code-review core, because the `.devloops` hunk's changed lines also emit `LOGIC_CHANGE` (`hasLogicChange` is not file-kind-gated; the exact set is pinned in the test).

## Validation

- Unit coverage: `.markdown`-only diff → `DOCS_ONLY`; `.devloops`-only diff → `CONFIG_ONLY`; the combined repro diff prunes with `fallbackToAll: false`.
- `diff-analyzer` + `change-classifier` suites: 49/49; `_post-convergence-change` suite covers the new `.markdown` trivial-docs case (79/79 combined).
- Full verify: 0 failures.

Closes #1450


