### PR TITLE
fix(gates): break the upsert↔reconcile circular import deadlocking draft_gate verdict posting

### DIFF
--- a/scripts/github/_draft-transition.mjs
+++ b/scripts/github/_draft-transition.mjs
@@ -1,0 +1,104 @@
+// Shared draft<->ready GraphQL/CLI mutations used by both reconcile-draft-gate.mjs
+// (the manual/CI recovery CLI) and upsert-checkpoint-verdict.mjs's in-process
+// self-heal transition (postDraftGateViaDraftTransition, #891).
+//
+// Deliberately its own module with NO dependency on either caller: previously
+// upsert-checkpoint-verdict.mjs reached these via a dynamic `import("./reconcile-
+// draft-gate.mjs")`, and reconcile-draft-gate.mjs statically imports
+// upsertCheckpointVerdict from upsert-checkpoint-verdict.mjs — a circular module
+// reference. When upsert-checkpoint-verdict.mjs is the CLI entry point (running
+// under its own top-level `await main()`), that dynamic import of a module which
+// circularly re-imports the still-evaluating entry module deadlocks Node's ESM
+// module linker: the import() promise never settles, main() never returns, and
+// the process eventually exits 13 with "Detected unsettled top-level await"
+// (issue #1455) — silently, without posting the gate verdict. Breaking the cycle
+// by extracting the shared mutations here (imported statically by both callers,
+// with no back-reference) removes the deadlock at its source instead of working
+// around it with retries or a load timeout.
+import { parseJsonText } from "../_core-helpers.mjs";
+import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
+const CONVERT_TO_DRAFT_MUTATION = [
+  "mutation($pullRequestId:ID!) {",
+  "  convertPullRequestToDraft(input: {pullRequestId: $pullRequestId}) {",
+  "    pullRequest {",
+  "      id",
+  "      isDraft",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+const PR_ID_QUERY = [
+  "query($owner:String!, $name:String!, $number:Int!) {",
+  "  repository(owner: $owner, name: $name) {",
+  "    pullRequest(number: $number) {",
+  "      id",
+  "      isDraft",
+  "    }",
+  "  }",
+  "}",
+].join("\n");
+async function resolvePrNodeId({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
+  const [owner, name] = repo.split("/");
+  const result = await runChild(ghCommand, [
+    "api", "graphql",
+    "-f", "query=" + PR_ID_QUERY,
+    "-f", `owner=${owner}`,
+    "-f", `name=${name}`,
+    "-F", `number=${pr}`,
+  ], env);
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to resolve PR node ID for #${pr}: ${result.stderr.trim() || `exit code ${result.code}`}`
+    );
+  }
+  const payload = parseJsonText(result.stdout, {
+    label: `gh api graphql (resolvePrNodeId for #${pr})`,
+  });
+  const prData = payload?.data?.repository?.pullRequest;
+  if (!prData?.id) {
+    throw new Error(`Could not resolve PR node ID for #${pr}`);
+  }
+  return { id: prData.id, isDraft: prData.isDraft };
+}
+export async function convertPrToDraft({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
+  const resolvedPr = await resolvePrNodeId({ repo, pr }, { env, ghCommand, runChild });
+  if (resolvedPr.isDraft === true) {
+    return {
+      ...resolvedPr,
+      alreadyDraft: true,
+    };
+  }
+  const result = await runChild(ghCommand, [
+    "api", "graphql",
+    "-f", "query=" + CONVERT_TO_DRAFT_MUTATION,
+    "-F", `pullRequestId=${resolvedPr.id}`,
+  ], env);
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to convert PR #${pr} to draft: ${result.stderr.trim() || `exit code ${result.code}`}`
+    );
+  }
+  const payload = parseJsonText(result.stdout, {
+    label: `gh api graphql (convertPullRequestToDraft #${pr})`,
+  });
+  const converted = payload?.data?.convertPullRequestToDraft?.pullRequest;
+  if (converted?.isDraft !== true) {
+    throw new Error(`PR #${pr} was not set to draft state after mutation`);
+  }
+  return {
+    ...converted,
+    alreadyDraft: false,
+  };
+}
+export async function markPrReady({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
+  const result = await runChild(ghCommand, [
+    "pr", "ready", String(pr),
+    "--repo", repo,
+  ], env);
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to mark PR #${pr} ready: ${result.stderr.trim() || `exit code ${result.code}`}`
+    );
+  }
+  return true;
+}

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -6,6 +6,13 @@ import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectCheckpointEvidence } from "./detect-checkpoint-evidence.mjs";
 import { upsertCheckpointVerdict } from "./upsert-checkpoint-verdict.mjs";
