### PR TITLE
fix(gates): round_cap_reached allows the pre-approval fallback its own note permits; universal nextAction-consistency contract

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -252,6 +252,19 @@ function formatRefinementBlockedReason(linkedIssue, status, refinementArtifact) 
   return `The draft gate cannot complete: the linked issue has no detectable refinement artifact (Acceptance criteria / DoD / linked refinement doc). finding=${REFINEMENT_ARTIFACT_FINDING}`;
 }
 
+// #1472: describes the CI state a round-cap-reached fallback branch actually
+// granted on, for human-read reason text. preApprovalRequireCi:false plus a
+// non-success/non-crediblyGreen ciStatus is not "green CI" — claiming it is
+// would be the same false-CI-claim buildRoundExhaustionGateEvidenceNote below
+// exists to avoid. The `ciStatus === "success"` fallback covers the
+// requireCi:true path, where these callers are only reachable with ciStatus
+// "success" (failure/crediblyGreen/pending/none all return earlier).
+function describeAcceptedCiState(ciStatus, preApprovalRequireCi) {
+  if (ciStatus === "crediblyGreen") return "credibly green CI";
+  if (ciStatus === "success" || preApprovalRequireCi !== false) return "green CI";
+  return "CI not required by config";
+}
+
 function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }) {
   // #1472 defer: when CI is not required by config, the grant does not rest on
   // any CI verdict at all — do not claim "green or credibly green CI" for a
@@ -521,6 +534,21 @@ const PRE_APPROVAL_ENTRY_BOUNDARIES = Object.freeze([
   PR_CHECKPOINT.FINAL_APPROVAL_READY,
 ]);
 
+/**
+ * Identifies the ROUND_CAP_REACHED branch's own defensive grant shape (see
+ * that branch below): lifecycleState stays round_cap_reached (never
+ * round_cap_clean_fallback) while gateBoundary settles on
+ * pre_approval_gate_window. Every caller that exempts the round-cap clean
+ * fallback from the formal-request / unsettled-review guards
+ * (applyUnsettledCopilotReviewEntryGuard below, and
+ * detect-pr-gate-coordination-state.mjs's shouldGuardCopilotReviewRequest
+ * wiring) must exempt this shape too, or the grant this evaluator just
+ * returned gets rewritten straight back to a Copilot-review wait.
+ */
+export function isRoundCapReachedCleanGrant({ lifecycleState, gateBoundary } = {}) {
+  return lifecycleState === STATE.ROUND_CAP_REACHED && gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW;
+}
+
 function applyUnsettledCopilotReviewEntryGuard(input, result) {
   if (!result || typeof result !== "object" || !PRE_APPROVAL_ENTRY_BOUNDARIES.includes(result.gateBoundary)) {
     return null;
@@ -551,7 +579,12 @@ function applyUnsettledCopilotReviewEntryGuard(input, result) {
     maxCopilotRounds: input.maxCopilotRounds,
   });
   const lifecycleState = typeof input.lifecycleState === "string" ? input.lifecycleState.trim().toLowerCase() : "";
-  const roundCapCleanFallback = lifecycleState === STATE.ROUND_CAP_CLEAN_FALLBACK;
+  // Also exempt the evaluator's own ROUND_CAP_REACHED grant shape (#1472):
+  // without this, this guard would rewrite that grant back to
+  // waiting_for_copilot_review the instant it is produced, re-introducing the
+  // never-arriving-review dead-end the round-cap exemption exists to prevent.
+  const roundCapCleanFallback = lifecycleState === STATE.ROUND_CAP_CLEAN_FALLBACK
+    || isRoundCapReachedCleanGrant(result);
   if (
     roundCapReached
     && (input.sameHeadCleanConverged === true || roundCapCleanFallback)
@@ -1271,7 +1304,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
     }
 
     const roundExhaustionGateEvidenceNote = (roundCapReached && !roundCapNewCycleRequired)
-      ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds })
+      ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi })
       : null;
 
     if (!sameHeadCleanConverged && (!roundCapReached || roundCapNewCycleRequired)) {
@@ -1350,7 +1383,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
         reason: roundCapReached
-          ? `Round-cap clean fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`
+          ? `Round-cap clean fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${describeAcceptedCiState(ciStatus, preApprovalRequireCi)}). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`
           : (ciStatus === "crediblyGreen"
             ? "The current head has both a clean settled review cycle and clean `pre_approval_gate` evidence, and its zero-suite CI state is accepted as credibly green, so the PR is at the final approval boundary."
             : "The current head has both a clean settled review cycle and clean `pre_approval_gate` evidence, so the PR is at the final approval boundary."),
@@ -1381,7 +1414,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
       forbiddenActions,
       nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
       reason: roundCapReached
-        ? `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary.`
+        ? `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${describeAcceptedCiState(ciStatus, preApprovalRequireCi)}, so \`pre_approval_gate\` fallback is now the next legal boundary.`
         : (ciStatus === "crediblyGreen"
           ? "The current head has a clean settled post-draft review cycle, and its zero-suite CI state is accepted as credibly green, so `pre_approval_gate` is now the next legal boundary."
           : "The current head has a clean settled post-draft review cycle, so `pre_approval_gate` is now the next legal boundary."),
@@ -1513,7 +1546,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
-        reason: `Round-cap clean fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`,
+        reason: `Round-cap clean fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${describeAcceptedCiState(ciStatus, preApprovalRequireCi)}). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`,
         mergeStateStatus,
         conflictFiles,
           refinementArtifact,
@@ -1540,11 +1573,11 @@ function evaluatePrGateCoordinationCore(input = {}) {
       allowedNextActions,
       forbiddenActions,
       nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
-      reason: `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary (it reviews the current post-cap head; no further Copilot re-request is permitted).`,
+      reason: `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${describeAcceptedCiState(ciStatus, preApprovalRequireCi)}, so \`pre_approval_gate\` fallback is now the next legal boundary (it reviews the current post-cap head; no further Copilot re-request is permitted).`,
       mergeStateStatus,
       conflictFiles,
       refinementArtifact,
-      gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }),
+      gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }),
     copilotReviewRoundCount,
     });
   }
@@ -1556,9 +1589,11 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // for a caller re-checking gate entry with signals fresher than the
   // interpreter's snapshot (e.g. threads resolved between the interpreter run
   // and this re-check) — it is NOT how a normal ROUND_CAP_REACHED classification
-  // is expected to look, because the interpreter uses the SAME strict-CI
-  // predicate below: whenever that predicate and zero unresolved threads both
-  // hold on the snapshot the interpreter itself observed, the interpreter emits
+  // is expected to look, because the interpreter's own CI predicate is
+  // strictly wider than this branch's (it also accepts `crediblyGreen`, #1371):
+  // whenever this branch's narrower predicate and zero unresolved threads both
+  // hold on the snapshot the interpreter itself observed, the interpreter's
+  // wider check has already passed too, so the interpreter emits
   // ROUND_CAP_CLEAN_FALLBACK instead of ROUND_CAP_REACHED (see the
   // equivalence test in pr-gate-coordination.test.mjs). So on facts unchanged
   // since interpretation, this branch never fires; it only grants when the
