### PR TITLE
docs(ui-review): axe install is an explicit opt-in; stat trailing-slash files entries in the escaping-imports contract

### DIFF
--- a/.claude/skills/docs/ui-review-recipe-contract.md
+++ b/.claude/skills/docs/ui-review-recipe-contract.md
@@ -23,7 +23,7 @@ Playwright is an **optional peer dependency** of `dev-loops`: a repo that never
 runs a UI review carries none of its weight, so nothing installs it for you.
 
 ```
-npm install --save-dev @playwright/test @axe-core/playwright
+npm install --save-dev @playwright/test
 npx playwright install webkit
 ```
 
@@ -31,9 +31,17 @@ Stage 2 (`ui-review-drive`) and the loop-grill's `visual-grill-capture` stage
 launch headless WebKit through it. With either the package or the browser binary
 missing, both stages **stop with the install command as their stated reason** and
 report no failures — a setup gap on your machine is never charged to the PR under
-review. `@axe-core/playwright` is optional in the same way and drives only the
-computed-accessibility artifact: without it every `axe.json` is a deterministic
-JSON `null` and the rest of the review still works.
+review.
+
+`@axe-core/playwright` is a separate opt-in, only needed for the
+computed-accessibility artifact:
+
+```
+npm install --save-dev @axe-core/playwright
+```
+
+Without it every `axe.json` is a deterministic JSON `null` and the rest of the
+review still works.
 
 ## Where the recipe lives
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -34,6 +34,7 @@ nothing downstream and a local setup gap cannot be charged to the PR. Other
 stopped results are not alike — the missing-recipe stop carries a `must-fix` that
 is only surfaced by threading it onward, so read `failures`, not `stopped`, when
 deciding what to report.
+
 `@axe-core/playwright` is a separate opt-in
 (`npm install --save-dev @axe-core/playwright`) that drives only the
 computed-a11y artifact: without it every `axe.json` is a deterministic JSON

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -25,7 +25,7 @@ The two browser-driving stages (`ui-review-drive`, and the `visual-grill-capture
 stage the loop-grill uses) launch headless WebKit through Playwright, which is an
 **optional** peer dependency: a consumer who never runs a UI review carries none
 of its weight. Where one is run, install it once —
-`npm install --save-dev @playwright/test @axe-core/playwright`, then
+`npm install --save-dev @playwright/test`, then
 `npx playwright install webkit`. When either the package or the browser binary is
 missing, both stages stop with those instructions as the stop reason and carry no
 failure entries. That is deliberate: `ui-review-diagnose` turns every failure into
@@ -34,10 +34,11 @@ nothing downstream and a local setup gap cannot be charged to the PR. Other
 stopped results are not alike — the missing-recipe stop carries a `must-fix` that
 is only surfaced by threading it onward, so read `failures`, not `stopped`, when
 deciding what to report.
-`@axe-core/playwright` is optional in the same
-way and drives only the computed-a11y artifact: without it every `axe.json` is a
-deterministic JSON `null`, so a11y findings lose their grounding while the rest of
-the review still works.
+`@axe-core/playwright` is a separate opt-in
+(`npm install --save-dev @axe-core/playwright`) that drives only the
+computed-a11y artifact: without it every `axe.json` is a deterministic JSON
+`null`, so a11y findings lose their grounding while the rest of the review still
+works.
 
 The route's handoff envelope carries its stop rules and acceptance
 self-validation (defined in `handoff-envelope.mjs`): no product-code writes,

--- a/skills/docs/ui-review-recipe-contract.md
+++ b/skills/docs/ui-review-recipe-contract.md
@@ -23,7 +23,7 @@ Playwright is an **optional peer dependency** of `dev-loops`: a repo that never
 runs a UI review carries none of its weight, so nothing installs it for you.
 
 ```
-npm install --save-dev @playwright/test @axe-core/playwright
+npm install --save-dev @playwright/test
 npx playwright install webkit
 ```
 
@@ -31,9 +31,17 @@ Stage 2 (`ui-review-drive`) and the loop-grill's `visual-grill-capture` stage
 launch headless WebKit through it. With either the package or the browser binary
 missing, both stages **stop with the install command as their stated reason** and
 report no failures — a setup gap on your machine is never charged to the PR under
-review. `@axe-core/playwright` is optional in the same way and drives only the
-computed-accessibility artifact: without it every `axe.json` is a deterministic
-JSON `null` and the rest of the review still works.
+review.
+
+`@axe-core/playwright` is a separate opt-in, only needed for the
+computed-accessibility artifact:
+
+```
+npm install --save-dev @axe-core/playwright
+```
+
+Without it every `axe.json` is a deterministic JSON `null` and the rest of the
+review still works.
 
 ## Where the recipe lives
 

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -37,6 +37,7 @@ nothing downstream and a local setup gap cannot be charged to the PR. Other
 stopped results are not alike — the missing-recipe stop carries a `must-fix` that
 is only surfaced by threading it onward, so read `failures`, not `stopped`, when
 deciding what to report.
+
 `@axe-core/playwright` is a separate opt-in
 (`npm install --save-dev @axe-core/playwright`) that drives only the
 computed-a11y artifact: without it every `axe.json` is a deterministic JSON

--- a/skills/ui-review/SKILL.md
+++ b/skills/ui-review/SKILL.md
@@ -28,7 +28,7 @@ The two browser-driving stages (`ui-review-drive`, and the `visual-grill-capture
 stage the loop-grill uses) launch headless WebKit through Playwright, which is an
 **optional** peer dependency: a consumer who never runs a UI review carries none
 of its weight. Where one is run, install it once —