+// convertPrToDraft/markPrReady live in their own module (no dependency on this
+// file or upsert-checkpoint-verdict.mjs) so both callers can import them
+// statically without a circular reference back to upsert-checkpoint-verdict.mjs
+// — see _draft-transition.mjs's header comment for the deadlock that reference
+// caused (#1455).
+import { convertPrToDraft, markPrReady } from "./_draft-transition.mjs";
+export { convertPrToDraft, markPrReady };
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 const USAGE = `Usage: reconcile-draft-gate.mjs --repo <owner/name> --pr <number>
 Optional/manual recovery tool for an already non-draft PR when you want to
@@ -84,91 +91,6 @@ export function parseReconcileDraftGateCliArgs(argv) {
     throw parseError(error instanceof Error ? error.message : String(error));
   }
   return options;
-}
-const CONVERT_TO_DRAFT_MUTATION = [
-  "mutation($pullRequestId:ID!) {",
-  "  convertPullRequestToDraft(input: {pullRequestId: $pullRequestId}) {",
-  "    pullRequest {",
-  "      id",
-  "      isDraft",
-  "    }",
-  "  }",
-  "}",
-].join("\n");
-const PR_ID_QUERY = [
-  "query($owner:String!, $name:String!, $number:Int!) {",
-  "  repository(owner: $owner, name: $name) {",
-  "    pullRequest(number: $number) {",
-  "      id",
-  "      isDraft",
-  "    }",
-  "  }",
-  "}",
-].join("\n");
-async function resolvePrNodeId({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
-  const [owner, name] = repo.split("/");
-  const result = await runChild(ghCommand, [
-    "api", "graphql",
-    "-f", "query=" + PR_ID_QUERY,
-    "-f", `owner=${owner}`,
-    "-f", `name=${name}`,
-    "-F", `number=${pr}`,
-  ], env);
-  if (result.code !== 0) {
-    throw new Error(
-      `Failed to resolve PR node ID for #${pr}: ${result.stderr.trim() || `exit code ${result.code}`}`
-    );
-  }
-  const payload = parseJsonText(result.stdout, {
-    label: `gh api graphql (resolvePrNodeId for #${pr})`,
-  });
-  const prData = payload?.data?.repository?.pullRequest;
-  if (!prData?.id) {
-    throw new Error(`Could not resolve PR node ID for #${pr}`);
-  }
-  return { id: prData.id, isDraft: prData.isDraft };
-}
-export async function convertPrToDraft({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
-  const resolvedPr = await resolvePrNodeId({ repo, pr }, { env, ghCommand, runChild });
-  if (resolvedPr.isDraft === true) {
-    return {
-      ...resolvedPr,
-      alreadyDraft: true,
-    };
-  }
-  const result = await runChild(ghCommand, [
-    "api", "graphql",
-    "-f", "query=" + CONVERT_TO_DRAFT_MUTATION,
-    "-F", `pullRequestId=${resolvedPr.id}`,
-  ], env);
-  if (result.code !== 0) {
-    throw new Error(
-      `Failed to convert PR #${pr} to draft: ${result.stderr.trim() || `exit code ${result.code}`}`
-    );
-  }
-  const payload = parseJsonText(result.stdout, {
-    label: `gh api graphql (convertPullRequestToDraft #${pr})`,
-  });
-  const converted = payload?.data?.convertPullRequestToDraft?.pullRequest;
-  if (converted?.isDraft !== true) {
-    throw new Error(`PR #${pr} was not set to draft state after mutation`);
-  }
-  return {
-    ...converted,
-    alreadyDraft: false,
-  };
-}
-export async function markPrReady({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
-  const result = await runChild(ghCommand, [
-    "pr", "ready", String(pr),
-    "--repo", repo,
-  ], env);
-  if (result.code !== 0) {
-    throw new Error(
-      `Failed to mark PR #${pr} ready: ${result.stderr.trim() || `exit code ${result.code}`}`
-    );
-  }
-  return true;
 }
 function normalizeCheckBucket(check = {}) {
   const bucket = typeof check.bucket === "string" ? check.bucket.trim().toLowerCase() : "";

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -12,7 +12,6 @@ import { upsertCheckpointVerdict } from "./upsert-checkpoint-verdict.mjs";
 // — see _draft-transition.mjs's header comment for the deadlock that reference
 // caused (#1455).
 import { convertPrToDraft, markPrReady } from "./_draft-transition.mjs";
-export { convertPrToDraft, markPrReady };
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 const USAGE = `Usage: reconcile-draft-gate.mjs --repo <owner/name> --pr <number>
 Optional/manual recovery tool for an already non-draft PR when you want to

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -15,6 +15,7 @@ import { claimRunnerOwnership } from "../loop/_pr-runner-coordination.mjs";
 import { detectStaleRunner } from "../loop/_stale-runner-detection.mjs";
 import { detectInternalOnly } from "../loop/detect-internal-only-pr.mjs";
 import { FULL_HEAD_SHA_ERROR, normalizeFullHeadSha } from "../lib/head-sha.mjs";
+import { convertPrToDraft, markPrReady } from "./_draft-transition.mjs";
 const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
 const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
@@ -900,7 +901,6 @@ async function verifyComment({ repo, commentId }, { env, ghCommand, runChild = d
 // runners cause at most a transient draft flicker (not a stuck draft) — only a hard
 // crash mid-transition can leave the PR drafted until a subsequent run.
 async function postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot, runChild = defaultRunChild }) {
-  const { convertPrToDraft, markPrReady } = await import("./reconcile-draft-gate.mjs");
   process.stderr.write(
     `[draft_gate] ${options.repo}#${options.pr} is ready but needs clean draft_gate evidence; ` +
     `temporarily converting to draft to post the verdict, then restoring ready.\n`,

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2312,6 +2312,130 @@ test("upsert-checkpoint-verdict fails closed (no unbounded recursion) when the d
   }
 });
 
+test("upsert-checkpoint-verdict CLI posts the draft_gate self-heal verdict instead of hanging on an unsettled top-level await (#1455)", async () => {
+  // REGRESSION for #1455: this must run as a REAL CLI subprocess (real spawn,
+  // real `import.meta.url` top-level `await main()`), NOT the in-process
+  // makeGhMock harness the local `runNode` helper in this file uses for most
+  // tests — the bug only manifests when upsert-checkpoint-verdict.mjs is itself
+  // the ESM entry point.
+  //
+  // Root cause: postDraftGateViaDraftTransition dynamically imported
+  // "./reconcile-draft-gate.mjs", which statically imports upsertCheckpointVerdict
+  // BACK from this very file — a circular module reference. When this file is the
+  // CLI entry point (still suspended on its own top-level `await main()`), that
+  // dynamic import of a module which circularly re-imports the still-evaluating
+  // entry module deadlocks Node's ESM linker: the import() promise never settles,
+  // main() never returns, and the process exits 13 with "Detected unsettled
+  // top-level await" — WITHOUT posting the gate verdict comment.
+  //
+  // Repro shape (exact): a ready (non-draft) PR with NO prior draft_gate marker,
+  // clean pre_approval_gate evidence on the current head (drives coordination to
+  // RECONCILE_DRAFT_GATE), `--gate draft_gate`, `--execution-mode
+  // inline_single_agent`, current head SHA, and a real (non-empty) run id (the
+  // production default this file's tests otherwise set to "" — see the `runNode`
+  // helper above — which happens to also skip the unrelated verifyComment path).
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-1455-unsettled-await-"));
+
+  try {
+    const headSha = "abc1234000000000000000000000000000000000";
+    const cleanPreApprovalComment = {
+      id: 501,
+      body: [
+        "### Gate review: `pre_approval_gate`",
+        "",
+        `**Reviewed head SHA:** \`${headSha}\``,
+        "**Verdict:** clean",
+        "**Execution mode:** inline_single_agent",
+        "",
+        "**Findings summary:** no issues found",
+        "",
+        "**Next action:** await final human approval",
+      ].join("\n"),
+      html_url: "https://github.com/owner/repo/pull/17#issuecomment-501",
+      updated_at: "2026-05-30T17:00:00Z",
+    };
+    const copilotReviewOnHead = {
+      id: 1,
+      author: { login: "copilot-pull-request-reviewer" },
+      state: "COMMENTED",
+      submittedAt: "2026-05-30T16:00:00Z",
+      commit: { oid: headSha },
+    };
+    const prFacts = (isDraft) => JSON.stringify({
+      number: 17,
+      state: "OPEN",
+      isDraft,
+      headRefOid: headSha,
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+      body: DEFAULT_TEST_PR_BODY,
+      title: "Test PR",
+      closingIssuesReferences: [],
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      reviews: [copilotReviewOnHead],
+    }) + "\n";
+
+    const { env, ghLogPath } = await writeGhStubHelper(tempDir, [
+      // --- coordination pass 1 (isDraft: false -> reconcile) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup,files"], stdout: prFacts(false) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: JSON.stringify({ headRefOid: headSha }) + "\n" },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"], stdout: "src/index.ts\n" },
+      // --- resolve PR node id + convert to draft (the self-heal transition) ---
+      { assertArgs: ["api", "graphql", "name=repo", "number=17"], stdout: '{"data":{"repository":{"pullRequest":{"id":"PR_node","isDraft":false}}}}\n' },
+      { assertArgs: ["api", "graphql", "pullRequestId=PR_node"], stdout: '{"data":{"convertPullRequestToDraft":{"pullRequest":{"id":"PR_node","isDraft":true}}}}\n' },
+      // --- coordination pass 2 (isDraft: true -> posts normally) ---
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup,files"], stdout: prFacts(true) },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql", "pr=17"], stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n' },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: JSON.stringify({ headRefOid: headSha }) + "\n" },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify([[cleanPreApprovalComment]]) + "\n" },
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "files", "--jq", ".files[].path"], stdout: "src/index.ts\n" },
+      // --- post the draft_gate verdict + post-creation verify + restore ready ---
+      { assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"], stdout: '{"id":900,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-900"}\n' },
+      { assertArgs: ["api", "repos/owner/repo/issues/comments/900"], stdout: '{"id":900}\n' },
+      { assertArgs: ["pr", "ready", "17", "--repo", "owner/repo"], stdout: "{}\n" },
+    ], { matchMode: "claims", logCalls: true });
+    // A real (non-empty) run id — the production default — activates the
+    // post-creation verifyComment call above; it is orthogonal to the deadlock
+    // but matches the reported repro shape exactly.
+    env.DEVLOOPS_RUN_ID = "test-run-1455-real";
+
+    const result = await runNodeHelper(scriptPath, [
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", headSha,
+      "--verdict", "clean",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--execution-mode", "inline_single_agent",
+      "--inline-reason", "single-agent inline review (test)",
+    ], { env, cwd: tempDir });
+
+    // Pre-fix this exits 13 with "Detected unsettled top-level await" on stderr
+    // and empty stdout (no comment posted). Fixed: exits 0 with the created
+    // comment in the JSON envelope.
+    assert.equal(result.code, 0, `expected exit 0, got ${result.code}. stderr: ${result.stderr}`);
+    assert.doesNotMatch(result.stderr, /unsettled top-level await/i);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.action, "created");
+    assert.equal(payload.gate, "draft_gate");
+    assert.equal(payload.draftTransition, true);
+    assert.equal(payload.commentId, 900);
+
+    const ghLog = await readFile(ghLogPath, "utf8");
+    assert.ok(/convertPullRequestToDraft/.test(ghLog), "expected a convertPullRequestToDraft mutation");
+    assert.ok(/\["pr","ready","17"/.test(ghLog.replace(/\s/g, "")), "expected a `pr ready` call to restore the ready state");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict already-satisfied no-op sources executionMode from the gate marker (#891 review)", async () => {
   // The already-satisfied no-op must source executionMode from the gate MARKER
   // summary (which carries executionMode), not the strict COMMENT summary (which


### PR DESCRIPTION
`dev-loops gate upsert-verdict --gate draft_gate` on a ready PR with no prior clean draft-gate evidence crashed with exit 13 ("Detected unsettled top-level await at … `await main()`") and never posted the comment, leaving the PR without draft-gate evidence. `pre_approval_gate` on the same PR/head worked.

Root cause: the RECONCILE_DRAFT_GATE self-heal path dynamically `import()`ed `reconcile-draft-gate.mjs`, which itself statically imports `upsert-checkpoint-verdict.mjs`. When the latter runs as the CLI entry point — still suspended on its own top-level `await main()` — that circular reference deadlocks Node's ESM linker: the `import()` promise never settles. Reproduced exactly (same message, exit 13, no comment) with a real CLI subprocess against a controlled `gh` stub routing to RECONCILE_DRAFT_GATE.

Fix: `convertPrToDraft`/`markPrReady` move to a new caller-independent `scripts/github/_draft-transition.mjs` (depends only on the shared CLI helper modules, on neither caller); both callers import it statically, eliminating the dynamic-import workaround and the cycle. The regression test spawns the real CLI on the repro shape (no prior marker, current head, `inline_single_agent`) and fails with exit 13 on the pre-fix code (verified by temporary revert).

No other unsettled-await path was found on this branch; remaining error paths throw/reject cleanly under existing tests. The coordination evaluator was not touched (field consistency is PR 1490 / issue #1472).

## Validation

- `upsert-checkpoint-verdict` suite 88/88 (incl. the new subprocess regression); `reconcile-draft-gate` 15 pass / 2 pre-existing skips.
- Full verify: 0 failures.

Closes #1455

