### PR TITLE
fix(gate): drop the repo-local draft_gate override that blocked on worth-fixing-now

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -43,8 +43,12 @@ gates:
     # rounds on one PR (72 reviewer dispatches), must-fix per round ran
     # 1,1,7,0,1,1,3,0 while worth-fixing-now ran 6,11,17,14,16,9,12,7.
     #
-    # worth-fixing-now findings are still recorded in the ledger and the
-    # findings comment; they just stop blocking the draft-to-ready transition.
+    # worth-fixing-now findings still go through the normal fan-in flow
+    # (ledger + findings comment) as long as that flow is followed; this key
+    # does not itself force a count or a ledger entry for worth-fixing-now
+    # (upsert-checkpoint-verdict only requires explicit counts for the
+    # severities listed here). They just stop blocking the draft-to-ready
+    # transition.
     # preApproval blocks on both, but it re-reviews through its own, mostly
     # disjoint angle pool (draft and preApproval share only contradiction-lens)
     # and does not carry a specific unblocked draft-gate finding forward — the

--- a/.devloops
+++ b/.devloops
@@ -36,9 +36,23 @@ gates:
       - name: renderer-security
         enabled: false
     requireCi: true
+    # Draft gate blocks on must-fix only. With worth-fixing-now also blocking,
+    # this gate did not converge on a non-trivial change: correctness settled
+    # while worth-fixing-now renewed itself every round, because each fix round
+    # creates fresh surface for the next round to review. Measured over eight
+    # rounds on one PR (72 reviewer dispatches), must-fix per round ran
+    # 1,1,7,0,1,3,3,0 while worth-fixing-now ran 6,11,17,14,16,9,12,7.
+    #
+    # worth-fixing-now findings are still recorded in the ledger and the
+    # findings comment; they just stop blocking the draft-to-ready transition.
+    # preApproval below still blocks on both — that is the last bar before
+    # merge, and a finding that survives the draft gate is caught there.
+    #
+    # Interim: the better shape is the full severity set with a round cap, so
+    # the first rounds still block and only a demonstrated plateau softens.
+    # Revisit this once that lands.
     blockCleanOnFindingSeverities:
       - must-fix
-      - worth-fixing-now
   preApproval:
     dynamic:
       subtractive: true

--- a/.devloops
+++ b/.devloops
@@ -41,12 +41,19 @@ gates:
     # while worth-fixing-now renewed itself every round, because each fix round
     # creates fresh surface for the next round to review. Measured over eight
     # rounds on one PR (72 reviewer dispatches), must-fix per round ran
-    # 1,1,7,0,1,3,3,0 while worth-fixing-now ran 6,11,17,14,16,9,12,7.
+    # 1,1,7,0,1,1,3,0 while worth-fixing-now ran 6,11,17,14,16,9,12,7.
     #
     # worth-fixing-now findings are still recorded in the ledger and the
     # findings comment; they just stop blocking the draft-to-ready transition.