@@ -1579,20 +1614,13 @@ function evaluatePrGateCoordinationCore(input = {}) {
     const ciClause = ciStatus === "success" ? "green CI" : "CI not required by config";
     if (unresolvedThreadCount === 0 && ciConfirmedGreen) {
       if (preApprovalGate.currentHeadClean) {
-        const titleMarkers = findBlockingTitleMarkers(prTitle);
-        if (titleMarkers.length > 0) {
-          return buildTitleMarkerBlockedResult({
-            input,
-            currentHeadSha,
-            draftGateAlreadySatisfied: true,
-            draftGate,
-            preApprovalGate,
-            mergeStateStatus,
-            conflictFiles,
-            markers: titleMarkers,
-            refinementArtifact,
-          });
-        }
+        // No inline title-marker check here (#1472 coverage defer, equivalent
+        // mutant): both boundaries this block can return (FINAL_APPROVAL_READY,
+        // PRE_APPROVAL_GATE_WINDOW) are in TITLE_MARKER_GUARDED_BOUNDARIES, so
+        // evaluatePrGateCoordination's outer post-pass already re-blocks a
+        // title-marker head on the way out — an inline check here is
+        // byte-identical dead code, unlike the pre-existing ROUND_CAP_CLEAN_FALLBACK
+        // branch this one mirrors, which predates that outer post-pass.
         // Mirror ROUND_CAP_CLEAN_FALLBACK/#579: a clean current head with no clean
         // draft_gate evidence must reconcile the draft gate rather than jump to
         // final approval.

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1543,23 +1543,28 @@ function evaluatePrGateCoordinationCore(input = {}) {
     });
   }
 
-  // Round-cap reached, but the caller affirms the exhaustion note's own
-  // conditions already hold (#1472): rounds exhausted (guaranteed by this
-  // state) plus a current head with zero unresolved threads and green or
-  // credibly green CI. ROUND_CAP_REACHED is otherwise a compound "unresolved
-  // threads OR non-clean CI" hard stop (copilot-loop-state.mjs) with no
-  // dedicated boundary of its own, so without this branch the generic
-  // fallback below always names `report_blocked` — self-consistent on its
-  // own, but stale once the caller reports the head as clean: a caller that
-  // then recommends `run_pre_approval_gate` (mirroring the exhaustion note)
-  // would be naming an action `allowedNextActions` never grants, which
-  // upsert-checkpoint-verdict.mjs (validates against allowedNextActions)
-  // refuses outright — the exact deadlock #1472 reports. Any other
-  // combination (threads still unresolved, an unknown thread count, or CI not
-  // confirmed green/credibly-green) falls through unchanged to the generic
-  // default below, preserving today's blocked behavior exactly.
+  // Defensive gate-entry re-check for ROUND_CAP_REACHED (#1472): the compound
+  // "unresolved threads OR non-clean CI" hard stop that copilot-loop-state.mjs
+  // emits has no dedicated boundary of its own, so without this branch the
+  // generic fallback below always names `report_blocked`. This branch exists
+  // for a caller re-checking gate entry with signals fresher than the
+  // interpreter's snapshot (e.g. threads resolved between the interpreter run
+  // and this re-check) — it is NOT how a normal ROUND_CAP_REACHED classification
+  // is expected to look, because the interpreter uses the SAME strict-CI
+  // predicate below: whenever that predicate and zero unresolved threads both
+  // hold on the snapshot the interpreter itself observed, the interpreter emits
+  // ROUND_CAP_CLEAN_FALLBACK instead of ROUND_CAP_REACHED (see the
+  // equivalence test in pr-gate-coordination.test.mjs). So on facts unchanged
+  // since interpretation, this branch never fires; it only grants when the
+  // caller's re-check facts diverge from what the interpreter last saw. The
+  // predicate intentionally mirrors every other pre-approval CI boundary in
+  // this file (success, or CI not required) — `crediblyGreen` is unconfirmed
+  // CI and stays blocked here exactly as it does everywhere else (#1371). Any
+  // other combination (threads still unresolved, an unknown thread count, or
+  // CI not confirmed green) falls through unchanged to the generic default
+  // below, preserving today's blocked behavior exactly.
   if (effectiveLifecycleState === STATE.ROUND_CAP_REACHED && roundCapReached) {
-    const ciConfirmedGreen = ciStatus === "success" || ciStatus === "crediblyGreen" || !preApprovalRequireCi;
+    const ciConfirmedGreen = ciStatus === "success" || !preApprovalRequireCi;
     if (unresolvedThreadCount === 0 && ciConfirmedGreen) {
       if (preApprovalGate.currentHeadClean) {
         const titleMarkers = findBlockingTitleMarkers(prTitle);

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -266,13 +266,13 @@ function describeAcceptedCiState(ciStatus, preApprovalRequireCi) {
 }
 
 function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }) {
-  // #1472 defer: when CI is not required by config, the grant does not rest on
-  // any CI verdict at all — do not claim "green or credibly green CI" for a
-  // head whose CI may be failing/pending/none. Callers that omit ciStatus /
-  // preApprovalRequireCi keep the original CI-confirmed wording unchanged.
-  const ciDescriptor = preApprovalRequireCi === false && ciStatus !== "success"
-    ? "CI not required by config"
-    : "green or credibly green CI";
+  // One rule serves both the reason string and this note: callers that pass
+  // ciStatus/preApprovalRequireCi get describeAcceptedCiState's descriptor
+  // (never a CI claim the head doesn't have). Callers that omit both keep the
+  // original CI-confirmed wording unchanged.
+  const ciDescriptor = ciStatus === undefined && preApprovalRequireCi === undefined
+    ? "green or credibly green CI"
+    : describeAcceptedCiState(ciStatus, preApprovalRequireCi);
   return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and ${ciDescriptor}, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
 }
 

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -252,8 +252,15 @@ function formatRefinementBlockedReason(linkedIssue, status, refinementArtifact) 
   return `The draft gate cannot complete: the linked issue has no detectable refinement artifact (Acceptance criteria / DoD / linked refinement doc). finding=${REFINEMENT_ARTIFACT_FINDING}`;
 }
 
-function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }) {
-  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
+function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }) {
+  // #1472 defer: when CI is not required by config, the grant does not rest on
+  // any CI verdict at all — do not claim "green or credibly green CI" for a
+  // head whose CI may be failing/pending/none. Callers that omit ciStatus /
+  // preApprovalRequireCi keep the original CI-confirmed wording unchanged.
+  const ciDescriptor = preApprovalRequireCi === false && ciStatus !== "success"
+    ? "CI not required by config"
+    : "green or credibly green CI";
+  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and ${ciDescriptor}, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
 }
 
 /**
@@ -1565,6 +1572,12 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // below, preserving today's blocked behavior exactly.
   if (effectiveLifecycleState === STATE.ROUND_CAP_REACHED && roundCapReached) {
     const ciConfirmedGreen = ciStatus === "success" || !preApprovalRequireCi;
+    // ciConfirmedGreen above is only true when ciStatus is literally "success"
+    // OR CI is not required by config — never for an unconfirmed/failing/absent
+    // status gated in only because requireCi is false. Naming it "green" in
+    // human-read reason/evidence text for the latter case would be a false CI
+    // claim (#1472 defer), so describe the actual grant basis instead.
+    const ciClause = ciStatus === "success" ? "green CI" : "CI not required by config";
     if (unresolvedThreadCount === 0 && ciConfirmedGreen) {
       if (preApprovalGate.currentHeadClean) {
         const titleMarkers = findBlockingTitleMarkers(prTitle);
@@ -1618,7 +1631,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
           allowedNextActions,
           forbiddenActions,
           nextAction: PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
-          reason: `Round-cap exhaustion fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`,
+          reason: `Round-cap exhaustion fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${ciClause}). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`,
           mergeStateStatus,
           conflictFiles,
           refinementArtifact,
@@ -1646,11 +1659,11 @@ function evaluatePrGateCoordinationCore(input = {}) {
         allowedNextActions,
         forbiddenActions,
         nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
-        reason: `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary (it reviews the current post-cap head; no further Copilot re-request is permitted).`,
+        reason: `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads and ${ciClause}, so \`pre_approval_gate\` fallback is now the next legal boundary (it reviews the current post-cap head; no further Copilot re-request is permitted).`,
         mergeStateStatus,
         conflictFiles,
         refinementArtifact,
-        gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }),
+        gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }),
         copilotReviewRoundCount,
       });
     }

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -668,6 +668,16 @@ function evaluatePrGateCoordinationCore(input = {}) {
   const copilotReviewRoundCount = normalizeNonNegativeInteger(input.copilotReviewRoundCount);
   const maxCopilotRounds = normalizePositiveInteger(input.maxCopilotRounds);
   const roundCapReached = isCopilotRoundCapReached({ copilotReviewRoundCount, maxCopilotRounds });
+  // #1472: explicit current-head unresolved-thread signal for the round-cap
+  // fallback check below (STATE.ROUND_CAP_REACHED). Unlike copilotReviewRoundCount
+  // (which safely defaults to 0 when absent), an absent/invalid count here must
+  // NOT be coerced to 0 — that would silently treat an unknown thread count as
+  // clean and wrongly unblock the fallback. `null` means "unknown" (fail closed).
+  const unresolvedThreadCount = typeof input.unresolvedThreadCount === "number"
+    && Number.isFinite(input.unresolvedThreadCount)
+    && input.unresolvedThreadCount >= 0
+    ? Math.floor(input.unresolvedThreadCount)
+    : null;
   const postConvergenceSignificantChange = input.postConvergenceSignificantChange === true;
   const roundCapNewCycleRequired = roundCapReached && copilotReviewRoundCount > 0 && postConvergenceSignificantChange;
   const prTitle = typeof input.prTitle === "string" ? input.prTitle : "";
@@ -1531,6 +1541,114 @@ function evaluatePrGateCoordinationCore(input = {}) {
       gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }),
     copilotReviewRoundCount,
     });
+  }
+
+  // Round-cap reached, but the caller affirms the exhaustion note's own
+  // conditions already hold (#1472): rounds exhausted (guaranteed by this
+  // state) plus a current head with zero unresolved threads and green or
+  // credibly green CI. ROUND_CAP_REACHED is otherwise a compound "unresolved
+  // threads OR non-clean CI" hard stop (copilot-loop-state.mjs) with no
+  // dedicated boundary of its own, so without this branch the generic
+  // fallback below always names `report_blocked` — self-consistent on its
+  // own, but stale once the caller reports the head as clean: a caller that
+  // then recommends `run_pre_approval_gate` (mirroring the exhaustion note)
+  // would be naming an action `allowedNextActions` never grants, which
+  // upsert-checkpoint-verdict.mjs (validates against allowedNextActions)
+  // refuses outright — the exact deadlock #1472 reports. Any other
+  // combination (threads still unresolved, an unknown thread count, or CI not
+  // confirmed green/credibly-green) falls through unchanged to the generic
+  // default below, preserving today's blocked behavior exactly.
+  if (effectiveLifecycleState === STATE.ROUND_CAP_REACHED && roundCapReached) {
+    const ciConfirmedGreen = ciStatus === "success" || ciStatus === "crediblyGreen" || !preApprovalRequireCi;
+    if (unresolvedThreadCount === 0 && ciConfirmedGreen) {
+      if (preApprovalGate.currentHeadClean) {
+        const titleMarkers = findBlockingTitleMarkers(prTitle);
+        if (titleMarkers.length > 0) {
+          return buildTitleMarkerBlockedResult({
+            input,
+            currentHeadSha,
+            draftGateAlreadySatisfied: true,
+            draftGate,
+            preApprovalGate,
+            mergeStateStatus,
+            conflictFiles,
+            markers: titleMarkers,
+            refinementArtifact,
+          });
+        }
+        // Mirror ROUND_CAP_CLEAN_FALLBACK/#579: a clean current head with no clean
+        // draft_gate evidence must reconcile the draft gate rather than jump to
+        // final approval.
+        if (!draftGate.cleanEvidenceExists) {
+          return buildDraftGateNeededForMergeResult({
+            input,
+            currentHeadSha,
+            draftGate,
+            preApprovalGate,
+            mergeStateStatus,
+            conflictFiles,
+            underlyingReason: "Round-cap exhaustion fallback has clean pre_approval_gate but no clean draft_gate evidence.",
+            refinementArtifact,
+            effectiveLifecycleState,
+          });
+        }
+
+        pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]);
+        pushUnique(forbiddenActions, [
+          PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+          PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+          PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+          PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+        ]);
+        return buildResult({
+          repo: input.repo ?? null,
+          pr: Number.isInteger(input.pr) ? input.pr : null,
+          currentHeadSha,
+          lifecycleState: effectiveLifecycleState,
+          loopDisposition: loopDisposition ?? DISPOSITION.CLEAN_CONVERGED,
+          gateBoundary: PR_CHECKPOINT.FINAL_APPROVAL_READY,
+          draftGateAlreadySatisfied: true,
+          draftGate,
+          preApprovalGate,
+          allowedNextActions,
+          forbiddenActions,
+          nextAction: PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+          reason: `Round-cap exhaustion fallback accepted as draft gate equivalent (${copilotReviewRoundCount}/${maxCopilotRounds} rounds, zero unresolved threads, ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI). The current head has clean \`pre_approval_gate\` evidence, so the PR is at the final approval boundary.`,
+          mergeStateStatus,
+          conflictFiles,
+          refinementArtifact,
+        });
+      }
+
+      pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE]);
+      pushUnique(forbiddenActions, [
+        PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+        PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+        PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+        PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW,
+        PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+      ]);
+      return buildResult({
+        repo: input.repo ?? null,
+        pr: Number.isInteger(input.pr) ? input.pr : null,
+        currentHeadSha,
+        lifecycleState: effectiveLifecycleState,
+        loopDisposition: loopDisposition ?? DISPOSITION.CLEAN_CONVERGED,
+        gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW,
+        draftGateAlreadySatisfied: true,
+        draftGate,
+        preApprovalGate,
+        allowedNextActions,
+        forbiddenActions,
+        nextAction: PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+        reason: `The Copilot round limit is exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}), and the current head has zero unresolved threads with ${ciStatus === "crediblyGreen" ? "credibly green" : "green"} CI, so \`pre_approval_gate\` fallback is now the next legal boundary (it reviews the current post-cap head; no further Copilot re-request is permitted).`,
+        mergeStateStatus,
+        conflictFiles,
+        refinementArtifact,
+        gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds }),
+        copilotReviewRoundCount,
+      });
+    }
   }
 
   if (effectiveLifecycleState === STATE.LOW_SIGNAL_CONVERGED) {

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -680,10 +680,9 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // (which safely defaults to 0 when absent), an absent/invalid count here must
   // NOT be coerced to 0 — that would silently treat an unknown thread count as
   // clean and wrongly unblock the fallback. `null` means "unknown" (fail closed).
-  const unresolvedThreadCount = typeof input.unresolvedThreadCount === "number"
-    && Number.isFinite(input.unresolvedThreadCount)
+  const unresolvedThreadCount = Number.isInteger(input.unresolvedThreadCount)
     && input.unresolvedThreadCount >= 0
-    ? Math.floor(input.unresolvedThreadCount)
+    ? input.unresolvedThreadCount
     : null;
   const postConvergenceSignificantChange = input.postConvergenceSignificantChange === true;
   const roundCapNewCycleRequired = roundCapReached && copilotReviewRoundCount > 0 && postConvergenceSignificantChange;

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -265,15 +265,13 @@ function describeAcceptedCiState(ciStatus, preApprovalRequireCi) {
   return "CI not required by config";
 }
 
-function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }) {
-  // One rule serves both the reason string and this note: callers that pass
-  // ciStatus/preApprovalRequireCi get describeAcceptedCiState's descriptor
-  // (never a CI claim the head doesn't have). Callers that omit both keep the
-  // original CI-confirmed wording unchanged.
-  const ciDescriptor = ciStatus === undefined && preApprovalRequireCi === undefined
-    ? "green or credibly green CI"
-    : describeAcceptedCiState(ciStatus, preApprovalRequireCi);
-  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and ${ciDescriptor}, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
+function buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi, ciDescriptor }) {
+  // One rule serves both the reason string and this note. A branch whose CI
+  // acceptance differs from describeAcceptedCiState (the strict-green grant
+  // rejects crediblyGreen as a basis) passes its own descriptor explicitly so
+  // reason and note can never disagree.
+  const descriptor = ciDescriptor ?? describeAcceptedCiState(ciStatus, preApprovalRequireCi);
+  return `Copilot review rounds exhausted (${copilotReviewRoundCount}/${maxCopilotRounds}); current head has zero unresolved threads and ${descriptor}, so pre_approval_gate fallback is allowed without another Copilot re-request.`;
 }
 
 /**
@@ -1702,7 +1700,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
         mergeStateStatus,
         conflictFiles,
         refinementArtifact,
-        gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi }),
+        gateEvidenceNote: buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciDescriptor: ciClause }),
         copilotReviewRoundCount,
       });
     }

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1583,19 +1583,17 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // Defensive gate-entry re-check for ROUND_CAP_REACHED (#1472): the compound
   // "unresolved threads OR non-clean CI" hard stop that copilot-loop-state.mjs
   // emits has no dedicated boundary of its own, so without this branch the
-  // generic fallback below always names `report_blocked`. This branch exists
-  // for a caller re-checking gate entry with signals fresher than the
-  // interpreter's snapshot (e.g. threads resolved between the interpreter run
-  // and this re-check) — it is NOT how a normal ROUND_CAP_REACHED classification
-  // is expected to look, because the interpreter's own CI predicate is
-  // strictly wider than this branch's (it also accepts `crediblyGreen`, #1371):
-  // whenever this branch's narrower predicate and zero unresolved threads both
-  // hold on the snapshot the interpreter itself observed, the interpreter's
-  // wider check has already passed too, so the interpreter emits
-  // ROUND_CAP_CLEAN_FALLBACK instead of ROUND_CAP_REACHED (see the
-  // equivalence test in pr-gate-coordination.test.mjs). So on facts unchanged
-  // since interpretation, this branch never fires; it only grants when the
-  // caller's re-check facts diverge from what the interpreter last saw. The
+  // generic fallback below always names `report_blocked`. Both shipped
+  // callers read lifecycleState and the CI/thread facts from ONE snapshot, and
+  // the interpreter's own CI predicate is strictly wider than this branch's
+  // (it also accepts `crediblyGreen`, #1371): whenever this branch's narrower
+  // predicate and zero unresolved threads hold, the interpreter has already
+  // classified the snapshot ROUND_CAP_CLEAN_FALLBACK, never ROUND_CAP_REACHED
+  // (see the equivalence test in pr-gate-coordination.test.mjs). This branch
+  // is therefore unreachable through the shipped callers — it is pure
+  // defense-in-depth, demanded by issue 1472's corrected AC so the three
+  // fields can never disagree if a future caller hands the evaluator a
+  // round_cap_reached label alongside facts that satisfy the grant. The
   // predicate intentionally mirrors every other pre-approval CI boundary in
   // this file (success, or CI not required) — `crediblyGreen` is unconfirmed
   // CI and stays blocked here exactly as it does everywhere else (#1371). Any

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1614,13 +1614,25 @@ function evaluatePrGateCoordinationCore(input = {}) {
     const ciClause = ciStatus === "success" ? "green CI" : "CI not required by config";
     if (unresolvedThreadCount === 0 && ciConfirmedGreen) {
       if (preApprovalGate.currentHeadClean) {
-        // No inline title-marker check here (#1472 coverage defer, equivalent
-        // mutant): both boundaries this block can return (FINAL_APPROVAL_READY,
-        // PRE_APPROVAL_GATE_WINDOW) are in TITLE_MARKER_GUARDED_BOUNDARIES, so
-        // evaluatePrGateCoordination's outer post-pass already re-blocks a
-        // title-marker head on the way out — an inline check here is
-        // byte-identical dead code, unlike the pre-existing ROUND_CAP_CLEAN_FALLBACK
-        // branch this one mirrors, which predates that outer post-pass.
+        // Inline title-marker check, mirroring ROUND_CAP_CLEAN_FALLBACK: the
+        // outer post-pass guards FINAL_APPROVAL_READY and
+        // PRE_APPROVAL_GATE_WINDOW, but NOT the DRAFT_GATE_NEEDED boundary the
+        // sub-branch below can return — without this check a marker-titled
+        // head would route to reconcile_draft_gate instead of blocking.
+        const grantTitleMarkers = findBlockingTitleMarkers(prTitle);
+        if (grantTitleMarkers.length > 0) {
+          return buildTitleMarkerBlockedResult({
+            input,
+            currentHeadSha,
+            draftGateAlreadySatisfied: true,
+            draftGate,
+            preApprovalGate,
+            mergeStateStatus,
+            conflictFiles,
+            markers: grantTitleMarkers,
+            refinementArtifact,
+          });
+        }
         // Mirror ROUND_CAP_CLEAN_FALLBACK/#579: a clean current head with no clean
         // draft_gate evidence must reconcile the draft gate rather than jump to
         // final approval.

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2888,8 +2888,10 @@ for (const copilotReviewRequestStatus of ["requested", "already-requested"]) {
 // shape (gateBoundary pre_approval_gate_window) via isRoundCapReachedCleanGrant
 // — it must NOT blanket-exempt every round_cap_reached result. When the same
 // facts instead reach FINAL_APPROVAL_READY (preApprovalGate already clean on
-// the current head), a lingering review request is still a genuinely unsettled
-// signal and the guard must still fire.
+// the current head), the next step is human approval, a terminal claim held
+// to the conservative default: the guard still fires there, and the state
+// self-heals next cycle once the interpreter re-classifies the snapshot as
+// ROUND_CAP_CLEAN_FALLBACK (whose exemption is boundary-independent).
 test("round_cap_reached reaching final_approval_ready (not the window shape) still guards a lingering copilotReviewRequestStatus:requested (#1472)", () => {
   const result = evaluatePrGateCoordination({
     pr: 1460,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2571,3 +2571,220 @@ test("preApproval requireCi:false ignores a real CI failure at the pre_approval 
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
   assert.notEqual(result.gateBoundary, PR_CHECKPOINT.BLOCKED);
 });
+
+// #1472: ROUND_CAP_REACHED is a compound "unresolved threads OR non-clean CI"
+// hard stop with no dedicated boundary of its own. When a caller independently
+// affirms zero unresolved threads and green CI on the current head — exactly
+// the conditions buildRoundExhaustionGateEvidenceNote's own text promises — the
+// evaluator must recommend run_pre_approval_gate AND grant it in
+// allowedNextActions (never just forbiddenActions-silent), matching the
+// nextAction/allowedNextActions/forbiddenActions agreement upsert-checkpoint-
+// verdict.mjs (which validates against allowedNextActions/forbiddenActions,
+// not nextAction) relies on.
+test("round_cap_reached with zero unresolved threads and green CI allows run_pre_approval_gate (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  // Mirrors upsert-checkpoint-verdict.mjs's gate-entry validation exactly:
+  // `gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction)`.
+  assert.equal(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE), false);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW));
+  assert.equal(result.draftGateAlreadySatisfied, true);
+  assert.match(result.reason, /round limit is exhausted/i);
+  assert.ok(result.gateEvidenceNote);
+  assert.match(result.gateEvidenceNote, /zero unresolved threads/i);
+});
+
+test("round_cap_reached with zero unresolved threads and credibly green CI allows run_pre_approval_gate (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "crediblyGreen",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("round_cap_reached with clean current-head pre_approval AND clean draft_gate evidence reaches final approval (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "29aa40b7", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.FINAL_APPROVAL_READY);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+});
+
+test("round_cap_reached with unresolved threads present stays blocked exactly as today (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 1,
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("round_cap_reached with non-green CI stays blocked exactly as today even with zero unresolved threads (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "failure",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+test("round_cap_reached with an unknown unresolved-thread count fails closed and stays blocked (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    // unresolvedThreadCount intentionally omitted — unknown must not be
+    // coerced to "clean".
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+// #1472: general contract invariant, across every lifecycle state the
+// evaluator can be handed and a broad sweep of companion signals — the
+// synthesized nextAction must always be a member of allowedNextActions and
+// never a member of forbiddenActions. This is the general safety net the
+// round_cap_reached deadlock slipped through: a return statement naming
+// nextAction without granting it in allowedNextActions (or while forbidding
+// it) is exactly the shape upsert-checkpoint-verdict.mjs cannot act on.
+test("contract: nextAction is always allowed and never forbidden, across every lifecycle state (#1472)", () => {
+  const lifecycleStates = Object.values(STATE);
+  const ciStatuses = ["success", "failure", "pending", "none", "crediblyGreen"];
+  const draftGateFixtures = [
+    gate({ visible: false }),
+    gate({ visible: true, headSha: "abc12345", verdict: "clean" }),
+  ];
+  const preApprovalGateFixtures = [
+    gate({ visible: false }),
+    gate({ visible: true, headSha: "abc12345", verdict: "clean" }),
+  ];
+  const unresolvedThreadCounts = [0, 1, undefined];
+  const prDrafts = [true, false];
+  const roundCapCombos = [
+    { copilotReviewRoundCount: 0, maxCopilotRounds: 5 },
+    { copilotReviewRoundCount: 5, maxCopilotRounds: 5 },
+  ];
+
+  let checked = 0;
+  for (const lifecycleState of lifecycleStates) {
+    for (const ciStatus of ciStatuses) {
+      for (const draftGateFixture of draftGateFixtures) {
+        for (const preApprovalGateFixture of preApprovalGateFixtures) {
+          for (const unresolvedThreadCount of unresolvedThreadCounts) {
+            for (const prDraft of prDrafts) {
+              for (const { copilotReviewRoundCount, maxCopilotRounds } of roundCapCombos) {
+                const result = evaluatePrGateCoordination({
+                  pr: 1,
+                  currentHeadSha: "abc123456789",
+                  prDraft,
+                  lifecycleState,
+                  ciStatus,
+                  copilotReviewRoundCount,
+                  maxCopilotRounds,
+                  unresolvedThreadCount,
+                  draftGate: draftGateFixture,
+                  draftGateMarker: draftGateFixture.visible
+                    ? { ...draftGateFixture, contractComplete: true }
+                    : draftGateFixture,
+                  preApprovalGate: preApprovalGateFixture,
+                  preApprovalGateMarker: preApprovalGateFixture.visible
+                    ? { ...preApprovalGateFixture, contractComplete: true }
+                    : preApprovalGateFixture,
+                });
+                checked += 1;
+                const context = JSON.stringify({ lifecycleState, ciStatus, unresolvedThreadCount, prDraft, copilotReviewRoundCount, maxCopilotRounds });
+                assert.ok(
+                  result.allowedNextActions.includes(result.nextAction),
+                  `nextAction "${result.nextAction}" missing from allowedNextActions for ${context}`,
+                );
+                assert.ok(
+                  !result.forbiddenActions.includes(result.nextAction),
+                  `nextAction "${result.nextAction}" present in forbiddenActions for ${context}`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  assert.ok(checked > 0);
+});

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2711,6 +2711,35 @@ test("round_cap_reached with requireCi:false and failing CI grants run_pre_appro
   assert.match(result.gateEvidenceNote, /CI not required by config/i);
 });
 
+// crediblyGreen enters this branch only via requireCi:false (the strict-green
+// grant rejects it as a basis, #1371) — so BOTH reason and note must name the
+// actual basis, never "credibly green CI". Pins the ciDescriptor override:
+// without it the note delegates to describeAcceptedCiState and disagrees.
+test("round_cap_reached with requireCi:false and crediblyGreen CI names config-not-required as the basis in reason AND note (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "crediblyGreen",
+    preApprovalRequireCi: false,
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert.match(result.reason, /CI not required by config/i);
+  assert.doesNotMatch(result.reason, /credibly green/i);
+  assert.match(result.gateEvidenceNote, /CI not required by config/i);
+  assert.doesNotMatch(result.gateEvidenceNote, /credibly green/i);
+});
+
 // #1371 re-verify: crediblyGreen is unconfirmed CI and stays blocked at the
 // round-cap-reached fallback exactly as it does at every other pre-approval
 // boundary in this file (lines ~1016/1219/1404/1655) — this branch must not

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2742,7 +2742,7 @@ test("round_cap_reached with requireCi:false and crediblyGreen CI names config-n
 
 // #1371 re-verify: crediblyGreen is unconfirmed CI and stays blocked at the
 // round-cap-reached fallback exactly as it does at every other pre-approval
-// boundary in this file (lines ~1016/1219/1404/1655) — this branch must not
+// boundary in this file — this branch must not
 // be the one place a crediblyGreen head is granted gate entry.
 test("round_cap_reached with zero unresolved threads and credibly green CI stays blocked (#1371, #1472)", () => {
   const result = evaluatePrGateCoordination({

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -428,6 +428,40 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.match(result.reason, /pre_approval_gate/i);
 });
 
+// #1472: this is the SAME reachable branch as the test above (READY_TO_REREQUEST_REVIEW
+// at the round cap, PRE_APPROVAL_GATE_WINDOW) — the only difference is
+// preApprovalRequireCi:false with a failing CI. Before this fix,
+// buildRoundExhaustionGateEvidenceNote's two pre-existing call sites omitted
+// ciStatus/preApprovalRequireCi, so both the gateEvidenceNote and the reason
+// string claimed "green or credibly green CI" / "green CI" for a head whose
+// CI is literally failing. Pins the honest wording on the production path
+// real callers actually take (not just the new, narrower ROUND_CAP_REACHED branch).
+test("round-cap exhaustion with requireCi:false and failing CI does not claim green CI (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    sameHeadCleanConverged: false,
+    ciStatus: "failure",
+    preApprovalRequireCi: false,
+    copilotReviewRoundCount: 5,
+    maxCopilotRounds: 5,
+    draftGate: gate({ visible: true, headSha: "fedcba9", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "fedcba9", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert.doesNotMatch(result.reason, /green CI/i);
+  assert.match(result.reason, /CI not required by config/i);
+  assert.doesNotMatch(result.gateEvidenceNote, /green CI/i);
+  assert.match(result.gateEvidenceNote, /CI not required by config/i);
+});
+
 // #1387: at ROUND_CAP_CLEAN_FALLBACK, a post-convergence significant change must
 // NOT force rerequest_copilot_review — the round cap makes that rerequest
 // impossible (request-copilot-review.mjs suppresses it), so the only allowed
@@ -524,6 +558,39 @@ test("round_cap_clean_fallback routes a post-cap clean head to pre_approval_gate
   assert.equal(result.draftGateAlreadySatisfied, true);
   assert.match(result.reason, /round limit is exhausted/i);
   assert.match(result.reason, /pre_approval_gate/i);
+});
+
+// #1472: same reachable branch as the test above (ROUND_CAP_CLEAN_FALLBACK,
+// PRE_APPROVAL_GATE_WINDOW) with preApprovalRequireCi:false and a failing CI.
+// buildRoundExhaustionGateEvidenceNote's call site here (and the sibling reason
+// string) omitted ciStatus/preApprovalRequireCi before this fix, so a failing
+// head still got told its CI was "green" in both the gateEvidenceNote and the
+// reason posted to the gate comment — the exact false claim this PR set out
+// to remove, but only fixed (pre-fix) on an interpreter-unreachable branch.
+test("round_cap_clean_fallback with requireCi:false and failing CI does not claim green CI (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 892,
+    currentHeadSha: "ef84bca2deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_CLEAN_FALLBACK,
+    loopDisposition: DISPOSITION.CLEAN_CONVERGED,
+    sameHeadCleanConverged: false,
+    ciStatus: "failure",
+    preApprovalRequireCi: false,
+    copilotReviewRoundCount: 5,
+    maxCopilotRounds: 5,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert.doesNotMatch(result.reason, /green CI/i);
+  assert.match(result.reason, /CI not required by config/i);
+  assert.doesNotMatch(result.gateEvidenceNote, /green CI/i);
+  assert.match(result.gateEvidenceNote, /CI not required by config/i);
 });
 
 // #579 (gate review): a round-cap clean fallback with a clean current-head
@@ -2693,6 +2760,102 @@ test("round_cap_reached with clean current-head pre_approval AND clean draft_gat
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
 });
 
+// #579/#1472: mirrors "round_cap_clean_fallback with clean pre_approval but no
+// draft_gate evidence reconciles the draft gate" for the ROUND_CAP_REACHED
+// grant — a clean current head with no clean draft_gate evidence must
+// reconcile the draft gate, NOT jump to final approval (#579 no gate
+// exemptions). Pins the `!draftGate.cleanEvidenceExists` sub-branch: deleting
+// it flips this exact shape from draft_gate_needed/reconcile_draft_gate to
+// final_approval_ready/await_final_human_approval undetected.
+test("round_cap_reached with clean current-head pre_approval but no draft_gate evidence reconciles the draft gate (#579, #1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: true, headSha: "29aa40b7", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DRAFT_GATE_NEEDED);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE);
+  assert.equal(result.draftGate.cleanEvidenceExists, false);
+  assert.equal(result.draftGateAlreadySatisfied, false);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+  assert.match(result.reason, /no gate exemptions, #579/i);
+});
+
+// #1472: applyUnsettledCopilotReviewEntryGuard (the core-side #1190 mirror of
+// the detector's formal-request guard) runs unconditionally after the
+// evaluator's own ROUND_CAP_REACHED grant, on the SAME input this evaluator
+// call receives. A lingering requested/already-requested Copilot review
+// status on a post-cap head is for a review that can never come (no further
+// round is permitted), so — same as ROUND_CAP_CLEAN_FALLBACK — it must not
+// re-block this grant. Fails pre-fix: without widening this guard's exemption
+// with isRoundCapReachedCleanGrant, both statuses get rewritten to
+// waiting_for_copilot_review, dead-ending the loop.
+for (const copilotReviewRequestStatus of ["requested", "already-requested"]) {
+  test(`round_cap_reached + pre_approval_gate_window grant survives a lingering copilotReviewRequestStatus:${copilotReviewRequestStatus} (#1472)`, () => {
+    const result = evaluatePrGateCoordination({
+      pr: 1460,
+      currentHeadSha: "29aa40b7deadbeef",
+      prDraft: false,
+      lifecycleState: STATE.ROUND_CAP_REACHED,
+      loopDisposition: DISPOSITION.BLOCKED,
+      ciStatus: "success",
+      copilotReviewRoundCount: 2,
+      maxCopilotRounds: 2,
+      unresolvedThreadCount: 0,
+      copilotReviewRequestStatus,
+      draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+      draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+      preApprovalGate: gate({ visible: false }),
+      preApprovalGateMarker: gate({ visible: false }),
+    });
+
+    assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+    assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+    assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  });
+}
+
+// #1472 control: the round-cap exemption above is scoped to the grant's own
+// shape (gateBoundary pre_approval_gate_window) via isRoundCapReachedCleanGrant
+// — it must NOT blanket-exempt every round_cap_reached result. When the same
+// facts instead reach FINAL_APPROVAL_READY (preApprovalGate already clean on
+// the current head), a lingering review request is still a genuinely unsettled
+// signal and the guard must still fire.
+test("round_cap_reached reaching final_approval_ready (not the window shape) still guards a lingering copilotReviewRequestStatus:requested (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    copilotReviewRequestStatus: "requested",
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: true, headSha: "29aa40b7", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.POST_DRAFT_EXTERNAL_REVIEW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.WAIT_FOR_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL));
+});
+
 test("round_cap_reached with unresolved threads present stays blocked exactly as today (#1472)", () => {
   const result = evaluatePrGateCoordination({
     pr: 1460,
@@ -2794,6 +2957,7 @@ test("round_cap_reached grant branch and copilot-loop-state's round-cap fallback
   const roundCap = { copilotReviewRoundCount: 5, maxCopilotRounds: 5 };
 
   let checked = 0;
+  let grantedCount = 0;
   for (const ciStatus of ciStatuses) {
     for (const preApprovalRequireCi of requireCiOptions) {
       for (const unresolvedThreadCount of threadCounts) {
@@ -2813,6 +2977,7 @@ test("round_cap_reached grant branch and copilot-loop-state's round-cap fallback
         });
         const granted = evaluated.nextAction === PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE
           || evaluated.nextAction === PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL;
+        if (granted) grantedCount += 1;
 
         const interpreted = interpretLoopState({
           prExists: true,
@@ -2845,6 +3010,11 @@ test("round_cap_reached grant branch and copilot-loop-state's round-cap fallback
     }
   }
   assert.ok(checked > 0);
+  // #1472 (round-2 sweep defer, closed here): a vacuous sweep (e.g. the grant
+  // becoming unreachable) would still pass every assertion above — pin that
+  // at least one fact combination actually grants, so a future change that
+  // silently makes the grant unreachable fails this test.
+  assert.ok(grantedCount > 0, "sweep never exercised a granted case — the round_cap_reached grant may have become unreachable");
 });
 
 // #1472: general contract invariant, across every lifecycle state the

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -423,7 +423,7 @@ test("round-cap exhaustion opens the pre-approval gate window even without a cur
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
+  assert.equal(result.gateEvidenceNote, "Copilot review rounds exhausted (5/5); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.");
   assert.match(result.reason, /round limit/i);
   assert.match(result.reason, /pre_approval_gate/i);
 });

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2612,6 +2612,38 @@ test("round_cap_reached with zero unresolved threads and green CI allows run_pre
   assert.match(result.gateEvidenceNote, /zero unresolved threads/i);
 });
 
+// #1472 defer: when preApprovalRequireCi is false, ciConfirmedGreen is true
+// regardless of the actual CI status, so a "failure" head can still reach this
+// grant. The reason/gateEvidenceNote must not claim the CI is green in that
+// case (a false claim in human-read gate evidence) — they must instead say CI
+// was not required.
+test("round_cap_reached with requireCi:false and failing CI grants run_pre_approval_gate without claiming green CI (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "failure",
+    preApprovalRequireCi: false,
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: true, headSha: "7e0e303b", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "7e0e303b", verdict: "clean", contractComplete: true }),
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW);
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert.doesNotMatch(result.reason, /green CI/i);
+  assert.match(result.reason, /CI not required by config/i);
+  assert.ok(result.gateEvidenceNote);
+  assert.doesNotMatch(result.gateEvidenceNote, /green.{0,20}CI/i);
+  assert.match(result.gateEvidenceNote, /CI not required by config/i);
+});
+
 // #1371 re-verify: crediblyGreen is unconfirmed CI and stays blocked at the
 // round-cap-reached fallback exactly as it does at every other pre-approval
 // boundary in this file (lines ~1016/1219/1404/1655) — this branch must not

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2612,7 +2612,11 @@ test("round_cap_reached with zero unresolved threads and green CI allows run_pre
   assert.match(result.gateEvidenceNote, /zero unresolved threads/i);
 });
 
-test("round_cap_reached with zero unresolved threads and credibly green CI allows run_pre_approval_gate (#1472)", () => {
+// #1371 re-verify: crediblyGreen is unconfirmed CI and stays blocked at the
+// round-cap-reached fallback exactly as it does at every other pre-approval
+// boundary in this file (lines ~1016/1219/1404/1655) — this branch must not
+// be the one place a crediblyGreen head is granted gate entry.
+test("round_cap_reached with zero unresolved threads and credibly green CI stays blocked (#1371, #1472)", () => {
   const result = evaluatePrGateCoordination({
     pr: 1460,
     currentHeadSha: "29aa40b7deadbeef",
@@ -2629,9 +2633,9 @@ test("round_cap_reached with zero unresolved threads and credibly green CI allow
     preApprovalGateMarker: gate({ visible: false }),
   });
 
-  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
-  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
-  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
 test("round_cap_reached with clean current-head pre_approval AND clean draft_gate evidence reaches final approval (#1472)", () => {
@@ -2716,6 +2720,77 @@ test("round_cap_reached with an unknown unresolved-thread count fails closed and
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
   assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
+// #1472 reachability: the ROUND_CAP_REACHED grant branch above is a defensive
+// gate-entry re-check, not a path the interpreter's own routing is expected to
+// take. Prove the equivalence the branch's comment claims: for every
+// combination of facts where the evaluator's branch would grant gate entry
+// (zero unresolved threads, CI predicate satisfied), copilot-loop-state's
+// interpreter — fed the SAME facts at the SAME round cap — already classifies
+// the snapshot as ROUND_CAP_CLEAN_FALLBACK, never ROUND_CAP_REACHED. So the
+// branch's guard (effectiveLifecycleState === ROUND_CAP_REACHED) and its own
+// grant condition can never both be true from facts a real caller reads
+// straight off the interpreter; the two predicates cannot silently drift
+// apart without this test catching it.
+test("round_cap_reached grant branch and copilot-loop-state's round-cap fallback agree on identical facts (#1472)", () => {
+  const ciStatuses = ["success", "failure", "pending", "none", "crediblyGreen"];
+  const requireCiOptions = [true, false];
+  const threadCounts = [0, 1, 3];
+  const roundCap = { copilotReviewRoundCount: 5, maxCopilotRounds: 5 };
+
+  let checked = 0;
+  for (const ciStatus of ciStatuses) {
+    for (const preApprovalRequireCi of requireCiOptions) {
+      for (const unresolvedThreadCount of threadCounts) {
+        checked += 1;
+        const evaluated = evaluatePrGateCoordination({
+          pr: 1472,
+          currentHeadSha: "29aa40b7deadbeef",
+          prDraft: false,
+          lifecycleState: STATE.ROUND_CAP_REACHED,
+          loopDisposition: DISPOSITION.BLOCKED,
+          ciStatus,
+          preApprovalRequireCi,
+          ...roundCap,
+          unresolvedThreadCount,
+          preApprovalGate: gate({ visible: false }),
+          preApprovalGateMarker: gate({ visible: false }),
+        });
+        const granted = evaluated.nextAction === PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE
+          || evaluated.nextAction === PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL;
+
+        const interpreted = interpretLoopState({
+          prExists: true,
+          prNumber: 1472,
+          copilotReviewRequestStatus: "none",
+          copilotReviewPresent: true,
+          copilotReviewOnCurrentHead: false,
+          unresolvedThreadCount,
+          actionableThreadCount: unresolvedThreadCount,
+          ...roundCap,
+          ciStatus,
+        }, { maxCopilotRounds: roundCap.maxCopilotRounds, preApprovalRequireCi });
+
+        const context = JSON.stringify({ ciStatus, preApprovalRequireCi, unresolvedThreadCount });
+        if (granted) {
+          assert.equal(
+            interpreted.state,
+            STATE.ROUND_CAP_CLEAN_FALLBACK,
+            `evaluator granted gate entry but interpreter did not classify identical facts as round_cap_clean_fallback for ${context}`,
+          );
+        }
+        if (interpreted.state === STATE.ROUND_CAP_REACHED) {
+          assert.equal(
+            granted,
+            false,
+            `interpreter hard-stopped at round_cap_reached but the evaluator granted gate entry on identical facts for ${context}`,
+          );
+        }
+      }
+    }
+  }
+  assert.ok(checked > 0);
 });
 
 // #1472: general contract invariant, across every lifecycle state the

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2793,6 +2793,34 @@ test("round_cap_reached with clean current-head pre_approval but no draft_gate e
   assert.match(result.reason, /no gate exemptions, #579/i);
 });
 
+// Same shape with a blocking title marker: DRAFT_GATE_NEEDED is NOT in
+// TITLE_MARKER_GUARDED_BOUNDARIES, so the outer post-pass cannot re-block this
+// sub-path — the grant block's inline check (mirroring ROUND_CAP_CLEAN_FALLBACK)
+// must. Fails without it: the WIP head routes to reconcile_draft_gate.
+test("round_cap_reached grant shape with a WIP title blocks on the title marker, not reconcile_draft_gate (#842, #1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    prTitle: "WIP: do not merge yet",
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    unresolvedThreadCount: 0,
+    draftGate: gate({ visible: false }),
+    draftGateMarker: gate({ visible: false }),
+    preApprovalGate: gate({ visible: true, headSha: "29aa40b7", verdict: "clean" }),
+    preApprovalGateMarker: gate({ visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true }),
+  });
+
+  assert.equal(result.lifecycleState, "title_marker_blocked");
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.DRAFT_GATE_NEEDED);
+  assert(!result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE));
+});
+
 // #1472: applyUnsettledCopilotReviewEntryGuard (the core-side #1190 mirror of
 // the detector's formal-request guard) runs unconditionally after the
 // evaluator's own ROUND_CAP_REACHED grant, on the SAME input this evaluator

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2754,6 +2754,28 @@ test("round_cap_reached with an unknown unresolved-thread count fails closed and
   assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+test("round_cap_reached with a non-integer unresolved-thread count fails closed and stays blocked (#1472)", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prDraft: false,
+    lifecycleState: STATE.ROUND_CAP_REACHED,
+    loopDisposition: DISPOSITION.BLOCKED,
+    ciStatus: "success",
+    copilotReviewRoundCount: 2,
+    maxCopilotRounds: 2,
+    // A fractional count must be treated as unknown (null), never floored to
+    // 0 — flooring would satisfy the grant's zero-threads precondition.
+    unresolvedThreadCount: 0.5,
+    preApprovalGate: gate({ visible: false }),
+    preApprovalGateMarker: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REPORT_BLOCKED);
+  assert(result.allowedNextActions.includes(PR_CHECKPOINT_ACTION.REPORT_BLOCKED));
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+});
+
 // #1472 reachability: the ROUND_CAP_REACHED grant branch above is a defensive
 // gate-entry re-check, not a path the interpreter's own routing is expected to
 // take. Prove the equivalence the branch's comment claims: for every
@@ -2828,10 +2850,12 @@ test("round_cap_reached grant branch and copilot-loop-state's round-cap fallback
 // #1472: general contract invariant, across every lifecycle state the
 // evaluator can be handed and a broad sweep of companion signals — the
 // synthesized nextAction must always be a member of allowedNextActions and
-// never a member of forbiddenActions. This is the general safety net the
-// round_cap_reached deadlock slipped through: a return statement naming
-// nextAction without granting it in allowedNextActions (or while forbidding
-// it) is exactly the shape upsert-checkpoint-verdict.mjs cannot act on.
+// never a member of forbiddenActions. Forward-drift guard: no committed
+// evaluator version violates this matrix (the pre-fix round_cap_reached shape
+// returned a self-consistent report_blocked), but a future return statement
+// naming a nextAction without granting it in allowedNextActions (or while
+// forbidding it) is exactly the shape upsert-checkpoint-verdict.mjs cannot
+// act on, so the sweep pins the invariant against regression.
 test("contract: nextAction is always allowed and never forbidden, across every lifecycle state (#1472)", () => {
   const lifecycleStates = Object.values(STATE);
   const ciStatuses = ["success", "failure", "pending", "none", "crediblyGreen"];

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1007,6 +1007,10 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     ciStatus: coordinationContext.snapshot?.ciStatus ?? null,
     copilotReviewRoundCount: coordinationContext.snapshot?.copilotReviewRoundCount ?? 0,
     maxCopilotRounds,
+    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
+    // confirm "zero unresolved threads" (the exhaustion note's own promise)
+    // rather than trusting a stale/compound lifecycleState label alone.
+    unresolvedThreadCount: coordinationContext.snapshot?.unresolvedThreadCount ?? null,
     sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
     // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
     // sameHeadCleanConverged, so an outstanding request on the current head refuses

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -953,6 +953,50 @@ async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRo
   return { ...result, draftTransition: true };
 }
 
+// #1472: builds the exact input object passed to evaluatePrGateCoordination.
+// Exported (and used by upsertCheckpointVerdict below, not duplicated) so a
+// test can assert the real production wiring — e.g. that unresolvedThreadCount
+// is threaded from coordinationContext.snapshot rather than a test
+// re-implementing this object literal.
+export function buildCoordinationEvaluatorInput({
+  coordinationContext,
+  maxCopilotRounds,
+  draftGateConfig,
+  preApprovalGateConfig,
+  reviewMode,
+}) {
+  return {
+    repo: coordinationContext.repo,
+    pr: coordinationContext.pr,
+    currentHeadSha: coordinationContext.currentHeadSha,
+    prDraft: Boolean(coordinationContext.prData?.isDraft),
+    prClosed: String(coordinationContext.prData?.state || "").toUpperCase() === "CLOSED",
+    prMerged: String(coordinationContext.prData?.state || "").toUpperCase() === "MERGED",
+    lifecycleState: coordinationContext.interpretation.state,
+    loopDisposition: coordinationContext.disposition.loopDisposition,
+    ciStatus: coordinationContext.snapshot?.ciStatus ?? null,
+    copilotReviewRoundCount: coordinationContext.snapshot?.copilotReviewRoundCount ?? 0,
+    maxCopilotRounds,
+    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
+    // confirm "zero unresolved threads" (the exhaustion note's own promise)
+    // rather than trusting a stale/compound lifecycleState label alone.
+    unresolvedThreadCount: coordinationContext.snapshot?.unresolvedThreadCount ?? null,
+    sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
+    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
+    // sameHeadCleanConverged, so an outstanding request on the current head refuses
+    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
+    copilotReviewRequestStatus: coordinationContext.snapshot?.copilotReviewRequestStatus ?? "none",
+    draftGateRequireCi: draftGateConfig.requireCi,
+    preApprovalRequireCi: preApprovalGateConfig.requireCi,
+    draftGate: coordinationContext.gateEvidence.draftGate,
+    draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,
+    refinementArtifact: coordinationContext.refinementArtifact,
+    preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
+    preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
+    ...(reviewMode ? { reviewMode } : {}),
+  };
+}
+
 export async function upsertCheckpointVerdict(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), runChild = defaultRunChild } = {}) {
   const gh = { env, ghCommand, repoRoot, runChild };
   // Root cause 1: allow resurrected sessions to claim ownership when the previous
@@ -995,36 +1039,13 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     // Non-fatal: internal-only detection failure is best-effort.
     // Proceed with the default (external Copilot review) mode.
   }
-  const coordination = evaluatePrGateCoordination({
-    repo: coordinationContext.repo,
-    pr: coordinationContext.pr,
-    currentHeadSha: coordinationContext.currentHeadSha,
-    prDraft: Boolean(coordinationContext.prData?.isDraft),
-    prClosed: String(coordinationContext.prData?.state || "").toUpperCase() === "CLOSED",
-    prMerged: String(coordinationContext.prData?.state || "").toUpperCase() === "MERGED",
-    lifecycleState: coordinationContext.interpretation.state,
-    loopDisposition: coordinationContext.disposition.loopDisposition,
-    ciStatus: coordinationContext.snapshot?.ciStatus ?? null,
-    copilotReviewRoundCount: coordinationContext.snapshot?.copilotReviewRoundCount ?? 0,
+  const coordination = evaluatePrGateCoordination(buildCoordinationEvaluatorInput({
+    coordinationContext,
     maxCopilotRounds,
-    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
-    // confirm "zero unresolved threads" (the exhaustion note's own promise)
-    // rather than trusting a stale/compound lifecycleState label alone.
-    unresolvedThreadCount: coordinationContext.snapshot?.unresolvedThreadCount ?? null,
-    sameHeadCleanConverged: coordinationContext.interpretation.sameHeadCleanConverged,
-    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
-    // sameHeadCleanConverged, so an outstanding request on the current head refuses
-    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
-    copilotReviewRequestStatus: coordinationContext.snapshot?.copilotReviewRequestStatus ?? "none",
-    draftGateRequireCi: draftGateConfig.requireCi,
-    preApprovalRequireCi: preApprovalGateConfig.requireCi,
-    draftGate: coordinationContext.gateEvidence.draftGate,
-    draftGateMarker: coordinationContext.gateEvidence.draftGateMarker,
-    refinementArtifact: coordinationContext.refinementArtifact,
-    preApprovalGate: coordinationContext.gateEvidence.preApprovalGate,
-    preApprovalGateMarker: coordinationContext.gateEvidence.preApprovalGateMarker,
-    ...(reviewMode ? { reviewMode } : {}),
-  });
+    draftGateConfig,
+    preApprovalGateConfig,
+    reviewMode,
+  }));
   if (!options.gate) {
     if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE)) {
       options.gate = "draft_gate";

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -13,8 +13,8 @@ import {
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinement, resolveRefinementConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { STATE, buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
-import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION, REFINEMENT_ARTIFACT_SPEC_SOURCE } from "@dev-loops/core/loop/pr-gate-coordination";
+import { buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
+import { evaluatePrGateCoordination, isRoundCapReachedCleanGrant, PR_CHECKPOINT, PR_CHECKPOINT_ACTION, REFINEMENT_ARTIFACT_SPEC_SOURCE } from "@dev-loops/core/loop/pr-gate-coordination";
 import { shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
 import { PLAN_FILE_PROMOTION_DOC_PATH_PATTERN } from "@dev-loops/core/loop/plan-file-promote-contract";
 import { UI_E2E_CHECK_NAMES } from "@dev-loops/core/loop/ui-e2e-scoping";
@@ -24,6 +24,9 @@ import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.m
 import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+// #1472: re-exported so scripts/test callers that imported this predicate
+// from this module before it moved to packages/core keep working.
+export { isRoundCapReachedCleanGrant };
 const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
 const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
 Determine which PR gate/transition is legal next for a pull request.
@@ -621,15 +624,15 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
   };
 }
 
-// #1472: the evaluator's ROUND_CAP_REACHED grant branch (a defensive gate-entry
-// re-check, in evaluatePrGateCoordination, reachable only by a caller whose
-// unresolvedThreadCount/ciStatus are fresher than what the interpreter last
-// saw) settles on this exact shape: lifecycleState stays round_cap_reached
-// (never round_cap_clean_fallback) while gateBoundary is pre_approval_gate_window.
-// Exported so the formal-request-guard exemption below (and its test) can name
-// this shape without duplicating the literal comparison.
-export function isRoundCapReachedCleanGrant({ lifecycleState, gateBoundary } = {}) {
-  return lifecycleState === STATE.ROUND_CAP_REACHED && gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW;
+// #1472: composes the formal-request guard's round-cap exemption from both
+// shapes that must suppress it — the interpreter's own roundCapCleanEligible
+// (round_cap_clean_fallback) and the evaluator's independent ROUND_CAP_REACHED
+// grant (isRoundCapReachedCleanGrant, imported from packages/core, the same
+// predicate the core-side applyUnsettledCopilotReviewEntryGuard mirror uses).
+// Exported so a test can exercise this exact composition instead of
+// re-implementing it.
+export function resolveRoundCapCleanFallback({ roundCapCleanEligible, evaluatorResult }) {
+  return roundCapCleanEligible === true || isRoundCapReachedCleanGrant(evaluatorResult);
 }
 
 async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
@@ -645,6 +648,57 @@ async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.e
     if (login && isCopilotLogin(login)) return true;
   }
   return false;
+}
+
+// #1472: builds the exact input object passed to evaluatePrGateCoordination.
+// Exported (and used by detectPrGateCoordinationState below, not duplicated)
+// so a test can assert the real production wiring — e.g. that
+// unresolvedThreadCount is threaded from context.snapshot rather than a test
+// re-implementing this object literal.
+export function buildGateCoordinationEvaluatorInput({
+  context,
+  maxCopilotRounds,
+  draftGateConfig,
+  preApprovalGateConfig,
+  postConvergenceSignificantChange,
+}) {
+  return {
+    repo: context.repo,
+    pr: context.pr,
+    currentHeadSha: context.currentHeadSha,
+    prDraft: Boolean(context.prData?.isDraft),
+    prClosed: String(context.prData?.state || "").toUpperCase() === "CLOSED",
+    prMerged: String(context.prData?.state || "").toUpperCase() === "MERGED",
+    prTitle: context.prData?.title,
+    mergeStateStatus: context.mergeStateStatus,
+    mergeable: context.mergeable,
+    conflictFiles: context.conflictFiles,
+    // UI e2e auto-scoping (#976): path-triggered + fail-closed precondition.
+    changedFiles: extractChangedFiles(context.prData),
+    uiE2ePassed: deriveUiE2ePassed(context.prData),
+    lifecycleState: context.interpretation.state,
+    loopDisposition: context.disposition.loopDisposition,
+    ciStatus: context.snapshot?.ciStatus ?? null,
+    copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
+    maxCopilotRounds,
+    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
+    // confirm "zero unresolved threads" (the exhaustion note's own promise)
+    // rather than trusting a stale/compound lifecycleState label alone.
+    unresolvedThreadCount: context.snapshot?.unresolvedThreadCount ?? null,
+    sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
+    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
+    // sameHeadCleanConverged, so an outstanding request on the current head refuses
+    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
+    copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
+    draftGateRequireCi: draftGateConfig.requireCi,
+    preApprovalRequireCi: preApprovalGateConfig.requireCi,
+    draftGate: context.gateEvidence.draftGate,
+    draftGateMarker: context.gateEvidence.draftGateMarker,
+    preApprovalGate: context.gateEvidence.preApprovalGate,
+    preApprovalGateMarker: context.gateEvidence.preApprovalGateMarker,
+    refinementArtifact: context.refinementArtifact,
+    postConvergenceSignificantChange,
+  };
 }
 
 export async function detectPrGateCoordinationState(options, runtime = {}) {
@@ -681,43 +735,13 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     },
     runtime,
   );
-  const result = evaluatePrGateCoordination({
-    repo: context.repo,
-    pr: context.pr,
-    currentHeadSha: context.currentHeadSha,
-    prDraft: Boolean(context.prData?.isDraft),
-    prClosed: String(context.prData?.state || "").toUpperCase() === "CLOSED",
-    prMerged: String(context.prData?.state || "").toUpperCase() === "MERGED",
-    prTitle: context.prData?.title,
-    mergeStateStatus: context.mergeStateStatus,
-    mergeable: context.mergeable,
-    conflictFiles: context.conflictFiles,
-    // UI e2e auto-scoping (#976): path-triggered + fail-closed precondition.
-    changedFiles: extractChangedFiles(context.prData),
-    uiE2ePassed: deriveUiE2ePassed(context.prData),
-    lifecycleState: context.interpretation.state,
-    loopDisposition: context.disposition.loopDisposition,
-    ciStatus: context.snapshot?.ciStatus ?? null,
-    copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
+  const result = evaluatePrGateCoordination(buildGateCoordinationEvaluatorInput({
+    context,
     maxCopilotRounds,
-    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
-    // confirm "zero unresolved threads" (the exhaustion note's own promise)
-    // rather than trusting a stale/compound lifecycleState label alone.
-    unresolvedThreadCount: context.snapshot?.unresolvedThreadCount ?? null,
-    sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
-    // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
-    // sameHeadCleanConverged, so an outstanding request on the current head refuses
-    // RUN_PRE_APPROVAL_GATE even if sameHeadCleanConverged were somehow stale/wrong.
-    copilotReviewRequestStatus: context.snapshot?.copilotReviewRequestStatus ?? "none",
-    draftGateRequireCi: draftGateConfig.requireCi,
-    preApprovalRequireCi: preApprovalGateConfig.requireCi,
-    draftGate: context.gateEvidence.draftGate,
-    draftGateMarker: context.gateEvidence.draftGateMarker,
-    preApprovalGate: context.gateEvidence.preApprovalGate,
-    preApprovalGateMarker: context.gateEvidence.preApprovalGateMarker,
-    refinementArtifact: context.refinementArtifact,
+    draftGateConfig,
+    preApprovalGateConfig,
     postConvergenceSignificantChange,
-  });
+  }));
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.
   // Only query timeline when cheap preconditions pass — avoids unnecessary
@@ -739,8 +763,10 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   // re-blocking the exact fallback the grant just opened. Widen the exemption
   // to cover that shape too — it is the same "no further Copilot round is
   // legal" fact pattern roundCapCleanEligible already exempts.
-  const roundCapCleanFallback = (context.interpretation?.roundCapCleanEligible ?? false)
-    || isRoundCapReachedCleanGrant(result);
+  const roundCapCleanFallback = resolveRoundCapCleanFallback({
+    roundCapCleanEligible: context.interpretation?.roundCapCleanEligible ?? false,
+    evaluatorResult: result,
+  });
   const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
     && guardBoundaries.has(result.gateBoundary)
     // cap-0 disables the Copilot gate, so shouldGuardCopilotReviewRequest always

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -24,9 +24,6 @@ import { detectCheckpointEvidence } from "../github/detect-checkpoint-evidence.m
 import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
-// #1472: re-exported so scripts/test callers that imported this predicate
-// from this module before it moved to packages/core keep working.
-export { isRoundCapReachedCleanGrant };
 const UNMERGED_GIT_STATUS_CODES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
 const USAGE = `Usage: detect-pr-gate-coordination-state.mjs --repo <owner/name> --pr <number>
 Determine which PR gate/transition is legal next for a pull request.

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -689,6 +689,10 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     ciStatus: context.snapshot?.ciStatus ?? null,
     copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount ?? 0,
     maxCopilotRounds,
+    // #1472: lets the evaluator's ROUND_CAP_REACHED handling independently
+    // confirm "zero unresolved threads" (the exhaustion note's own promise)
+    // rather than trusting a stale/compound lifecycleState label alone.
+    unresolvedThreadCount: context.snapshot?.unresolvedThreadCount ?? null,
     sameHeadCleanConverged: context.interpretation.sameHeadCleanConverged,
     // Independent gate-ENTRY re-check (#1190): fed alongside (not derived from)
     // sameHeadCleanConverged, so an outstanding request on the current head refuses

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -13,7 +13,7 @@ import {
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinement, resolveRefinementConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
+import { STATE, buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination, PR_CHECKPOINT, PR_CHECKPOINT_ACTION, REFINEMENT_ARTIFACT_SPEC_SOURCE } from "@dev-loops/core/loop/pr-gate-coordination";
 import { shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
 import { PLAN_FILE_PROMOTION_DOC_PATH_PATTERN } from "@dev-loops/core/loop/plan-file-promote-contract";
@@ -621,6 +621,17 @@ export async function loadPrGateCoordinationContext(options, runtime = {}) {
   };
 }
 
+// #1472: the evaluator's ROUND_CAP_REACHED grant branch (a defensive gate-entry
+// re-check, in evaluatePrGateCoordination, reachable only by a caller whose
+// unresolvedThreadCount/ciStatus are fresher than what the interpreter last
+// saw) settles on this exact shape: lifecycleState stays round_cap_reached
+// (never round_cap_clean_fallback) while gateBoundary is pre_approval_gate_window.
+// Exported so the formal-request-guard exemption below (and its test) can name
+// this shape without duplicating the literal comparison.
+export function isRoundCapReachedCleanGrant({ lifecycleState, gateBoundary } = {}) {
+  return lifecycleState === STATE.ROUND_CAP_REACHED && gateBoundary === PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW;
+}
+
 async function fetchCopilotEverFormallyRequested({ repo, pr }, { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
   const result = await runChild(
     ghCommand,
@@ -721,7 +732,15 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
   // Round-cap clean fallback (#896): the interpreter resolved a clean post-cap head
   // (zero unresolved threads + green CI) that Copilot will not re-review. The formal
   // request guard must not fire here — pre_approval_gate reviews the post-cap head.
-  const roundCapCleanFallback = context.interpretation?.roundCapCleanEligible ?? false;
+  //
+  // #1472: without this, the guard below would rewrite the evaluator's
+  // ROUND_CAP_REACHED grant (see isRoundCapReachedCleanGrant) to
+  // request_copilot_review whenever Copilot was never formally requested,
+  // re-blocking the exact fallback the grant just opened. Widen the exemption
+  // to cover that shape too — it is the same "no further Copilot round is
+  // legal" fact pattern roundCapCleanEligible already exempts.
+  const roundCapCleanFallback = (context.interpretation?.roundCapCleanEligible ?? false)
+    || isRoundCapReachedCleanGrant(result);
   const copilotReviewEverFormallyRequested = copilotReviewRequestStatus === "none"
     && guardBoundaries.has(result.gateBoundary)
     // cap-0 disables the Copilot gate, so shouldGuardCopilotReviewRequest always

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -7,6 +7,7 @@ import test, { after, before } from "node:test";
 import { DEFAULT_TEST_PR_BODY, makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
+  buildCoordinationEvaluatorInput,
   buildInlineExecutionWarning,
   parseUpsertCheckpointVerdictCliArgs,
   renderGateReviewCommentBody,
@@ -202,6 +203,49 @@ function buildGateComment({
     updated_at: updatedAt,
   };
 }
+
+// #1472: buildCoordinationEvaluatorInput is the exact function
+// upsertCheckpointVerdict calls to assemble evaluatePrGateCoordination's
+// input — not a re-implementation. Mutation check: replacing
+// `coordinationContext.snapshot?.unresolvedThreadCount ?? null` with a
+// hardcoded `null` in that function fails this assertion, unlike a test that
+// reproduces the object literal independently.
+test("buildCoordinationEvaluatorInput threads unresolvedThreadCount from coordinationContext.snapshot (#1472)", () => {
+  const coordinationContext = {
+    repo: "owner/repo",
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prData: { isDraft: false, state: "OPEN" },
+    interpretation: { state: "round_cap_reached", sameHeadCleanConverged: false },
+    disposition: { loopDisposition: "blocked" },
+    snapshot: { ciStatus: "success", copilotReviewRoundCount: 2, unresolvedThreadCount: 0, copilotReviewRequestStatus: "none" },
+    gateEvidence: {
+      draftGate: { visible: true, headSha: "29aa40b7", verdict: "clean" },
+      draftGateMarker: { visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true },
+      preApprovalGate: { visible: false },
+      preApprovalGateMarker: { visible: false },
+    },
+    refinementArtifact: null,
+  };
+  const input = buildCoordinationEvaluatorInput({
+    coordinationContext,
+    maxCopilotRounds: 2,
+    draftGateConfig: { requireCi: true },
+    preApprovalGateConfig: { requireCi: true },
+    reviewMode: null,
+  });
+  assert.equal(input.unresolvedThreadCount, 0);
+
+  const nonZeroContext = { ...coordinationContext, snapshot: { ...coordinationContext.snapshot, unresolvedThreadCount: 4 } };
+  const nonZeroInput = buildCoordinationEvaluatorInput({
+    coordinationContext: nonZeroContext,
+    maxCopilotRounds: 2,
+    draftGateConfig: { requireCi: true },
+    preApprovalGateConfig: { requireCi: true },
+    reviewMode: null,
+  });
+  assert.equal(nonZeroInput.unresolvedThreadCount, 4);
+});
 
 test("parseUpsertCheckpointVerdictCliArgs rejects malformed arguments deterministically", () => {
   assert.throws(

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1065,7 +1065,7 @@ test("upsert-checkpoint-verdict appends the round-cap fallback note to pre-appro
         assertArgContains: [
           "body=### Gate review: `pre_approval_gate`",
           "**Findings summary:** no issues found",
-          "**Gate evidence note:** Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
+          "**Gate evidence note:** Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.",
         ],
         // The evidence note must render on its own labeled line — never spliced
         // with `;` into the findings summary (pre-fix render).
@@ -3288,7 +3288,7 @@ test("upsert-checkpoint-verdict --findings-json structured verdict renders the g
   // `**Findings summary:**` line — exactly like the free-text path. The same PR
   // state as the free-text round-cap test drives coordination to emit the note.
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-json-note-"));
-  const roundExhaustionNote = "Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green or credibly green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.";
+  const roundExhaustionNote = "Copilot review rounds exhausted (5/2); current head has zero unresolved threads and green CI, so pre_approval_gate fallback is allowed without another Copilot re-request.";
   try {
     const findingsPath = path.join(tempDir, "findings.json");
     await writeFile(

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -6,10 +6,10 @@ import test from "node:test";
 import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
-import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, isRoundCapReachedCleanGrant } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 import { emitResult } from "../../scripts/lib/jq-output.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
-import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
+import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION, shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
 import { buildPlanFilePromotionMarker, buildPromotionPrBody } from "@dev-loops/core/loop/plan-file-promote-contract";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
@@ -1825,5 +1825,72 @@ test("deriveUiE2ePassed reads UI e2e checks from statusCheckRollup", () => {
     deriveUiE2ePassed({ statusCheckRollup: [{ name: "viewer-smoke", conclusion: "SKIPPED" }, { name: "deck-smoke", conclusion: "SUCCESS" }] }),
     true,
     "SKIPPED check should not block the gate",
+  );
+});
+
+// #1472: isRoundCapReachedCleanGrant names the shape evaluatePrGateCoordination's
+// defensive ROUND_CAP_REACHED grant branch settles on (lifecycleState stays
+// round_cap_reached — never round_cap_clean_fallback — while gateBoundary is
+// pre_approval_gate_window). The formal-request guard in
+// detectPrGateCoordinationState widens its round-cap exemption with this
+// predicate so that grant is not immediately re-blocked.
+test("isRoundCapReachedCleanGrant identifies the round_cap_reached + pre_approval_gate_window grant shape", () => {
+  assert.equal(
+    isRoundCapReachedCleanGrant({ lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW }),
+    true,
+  );
+  assert.equal(
+    isRoundCapReachedCleanGrant({ lifecycleState: "round_cap_clean_fallback", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW }),
+    false,
+    "round_cap_clean_fallback is already covered by roundCapCleanEligible, not this shape",
+  );
+  assert.equal(
+    isRoundCapReachedCleanGrant({ lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED }),
+    false,
+    "a different gate boundary is not the grant's own shape",
+  );
+  assert.equal(isRoundCapReachedCleanGrant(), false);
+});
+
+// #1472: this reproduces detectPrGateCoordinationState's exact guard-input
+// wiring (roundCapCleanFallback widened by isRoundCapReachedCleanGrant) for an
+// evaluator result with lifecycleState round_cap_reached + gateBoundary
+// pre_approval_gate_window and Copilot never formally requested. Pre-fix
+// (roundCapCleanFallback sourced only from context.interpretation's
+// roundCapCleanEligible, which is false at round_cap_reached) this returns
+// true — the guard fires and rewrites the grant to request_copilot_review,
+// re-blocking the exact fallback the grant just opened. Fixed, it must return
+// false so the grant survives the post-pass unchanged.
+test("formal-request guard does not re-block the round_cap_reached clean-grant shape when Copilot was never formally requested (#1472)", () => {
+  const evaluatorResult = { lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW };
+  const guardInputs = {
+    copilotReviewRequestStatus: "none",
+    copilotReviewRoundCount: 5,
+    copilotReviewEverFormallyRequested: false,
+    maxCopilotRounds: 5,
+    sameHeadCleanConverged: false,
+    postConvergenceSignificantChange: false,
+    gateBoundary: evaluatorResult.gateBoundary,
+  };
+
+  // Pre-fix shape: roundCapCleanFallback sourced only from
+  // context.interpretation.roundCapCleanEligible, which is false at
+  // round_cap_reached (that field is only true for round_cap_clean_fallback).
+  // With no exemption applying, the guard fires and would rewrite the grant
+  // to request_copilot_review.
+  assert.equal(
+    shouldGuardCopilotReviewRequest({ ...guardInputs, roundCapCleanFallback: false }),
+    true,
+    "sanity: without the #1472 exemption, the guard fires and re-blocks the grant",
+  );
+
+  // Fixed shape: roundCapCleanFallback widened with isRoundCapReachedCleanGrant,
+  // exactly as detectPrGateCoordinationState now computes it.
+  const roundCapCleanFallback = false || isRoundCapReachedCleanGrant(evaluatorResult);
+  assert.equal(roundCapCleanFallback, true);
+  assert.equal(
+    shouldGuardCopilotReviewRequest({ ...guardInputs, roundCapCleanFallback }),
+    false,
+    "the round_cap_reached clean grant must not be rewritten to request_copilot_review",
   );
 });

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
-import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, isRoundCapReachedCleanGrant } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, isRoundCapReachedCleanGrant, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 import { emitResult } from "../../scripts/lib/jq-output.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION, shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
@@ -1828,6 +1828,52 @@ test("deriveUiE2ePassed reads UI e2e checks from statusCheckRollup", () => {
   );
 });
 
+// #1472: buildGateCoordinationEvaluatorInput is the exact function
+// detectPrGateCoordinationState calls to assemble evaluatePrGateCoordination's
+// input — not a re-implementation. Mutation check: replacing
+// `context.snapshot?.unresolvedThreadCount ?? null` with a hardcoded `null`
+// in that function fails this assertion, unlike a test that reproduces the
+// object literal independently.
+test("buildGateCoordinationEvaluatorInput threads unresolvedThreadCount from context.snapshot (#1472)", () => {
+  const context = {
+    repo: "owner/repo",
+    pr: 1460,
+    currentHeadSha: "29aa40b7deadbeef",
+    prData: { isDraft: false, state: "OPEN", title: "Fix things", reviews: [], files: [] },
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    conflictFiles: [],
+    interpretation: { state: "round_cap_reached", sameHeadCleanConverged: false, roundCapCleanEligible: false },
+    disposition: { loopDisposition: "blocked" },
+    snapshot: { ciStatus: "success", copilotReviewRoundCount: 2, unresolvedThreadCount: 0, copilotReviewRequestStatus: "none" },
+    gateEvidence: {
+      draftGate: { visible: true, headSha: "29aa40b7", verdict: "clean" },
+      draftGateMarker: { visible: true, headSha: "29aa40b7", verdict: "clean", contractComplete: true },
+      preApprovalGate: { visible: false },
+      preApprovalGateMarker: { visible: false },
+    },
+    refinementArtifact: null,
+  };
+  const input = buildGateCoordinationEvaluatorInput({
+    context,
+    maxCopilotRounds: 2,
+    draftGateConfig: { requireCi: true },
+    preApprovalGateConfig: { requireCi: true },
+    postConvergenceSignificantChange: false,
+  });
+  assert.equal(input.unresolvedThreadCount, 0);
+
+  const nonZeroContext = { ...context, snapshot: { ...context.snapshot, unresolvedThreadCount: 3 } };
+  const nonZeroInput = buildGateCoordinationEvaluatorInput({
+    context: nonZeroContext,
+    maxCopilotRounds: 2,
+    draftGateConfig: { requireCi: true },
+    preApprovalGateConfig: { requireCi: true },
+    postConvergenceSignificantChange: false,
+  });
+  assert.equal(nonZeroInput.unresolvedThreadCount, 3);
+});
+
 // #1472: isRoundCapReachedCleanGrant names the shape evaluatePrGateCoordination's
 // defensive ROUND_CAP_REACHED grant branch settles on (lifecycleState stays
 // round_cap_reached — never round_cap_clean_fallback — while gateBoundary is
@@ -1852,15 +1898,40 @@ test("isRoundCapReachedCleanGrant identifies the round_cap_reached + pre_approva
   assert.equal(isRoundCapReachedCleanGrant(), false);
 });
 
-// #1472: this reproduces detectPrGateCoordinationState's exact guard-input
-// wiring (roundCapCleanFallback widened by isRoundCapReachedCleanGrant) for an
-// evaluator result with lifecycleState round_cap_reached + gateBoundary
-// pre_approval_gate_window and Copilot never formally requested. Pre-fix
-// (roundCapCleanFallback sourced only from context.interpretation's
-// roundCapCleanEligible, which is false at round_cap_reached) this returns
-// true — the guard fires and rewrites the grant to request_copilot_review,
-// re-blocking the exact fallback the grant just opened. Fixed, it must return
-// false so the grant survives the post-pass unchanged.
+// #1472: resolveRoundCapCleanFallback is the exact exported function
+// detectPrGateCoordinationState calls to compose its guard input — not a
+// re-implementation of that line. Mutation check: deleting the
+// `isRoundCapReachedCleanGrant` widening from resolveRoundCapCleanFallback's
+// body would flip this assertion (roundCapCleanEligible is false at
+// round_cap_reached; only the grant-shape check makes it true), so this test
+// fails if that widening regresses, unlike testing a copy of the expression.
+test("resolveRoundCapCleanFallback widens the round-cap exemption for the evaluator's round_cap_reached clean-grant shape (#1472)", () => {
+  const evaluatorResult = { lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW };
+
+  assert.equal(
+    resolveRoundCapCleanFallback({ roundCapCleanEligible: false, evaluatorResult }),
+    true,
+    "the round_cap_reached + pre_approval_gate_window grant shape must widen the exemption even when roundCapCleanEligible (round_cap_clean_fallback) is false",
+  );
+  assert.equal(
+    resolveRoundCapCleanFallback({ roundCapCleanEligible: false, evaluatorResult: { lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_NEEDED } }),
+    false,
+    "a different gate boundary is not the grant's own shape",
+  );
+  assert.equal(
+    resolveRoundCapCleanFallback({ roundCapCleanEligible: true, evaluatorResult: null }),
+    true,
+    "roundCapCleanEligible alone (round_cap_clean_fallback) still exempts",
+  );
+});
+
+// #1472: this drives detectPrGateCoordinationState's production wiring
+// end-to-end — the formal-request guard must not rewrite the evaluator's
+// round_cap_reached clean-grant back to request_copilot_review. Mutation
+// check: reverting resolveRoundCapCleanFallback to `roundCapCleanEligible ===
+// true` (dropping the isRoundCapReachedCleanGrant widening) makes this fail,
+// because it exercises the real composed value shouldGuardCopilotReviewRequest
+// sees, not a copy of the expression.
 test("formal-request guard does not re-block the round_cap_reached clean-grant shape when Copilot was never formally requested (#1472)", () => {
   const evaluatorResult = { lifecycleState: "round_cap_reached", gateBoundary: PR_CHECKPOINT.PRE_APPROVAL_GATE_WINDOW };
   const guardInputs = {
@@ -1873,20 +1944,20 @@ test("formal-request guard does not re-block the round_cap_reached clean-grant s
     gateBoundary: evaluatorResult.gateBoundary,
   };
 
-  // Pre-fix shape: roundCapCleanFallback sourced only from
-  // context.interpretation.roundCapCleanEligible, which is false at
-  // round_cap_reached (that field is only true for round_cap_clean_fallback).
-  // With no exemption applying, the guard fires and would rewrite the grant
-  // to request_copilot_review.
+  // Sanity: without any round-cap exemption applying, the guard fires and
+  // would rewrite the grant to request_copilot_review.
   assert.equal(
     shouldGuardCopilotReviewRequest({ ...guardInputs, roundCapCleanFallback: false }),
     true,
     "sanity: without the #1472 exemption, the guard fires and re-blocks the grant",
   );
 
-  // Fixed shape: roundCapCleanFallback widened with isRoundCapReachedCleanGrant,
-  // exactly as detectPrGateCoordinationState now computes it.
-  const roundCapCleanFallback = false || isRoundCapReachedCleanGrant(evaluatorResult);
+  // Production wiring: resolveRoundCapCleanFallback (the function
+  // detectPrGateCoordinationState actually calls) composes the exemption.
+  const roundCapCleanFallback = resolveRoundCapCleanFallback({
+    roundCapCleanEligible: false,
+    evaluatorResult,
+  });
   assert.equal(roundCapCleanFallback, true);
   assert.equal(
     shouldGuardCopilotReviewRequest({ ...guardInputs, roundCapCleanFallback }),

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -6,7 +6,8 @@ import test from "node:test";
 import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
-import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, isRoundCapReachedCleanGrant, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { isRoundCapReachedCleanGrant } from "@dev-loops/core/loop/pr-gate-coordination";
 import { emitResult } from "../../scripts/lib/jq-output.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION, shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";


### PR DESCRIPTION
Issue `1472` reported a `round_cap_reached` output whose `nextAction` (`run_pre_approval_gate`) was absent from `allowedNextActions` (`["report_blocked"]`), observed live on PR `1460`. Review probes could not reproduce that disagreement from this repo's pre-fix evaluator — it returned a self-consistent `report_blocked` for the shape — so this PR is contract-consistency hardening, not the fix for that live merge deadlock: the deadlock's root cause was the gate-evidence status stuck PENDING, fixed separately by the verdict-comment refire in the gate-evidence workflow (PR `1483`). This change makes the round-cap fallback an explicit, strictly-guarded grant (`run_pre_approval_gate` enters `allowedNextActions` only on zero unresolved threads and strictly green CI, or CI not required by config) and pins the three-fields agreement with a universal sweep across every lifecycle state the evaluator can be handed.

- `evaluatePrGateCoordination` gains a normalized `unresolvedThreadCount` input (fail-closed: unknown/invalid/non-integer → `null`, never coerced to 0) and a `ROUND_CAP_REACHED` branch: when the caller affirms zero unresolved threads AND CI is strictly `success` (or `preApproval.requireCi` is off), `allowedNextActions` includes `run_pre_approval_gate` — `crediblyGreen` stays blocked, matching every sibling pre-approval boundary. Unresolved threads, unknown thread count, or non-green CI all fall through to today's blocked behavior unchanged.
- Both callers (`detect-pr-gate-coordination-state.mjs` and `upsert-checkpoint-verdict.mjs`'s gate-entry re-check) thread the snapshot's `unresolvedThreadCount` through, with passthrough tests at both entry points.
- `isRoundCapReachedCleanGrant` lives in `packages/core/src/loop/pr-gate-coordination.mjs` and exempts the grant's pre-approval-window shape in both guards that gate it: the detector's formal-request guard and the core's own `applyUnsettledCopilotReviewEntryGuard` (previously each guard would rewrite the grant to a Copilot-review action, re-blocking the fallback it had just opened). The grant's final-approval terminal deliberately stays guarded — a conservative default before human approval, control-tested, self-healing once the interpreter re-classifies the snapshot as `round_cap_clean_fallback`.
- Honest CI wording on every reachable evidence path: `buildRoundExhaustionGateEvidenceNote` and the surrounding reason strings now describe the actual accepted CI state (`describeAcceptedCiState`), so `requireCi: false` with failing CI never claims "green CI" in posted gate evidence — fixed at the `round_cap_clean_fallback` and re-request branches real callers take, not just the new branch.
- The issue's requested general invariant is a contract test: for every lifecycle state × CI status × gate × thread-count × draft × round-cap combination the evaluator can emit, `nextAction ∈ allowedNextActions` and `nextAction ∉ forbiddenActions`. It is a forward-drift guard — the pre-fix evaluator returned a self-consistent `report_blocked` for this shape, so the regression burden sits with the dedicated grant tests, which do fail on pre-fix code (the blocked-shape tests pin behavior that was already correct).
- The grant block keeps its own inline title-marker check (mirroring `round_cap_clean_fallback`): the outer post-pass guards the final-approval and pre-approval-window boundaries but not the `DRAFT_GATE_NEEDED` sub-path, so a `WIP:`-titled head must block there rather than route to `reconcile_draft_gate` (pinned by a test that fails without the guard).

Note on reachability: the loop-state interpreter emits `round_cap_clean_fallback` (not `round_cap_reached`) whenever the grant's conditions hold, and both shipped callers read the lifecycle label and the CI/thread facts from one snapshot — so the new branch is unreachable through the shipped callers. It is pure defense-in-depth demanded by the corrected AC: the three fields can never disagree if a future caller hands the evaluator a `round_cap_reached` label with facts satisfying the grant. It is not the mechanism that resolved the PR `1460` deadlock; that root cause (gate-evidence status stuck PENDING) was fixed separately.

## Validation

- `pr-gate-coordination` suite 140/140 (incl. the CI-honesty, guard-widening, draft-gate-needed and title-marker pins, and interpreter/evaluator equivalence tests); detect-state 35 pass + 1 pre-existing skip; umbrella 12/12; upsert-verdict 88/88; copilot-loop-state 95/95; state-machine conformance green (6/6 machines).
- Full verify: 0 failures.

Closes #1472