-`npm install --save-dev @playwright/test @axe-core/playwright`, then
+`npm install --save-dev @playwright/test`, then
 `npx playwright install webkit`. When either the package or the browser binary is
 missing, both stages stop with those instructions as the stop reason and carry no
 failure entries. That is deliberate: `ui-review-diagnose` turns every failure into
@@ -37,10 +37,11 @@ nothing downstream and a local setup gap cannot be charged to the PR. Other
 stopped results are not alike — the missing-recipe stop carries a `must-fix` that
 is only surfaced by threading it onward, so read `failures`, not `stopped`, when
 deciding what to report.
-`@axe-core/playwright` is optional in the same
-way and drives only the computed-a11y artifact: without it every `axe.json` is a
-deterministic JSON `null`, so a11y findings lose their grounding while the rest of
-the review still works.
+`@axe-core/playwright` is a separate opt-in
+(`npm install --save-dev @axe-core/playwright`) that drives only the
+computed-a11y artifact: without it every `axe.json` is a deterministic JSON
+`null`, so a11y findings lose their grounding while the rest of the review still
+works.
 
 The route's handoff envelope carries its stop rules and acceptance
 self-validation (defined in `handoff-envelope.mjs`): no product-code writes,

--- a/test/contracts/no-package-escaping-imports.test.mjs
+++ b/test/contracts/no-package-escaping-imports.test.mjs
@@ -74,14 +74,22 @@ export async function resolveShippedDirs(files, repoRootUrl) {
     // Normalize "./scripts" and "scripts//" to "scripts" so the entry compares
     // equal to a path.relative() result.
     const name = path.normalize(entry).replace(/[\\/]+$/, "");
-    if (entry.endsWith("/")) {
-      dirs.add(name);
-      continue;
-    }
+    // Stat even a trailing-slash entry: npm treats "scripts" and "scripts/" as
+    // the same declaration, but a trailing slash on an entry that is actually a
+    // FILE on disk is an author error — surface it here as a clear failure
+    // rather than letting it walk() as a bogus dir later. An ENOENT trailing-
+    // slash entry still passes through as an absent dir (unbuilt output, say) —
+    // findEscapingImports already tolerates a shipped dir that isn't there yet.
     try {
-      if ((await stat(new URL(name, repoRootUrl))).isDirectory()) dirs.add(name);
+      const stats = await stat(new URL(name, repoRootUrl));
+      if (stats.isDirectory()) {
+        dirs.add(name);
+      } else if (entry.endsWith("/")) {
+        throw new Error(`package.json "files" entry ${JSON.stringify(entry)} has a trailing slash but is a file on disk, not a directory`);
+      } // a plain (non-slash) entry that is a file ships a single file, not a dir to scan
     } catch (err) {
-      if (err.code !== "ENOENT") throw err; // absent entry ships nothing to scan
+      if (err.code !== "ENOENT") throw err;
+      if (entry.endsWith("/")) dirs.add(name); // absent dir: trust the declared trailing slash
     }
   }
   return [...dirs];