-    # preApproval below still blocks on both — that is the last bar before
-    # merge, and a finding that survives the draft gate is caught there.
+    # preApproval blocks on both, but it re-reviews through its own, mostly
+    # disjoint angle pool (draft and preApproval share only contradiction-lens)
+    # and does not carry a specific unblocked draft-gate finding forward — the
+    # ledger records it "deferred" and nothing re-raises it. A worth-fixing-now
+    # finding from a draft-only angle is not "caught later"; it is recorded and
+    # left. This also affects light-mode dispatch: resolveGateDispatchMode
+    # escalates inline to full fan-out only on a blocking-severity inline
+    # finding, so a light-dispatched draft PR whose inline pass surfaces only
+    # worth-fixing-now now stays inline instead of escalating.
     #
     # Interim: the better shape is the full severity set with a round cap, so
     # the first rounds still block and only a demonstrated plateau softens.

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2588,12 +2588,13 @@ describe("role resolution", () => {
 // consumer .devloops must now explicitly disable a shipped angle it doesn't
 // want (enabled: false), or the angle silently merges back in by name. Pins
 // this repo's own shipped .devloops + extension-defaults.yaml against the
-// exact angle sets / mandatory sets / blockCleanOnFindingSeverities the
-// pre-redesign flat-key config resolved, so a future edit can't silently
-// regrow (or shrink) the effective gate-review surface.
+// exact angle sets / mandatory sets the pre-redesign flat-key config
+// resolved (blockCleanOnFindingSeverities is pinned to the current shipped
+// baseline instead — see CURRENT_BLOCK_CLEAN below), so a future edit can't
+// silently regrow (or shrink) the effective gate-review surface.
 // ============================================================================
 
-describe("shipped .devloops + extension-defaults.yaml resolve byte-identically to pre-#1404 (D3 regression guard)", () => {
+describe("shipped .devloops + extension-defaults.yaml resolve byte-identically to pre-#1404 for angle/mandatory sets, and to the current shipped baseline for blockCleanOnFindingSeverities (D3 regression guard)", () => {
   const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 
   // The exact sets origin/main (pre-#1404, flat mandatoryAngles/excludeAngles
@@ -2637,7 +2638,7 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
   const sortedSet = (arr) => [...new Set(arr)].sort();
 
   for (const gate of /** @type {const} */ (["draft", "preApproval", "spike"])) {
-    test(`${gate} gate: resolved angle set, mandatory set, and blockCleanOnFindingSeverities match pre-#1404`, async () => {
+    test(`${gate} gate: resolved angle set and mandatory set match pre-#1404; blockCleanOnFindingSeverities matches the current baseline`, async () => {
       const { loadDevLoopConfig, resolveGateAngles, resolveGateConfig } = await import("../src/config/config.mjs");
       const { config, errors } = await loadDevLoopConfig({ repoRoot: REPO_ROOT });
       assert.deepEqual(errors, []);

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2622,8 +2622,14 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
     preApproval: ["pr-checklist-matrix", "acceptance-criteria", "yagni", "contradiction-lens"],
     spike: [],
   };
-  const PRE_1404_BLOCK_CLEAN = {
-    draft: ["must-fix", "worth-fixing-now"],
+  // draft's blocking set is NOT the pre-#1404 baseline: it was deliberately
+  // narrowed to must-fix only (see .devloops gates.draft comment / issue
+  // #1527) because worth-fixing-now churns every draft-gate round on a
+  // non-trivial change and never converges. preApproval and spike are still
+  // pinned to their pre-#1404 values — only draft's entry here tracks the
+  // current shipped baseline rather than the pre-#1404 one.
+  const CURRENT_BLOCK_CLEAN = {
+    draft: ["must-fix"],
     preApproval: ["must-fix", "worth-fixing-now"],
     spike: ["must-fix"],
   };
@@ -2639,7 +2645,7 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
       const gateConfig = resolveGateConfig(config, gate);
       assert.deepEqual(sortedSet(angles), sortedSet(PRE_1404_ANGLE_SETS[gate]), `${gate} angle set`);
       assert.deepEqual(sortedSet(gateConfig.mandatoryAngles), sortedSet(PRE_1404_MANDATORY_SETS[gate]), `${gate} mandatory set`);
-      assert.deepEqual(sortedSet(gateConfig.blockCleanOnFindingSeverities), sortedSet(PRE_1404_BLOCK_CLEAN[gate]), `${gate} blockCleanOnFindingSeverities`);
+      assert.deepEqual(sortedSet(gateConfig.blockCleanOnFindingSeverities), sortedSet(CURRENT_BLOCK_CLEAN[gate]), `${gate} blockCleanOnFindingSeverities`);
     });
   }
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2638,7 +2638,7 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
   const sortedSet = (arr) => [...new Set(arr)].sort();
 
   for (const gate of /** @type {const} */ (["draft", "preApproval", "spike"])) {
-    test(`${gate} gate: resolved angle set and mandatory set match pre-#1404; blockCleanOnFindingSeverities matches the current baseline`, async () => {
+    test(`${gate} gate: resolved angle set and mandatory set match pre-#1404; blockCleanOnFindingSeverities matches the pinned baseline (see CURRENT_BLOCK_CLEAN comment above for which gate tracks which)`, async () => {
       const { loadDevLoopConfig, resolveGateAngles, resolveGateConfig } = await import("../src/config/config.mjs");
       const { config, errors } = await loadDevLoopConfig({ repoRoot: REPO_ROOT });
       assert.deepEqual(errors, []);
@@ -3205,6 +3205,34 @@ test("resolveGateDispatchMode: under threshold + only non-blocking finding → i
   });
   assert.equal(result.mode, "inline");
   assert.equal(result.reason, "under_threshold");
+});
+
+test("resolveGateDispatchMode: draft gate under threshold + worth-fixing-now-only inline finding → stays inline (must-fix-only blocking set)", () => {
+  const config = {
+    version: 1,
+    localImplementation: { lightMode: { enabled: true, maxFiles: 2, maxLines: 20 } },
+    gates: { draft: { blockCleanOnFindingSeverities: ["must-fix"] } },
+  };
+  const result = resolveGateDispatchMode(config, "draft", {
+    scope: { filesChanged: 1, linesChanged: 5 },
+    inlineFindingSeverities: ["worth-fixing-now"],
+  });
+  assert.equal(result.mode, "inline");
+  assert.equal(result.reason, "under_threshold");
+});
+
+test("resolveGateDispatchMode: draft gate under threshold + must-fix inline finding → escalated", () => {
+  const config = {
+    version: 1,
+    localImplementation: { lightMode: { enabled: true, maxFiles: 2, maxLines: 20 } },
+    gates: { draft: { blockCleanOnFindingSeverities: ["must-fix"] } },
+  };
+  const result = resolveGateDispatchMode(config, "draft", {
+    scope: { filesChanged: 1, linesChanged: 5 },
+    inlineFindingSeverities: ["must-fix"],
+  });
+  assert.equal(result.mode, "full_fanout");
+  assert.equal(result.reason, "escalated");
 });
 
 test("GATE_FULL_LABEL is gate:full", () => {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -712,7 +712,7 @@ test("upsert-checkpoint-verdict creates a new comment when no same-head marker e
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+      blockCleanOnFindingSeverities: ["must-fix"],
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1274,7 +1274,7 @@ test("upsert-checkpoint-verdict suppresses duplicate repost when the current sam
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+      blockCleanOnFindingSeverities: ["must-fix"],
     });
     // 8 gh calls: pr facts + requested_reviewers + review threads + headRefOid + issue comments + PR reviews + internal-only file check + light-mode facts (baseRefOid,labels) — the repo config enables lightMode, so an inline verdict triggers the #1174 light-fact fetch.
     assert.equal(result.ghCallCount(), 8);
@@ -1516,7 +1516,7 @@ test("upsert-checkpoint-verdict updates an incomplete same-head marker in place"
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-101",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+      blockCleanOnFindingSeverities: ["must-fix"],
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1609,7 +1609,7 @@ test("upsert-checkpoint-verdict updates the current same-head marker even when a
       warning: "A gate comment for \`draft_gate\` already exists on a different head SHA \`def5678000000000000000000000000000000000\` (comment 202). The old comment is stale for the current head.",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+      blockCleanOnFindingSeverities: ["must-fix"],
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1701,7 +1701,7 @@ test("upsert-checkpoint-verdict prefers the latest same-head marker when it diff
       commentUrl: "https://github.com/owner/repo/pull/17#issuecomment-202",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-      blockCleanOnFindingSeverities: ["must-fix", "worth-fixing-now"],
+      blockCleanOnFindingSeverities: ["must-fix"],
     });
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -1933,8 +1933,9 @@ test("upsert-checkpoint-verdict rejects clean verdict when unresolved blocking-s
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot set verdict "clean"/);
+    // draft_gate blocks on must-fix only (worth-fixing-now is recorded but
+    // non-blocking here); a must-fix count above zero is enough to reject.
     assert.match(payload.error, /must-fix/);
-    assert.match(payload.error, /worth-fixing-now/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -2028,7 +2029,9 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
       "--verdict", "clean",
       "--findings-summary", "all clear",
       "--next-action", "mark ready",
-      "--findings-severity-counts", '{"must-fix":0,"defer":0}',
+      // draft_gate blocks on must-fix only, so omitting must-fix (not
+      // worth-fixing-now) is what exercises "missing a blocking key" here.
+      "--findings-severity-counts", '{"worth-fixing-now":0,"defer":0}',
     ], { env });
 
     assert.equal(result.code, 1);
@@ -2036,7 +2039,7 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
     const payload = JSON.parse(result.stderr);
     assert.equal(payload.ok, false);
     assert.match(payload.error, /must include explicit counts for all configured blocking severities/);
-    assert.match(payload.error, /worth-fixing-now/);
+    assert.match(payload.error, /must-fix/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1934,8 +1934,9 @@ test("upsert-checkpoint-verdict rejects clean verdict when unresolved blocking-s
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot set verdict "clean"/);
     // draft_gate blocks on must-fix only (worth-fixing-now is recorded but
-    // non-blocking here); a must-fix count above zero is enough to reject.
-    assert.match(payload.error, /must-fix/);
+    // non-blocking here); assert the exact bracketed list so this fails if
+    // worth-fixing-now ever becomes blocking again for draft_gate.
+    assert.match(payload.error, /blocking severities \[must-fix\]\./);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -1963,7 +1964,7 @@ test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity f
       "--gate", "draft_gate",
       "--head-sha", "abc1234000000000000000000000000000000000",
       "--verdict", "clean",
-      "--findings-summary", "no issues found",
+      "--findings-summary", "0 must-fix; 1 worth-fixing-now recorded (non-blocking), 1 defer",
       "--next-action", "mark ready for review",
       // draft_gate blocks on must-fix only: a non-zero worth-fixing-now count
       // (like the non-zero defer count) must not block a clean verdict.

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -1965,7 +1965,9 @@ test("upsert-checkpoint-verdict allows clean verdict when no blocking-severity f
       "--verdict", "clean",
       "--findings-summary", "no issues found",
       "--next-action", "mark ready for review",
-      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":1}',
+      // draft_gate blocks on must-fix only: a non-zero worth-fixing-now count
+      // (like the non-zero defer count) must not block a clean verdict.
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":1,"defer":1}',
     ], { env });
 
     assert.equal(result.code, 0);
@@ -2005,8 +2007,12 @@ test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-c
     assert.equal(payload.ok, false);
     assert.match(payload.error, /Cannot set verdict "clean"/);
     assert.match(payload.error, /--findings-severity-counts is required/);
-    assert.match(payload.error, /must-fix/);
-    assert.match(payload.error, /worth-fixing-now/);
+    // The error text embeds a static example payload alongside the
+    // config-derived "(blocking: [...])" tail; assert the tail, which is
+    // the part that actually reflects draft_gate's configured blocking set
+    // (must-fix only — worth-fixing-now would match the example text
+    // regardless of what is configured).
+    assert.match(payload.error, /\(blocking: \[must-fix\]\)/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1527

## Summary

The draft gate blocked a `clean` verdict on both `must-fix` and `worth-fixing-now`, and on a non-trivial change that combination does not converge. Measured over eight draft-gate rounds on PR 1513, nine angles each, 72 reviewer dispatches:

| Round | must-fix | worth-fixing-now |
| --- | --- | --- |
| 1 | 1 | 6 |
| 2 | 1 | 11 |
| 3 | 7 | 17 |
| 4 | 0 | 14 |
| 5 | 1 | 16 |
| 6 | 1 | 9 |
| 7 | 3 | 12 |
| 8 | 0 | 7 |

Correctness settled — `must-fix` reached zero. The other column did not, because each fix round creates fresh surface for the next round to review: documentation that now lags the code, a test name that no longer matches its fixture, contract prose describing the previous revision. Every one of those findings was real; on the seventh round the fix pass rejected none of 27. They are simply not what the PR is for, and a fixed blocking set cannot express that difference.

## This aligns the repo with what it ships, rather than weakening a default

Worth stating plainly, because "remove a blocking severity" reads like a relaxation and this is not one.

`packages/core/src/config/extension-defaults.yaml` sets no `blockCleanOnFindingSeverities` for any gate, and `resolveGateConfig` falls back to `["must-fix"]` when the key is absent. A consumer repo with no override has therefore always blocked the draft gate on `must-fix` alone. This repo's own `.devloops` was the only place widening it to both severities — stricter than everything the project ships, and that extra strictness is what failed to converge.

Removing the override changes nothing for consumers.

## Scope and context

Boundary: one config delta and the tests that pinned it.

- `.devloops` — `gates.draft.blockCleanOnFindingSeverities` lists `must-fix` only, with the measured round data and the revisit note recorded inline so the setting does not read as an unexplained weakening.
- `packages/core/test/config.test.mjs` — the D3 regression guard's `PRE_1404_BLOCK_CLEAN` is renamed `CURRENT_BLOCK_CLEAN`, because the draft entry now tracks the current shipped baseline rather than the pre-#1404 one. `preApproval` and `spike` stay pinned to their pre-#1404 values. A drift guard that lies about which baseline it guards is worse than no guard, hence the rename rather than a quiet constant edit.
- `test/github/upsert-checkpoint-verdict.test.mjs` — eight assertions across nine tests that hardcoded the two-severity draft set, plus new coverage pinning the light-mode escalation consequence. Every failure traced to that single cause; none revealed behavior beyond the config delta. The `pre_approval_gate` assertions were left untouched and pass unmodified, which is the check that the other gate is genuinely unaffected.

Out of boundary: the pre-approval gate, the shipped consumer default, and `must-fix` anywhere.

## What this actually costs, corrected during review

An earlier revision of this description claimed an unblocked `worth-fixing-now` finding is "still caught before merge" at the pre-approval gate. **That was false and a reviewer caught it.** The two gates share exactly one angle out of eighteen (`contradiction-lens`), and an unblocked draft finding is stamped `deferred` in the disposition ledger with nothing re-raising it. A finding from any draft-only angle — `scope`, `coverage`, `determinism`, `input-validation`, `contract-surface`, `gate-evidence` — is recorded and left. It is not deferred to a later gate.

So the tradeoff is: those findings stay visible in the ledger and the findings comment, and nothing forces anyone to act on them. That is the actual cost, and it is accepted deliberately rather than argued away.

A second consequence, also undisclosed until review: `resolveGateDispatchMode` reads the same `blockCleanOnFindingSeverities` set to decide whether a light-dispatched PR escalates from inline review to a full fan-out. A light-dispatched draft PR whose inline pass surfaces only `worth-fixing-now` therefore now stays inline instead of escalating. Decoupling escalation from the blocking set would need its own config key, so it is documented here and in `.devloops` rather than redesigned in this change.

Both are reasons the round cap is the better long-term shape: it would soften only after a demonstrated plateau, leaving first-round findings and light-mode escalation untouched.

## Acceptance criteria

- [ ] `gates.draft.blockCleanOnFindingSeverities` lists `must-fix` only.
- [ ] `gates.preApproval.blockCleanOnFindingSeverities` is unchanged and still lists both.
- [ ] A draft gate with zero `must-fix` and non-zero `worth-fixing-now` records `clean`.
- [ ] A draft gate with any `must-fix` still refuses `clean`.
- [ ] The shipped default for consumer repos is unchanged, verified against `extension-defaults.yaml` and the `resolveGateConfig` fallback rather than asserted.
- [ ] The rationale recorded in `.devloops` states the real cost: an unblocked draft finding is recorded and left, not caught at a later gate.
- [ ] The light-mode escalation consequence is disclosed where a reader of the config will find it, and pinned by a test rather than only described.
- [ ] The `.devloops` draft entry is now byte-identical to the built-in default rather than a per-layer delta; disclosed because the file otherwise records only deltas.

## Definition of done

- [ ] `npm run verify` green — all eight suites.
- [ ] The reasoning is recorded where a reader of the config finds it, not only in this PR.

## Non-goals

- Changing the pre-approval gate.
- Changing the shipped default for consumer repos.
- Softening `must-fix` anywhere.
- Implementing the round cap. That is the better shape — full severity set for the first N rounds, softening only on a demonstrated plateau — and it is tracked separately. This change exists because that mechanism does not exist yet and an operator has no way to apply a cap by hand: `upsert-checkpoint-verdict` reads the configured blocking set, no CLI flag dispositions a finding, and hand-editing the ledger is barred by the fan-in contract.

## Validation

```
npm run verify
```

Green, run twice.