@@ -331,6 +339,24 @@ test("resolveShippedDirs classifies a files entry by what it is on disk, not by 
       // "./withslash/" normalizes onto "withslash" and is deduped, so the dir is
       // walked once rather than double-reporting every offender inside it.
       ["withslash", "noslash", "absent"],
+    );
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+// A trailing slash claims "this is a directory"; when the entry is actually a
+// file on disk, that claim is wrong and must fail loudly here rather than
+// surfacing later as a confusing walk() error.
+test("resolveShippedDirs refuses a trailing-slash files entry that is a file on disk", async () => {
+  const fixture = await mkdtemp(path.join(tmpdir(), "shipped-dirs-file-"));
+  try {
+    const repoRootUrl = pathToFileURL(`${fixture}/`);
+    await writeFile(path.join(fixture, "README.md"), "# not a dir\n");
+
+    await assert.rejects(
+      () => resolveShippedDirs(["README.md/"], repoRootUrl),
+      /has a trailing slash but is a file on disk/,
     );
   } finally {
     await rm(fixture, { recursive: true, force: true });

--- a/test/contracts/no-package-escaping-imports.test.mjs
+++ b/test/contracts/no-package-escaping-imports.test.mjs
@@ -356,7 +356,7 @@ test("resolveShippedDirs classifies a files entry by what it is on disk, not by 
 
 // A trailing slash claims "this is a directory"; when the entry is actually a
 // file on disk, that claim is wrong and must fail loudly here rather than
-// surfacing later as a confusing walk() error.
+// surfacing later as a raw ENOTDIR from the dir-exists probe.
 test("resolveShippedDirs refuses a trailing-slash files entry that is a file on disk", async () => {
   const fixture = await mkdtemp(path.join(tmpdir(), "shipped-dirs-file-"));
   try {

--- a/test/contracts/no-package-escaping-imports.test.mjs
+++ b/test/contracts/no-package-escaping-imports.test.mjs
@@ -74,10 +74,12 @@ export async function resolveShippedDirs(files, repoRootUrl) {
     // Normalize "./scripts" and "scripts//" to "scripts" so the entry compares
     // equal to a path.relative() result.
     const name = path.normalize(entry).replace(/[\\/]+$/, "");
-    // Stat even a trailing-slash entry: npm treats "scripts" and "scripts/" as
-    // the same declaration, but a trailing slash on an entry that is actually a
+    // Stat even a trailing-slash entry: npm resolves both spellings against the
+    // disk either way, but in THIS repo's manifest convention a trailing slash
+    // is the author saying "directory" — so an entry that is actually a
     // FILE on disk is an author error — surface it here as a clear failure
-    // rather than letting it walk() as a bogus dir later. An ENOENT trailing-
+    // rather than deferring to findEscapingImports' own dir-exists stat, which
+    // would fail later with a raw ENOTDIR and no pointer to the bad entry. An ENOENT trailing-
     // slash entry still passes through as an absent dir (unbuilt output, say) —
     // findEscapingImports already tolerates a shipped dir that isn't there yet.
     // stat inside the try, classification below it: the catch is strictly an

--- a/test/contracts/no-package-escaping-imports.test.mjs
+++ b/test/contracts/no-package-escaping-imports.test.mjs
@@ -80,17 +80,24 @@ export async function resolveShippedDirs(files, repoRootUrl) {
     // rather than letting it walk() as a bogus dir later. An ENOENT trailing-
     // slash entry still passes through as an absent dir (unbuilt output, say) —
     // findEscapingImports already tolerates a shipped dir that isn't there yet.
+    // stat inside the try, classification below it: the catch is strictly an
+    // errno filter for stat, so the deliberate author-error throw can never be
+    // coupled to (or later swallowed by) a widened errno filter.
+    let stats = null;
     try {
-      const stats = await stat(new URL(name, repoRootUrl));
-      if (stats.isDirectory()) {
-        dirs.add(name);
-      } else if (entry.endsWith("/")) {
-        throw new Error(`package.json "files" entry ${JSON.stringify(entry)} has a trailing slash but is a file on disk, not a directory`);
-      } // a plain (non-slash) entry that is a file ships a single file, not a dir to scan
+      stats = await stat(new URL(name, repoRootUrl));
     } catch (err) {
       if (err.code !== "ENOENT") throw err;
-      if (entry.endsWith("/")) dirs.add(name); // absent dir: trust the declared trailing slash
     }
+    if (stats === null) {
+      if (entry.endsWith("/")) dirs.add(name); // absent dir: trust the declared trailing slash
+      continue;
+    }
+    if (stats.isDirectory()) {
+      dirs.add(name);
+    } else if (entry.endsWith("/")) {
+      throw new Error(`package.json "files" entry ${JSON.stringify(entry)} has a trailing slash but is a file on disk, not a directory — drop the slash to ship it as a file, or point the entry at the intended directory`);
+    } // a plain (non-slash) entry that is a file ships a single file, not a dir to scan
   }
   return [...dirs];
 }

--- a/test/docs/ui-review-recipe-doc.test.mjs
+++ b/test/docs/ui-review-recipe-doc.test.mjs
@@ -135,3 +135,16 @@ test("collectKeys descends through effects/preprocess wrappers at nested levels"
     "walk must descend through pipe/transform wrappers to reach nested keys",
   );
 });
+
+test("prerequisites snippet matches the runtime PLAYWRIGHT_MISSING_MESSAGE install pair", async () => {
+  const { PLAYWRIGHT_MISSING_MESSAGE } = await import("../../scripts/loop/ui-review-capture.mjs");
+  const doc = await readFile(DOC_PATH, "utf8");
+  // The runtime stop reason names the exact default install pair; the doc's
+  // default snippet must carry both commands verbatim so they cannot drift.
+  for (const cmd of ["npm install --save-dev @playwright/test", "npx playwright install webkit"]) {
+    assert.ok(PLAYWRIGHT_MISSING_MESSAGE.includes(cmd), `runtime message must cite: ${cmd}`);
+    assert.ok(doc.includes(cmd), `doc must cite: ${cmd}`);
+  }
+  // Axe must NOT be part of the default pair in either surface.
+  assert.ok(!PLAYWRIGHT_MISSING_MESSAGE.includes("@axe-core/playwright"));
+});

--- a/test/docs/ui-review-recipe-doc.test.mjs
+++ b/test/docs/ui-review-recipe-doc.test.mjs
@@ -145,6 +145,14 @@ test("prerequisites snippet matches the runtime PLAYWRIGHT_MISSING_MESSAGE insta
     assert.ok(PLAYWRIGHT_MISSING_MESSAGE.includes(cmd), `runtime message must cite: ${cmd}`);
     assert.ok(doc.includes(cmd), `doc must cite: ${cmd}`);
   }
-  // Axe must NOT be part of the default pair in either surface.
+  // Axe must NOT be part of the default pair in either surface. The doc check
+  // pins the exact default line (anchored to end-of-line), so re-merging
+  // "@playwright/test @axe-core/playwright" into one command fails here — a
+  // bare substring check would pass on the pre-split combined command.
   assert.ok(!PLAYWRIGHT_MISSING_MESSAGE.includes("@axe-core/playwright"));
+  assert.match(
+    doc,
+    /^npm install --save-dev @playwright\/test$/m,
+    "the doc's default install line must be @playwright/test alone (axe is a separate opt-in)",
+  );
 });


### PR DESCRIPTION
The Prerequisites snippet in `skills/docs/ui-review-recipe-contract.md` (mirrored in `skills/ui-review/SKILL.md`) installed `@playwright/test` and `@axe-core/playwright` in one command, implying axe is required — while the surrounding prose states axe is optional and an axe-less run emits a deterministic JSON `null` for every `axe.json` with the rest of the review working. The snippet is now split: the default install is `@playwright/test` + `npx playwright install webkit`, with the axe install shown separately as an explicit opt-in for computed-accessibility artifacts. Both doc surfaces updated, `.claude/` mirrors regenerated.

Folded in per the issue: `resolveShippedDirs` in `test/contracts/no-package-escaping-imports.test.mjs` now stats trailing-slash `files` entries — an entry ending with `/` that is a file on disk fails with a clear message naming the entry, instead of a later raw `ENOTDIR` from the dir-exists probe; ENOENT still passes as an absent dir.

## Validation

- doc-guard: 216/216; escaping-imports contract: 11/11; full verify: 0 failures.

Closes #1471

