### PR TITLE
fix(queue): default runChild in resolve-active-board-item's CLI entry points

### DIFF
--- a/scripts/projects/resolve-active-board-item.mjs
+++ b/scripts/projects/resolve-active-board-item.mjs
@@ -46,6 +46,7 @@
 // Downstream (the dev-loop skill) resolves authoritative state from this number;
 // this helper deliberately makes no further decisions.
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { main as listQueueItems } from "./list-queue-items.mjs";
@@ -433,7 +434,7 @@ async function resolveNextUpHead(args, { env, runChild, cwd = process.cwd() } = 
   };
 }
 
-async function main(args, { env = process.env, runChild, cwd = process.cwd() } = {}) {
+async function main(args, { env = process.env, runChild = defaultRunChild, cwd = process.cwd() } = {}) {
   // Resolve the in_progress column name through the SAME statusColumns mapping
   // board-sync uses (#1098, #1143): a repo that renamed In Progress gets its
   // configured column queried, not the literal default. Fail CLOSED on a
@@ -466,7 +467,7 @@ function classifyExitCode(err) {
   return 2;
 }
 
-async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, runChild, cwd = process.cwd() } = {}) {
+async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, env = process.env, runChild = defaultRunChild, cwd = process.cwd() } = {}) {
   let args;
   try {
     args = parseCliArgs(argv);

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -1,6 +1,6 @@
 import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import { collapseToTarget, main, runCli, attemptClaimAndArbitrate } from "../../scripts/projects/resolve-active-board-item.mjs";
@@ -743,6 +743,55 @@ describe("board resolution from .devloops without --project (#1459)", () => {
       const { code, out } = await runCliCaptured(["--repo", "o/r"], child, cwd);
       assert.equal(code, 0);
       assert.deepEqual(JSON.parse(out), { ok: true, target: { kind: "issue", number: 5 }, source: "in-progress" });
+    });
+  });
+
+  it("a direct-CLI-shaped run without an injected runChild uses the shared default instead of crashing (#1545)", async () => {
+    // Regression: runCli/main declared runChild with no default and the module
+    // never imported one, so a direct CLI run crashed with "runChild is not a
+    // function" as soon as the Next Up pickup path needed a gh read (the
+    // in-progress short-circuit had masked it). Drive runCli with NO runChild
+    // injection and a PATH gh shim emulating an empty In Progress column plus
+    // one unassigned Next Up item, so the run must traverse the ownership path
+    // through the DEFAULT runChild to succeed.
+    await withTempCwd("queue:\n  board:\n    number: 7\n", async (cwd) => {
+      const binDir = nodePath.join(cwd, "stub-bin");
+      mkdirSync(binDir, { recursive: true });
+      const shim = `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+const q = argv.find((a) => a.startsWith("query=")) ?? "";
+const data = (d) => { process.stdout.write(JSON.stringify({ data: d })); process.exit(0); };
+if (q.includes("projectsV2(first")) data({ user: { projectsV2: { nodes: [{ id: "P_1", number: 7, title: "Board" }], pageInfo: { hasNextPage: false, endCursor: null } } } });
+if (q.includes("user(login")) data({ user: { id: "U_1" } });
+if (q.includes("fields(first")) data({ node: { fields: { nodes: [{ name: "Status", options: [{ id: "O_0", name: "Backlog" }, { id: "O_1", name: "Next Up" }, { id: "O_2", name: "In Progress" }, { id: "O_3", name: "Done" }] }], pageInfo: { hasNextPage: false, endCursor: null } } } });
+if (argv[0] === "api" && argv[1] === "user") { process.stdout.write(JSON.stringify({ login: "shim-viewer" })); process.exit(0); }
+if ((argv[0] === "issue" || argv[0] === "pr") && argv[1] === "view") { process.stdout.write(JSON.stringify({ assignees: [] })); process.exit(0); }
+if ((argv[0] === "issue" || argv[0] === "pr") && argv[1] === "edit") { process.stdout.write("{}"); process.exit(0); }
+data({ node: { items: { nodes: [{ id: "I_NU_9", fieldValues: { nodes: [{ field: { name: "Status" }, name: "Next Up" }] }, content: { __typename: "Issue", number: 9, title: "Head", url: "https://example.test", id: "C_9" } }], pageInfo: { hasNextPage: false, endCursor: null } } } });
+`;
+      const ghPath = nodePath.join(binDir, "gh");
+      writeFileSync(ghPath, shim);
+      chmodSync(ghPath, 0o755);
+      const prevPath = process.env.PATH;
+      process.env.PATH = `${binDir}:${prevPath}`;
+      try {
+        let out = "";
+        let err = "";
+        const prev = process.exitCode;
+        process.exitCode = undefined;
+        await runCli(["--repo", "o/r"], {
+          stdout: { write: (s2) => { out += s2; } },
+          stderr: { write: (s2) => { err += s2; } },
+          cwd,
+        });
+        const code = process.exitCode;
+        process.exitCode = prev;
+        assert.ok(!String(err).includes("runChild is not a function"), `must not crash on the missing default: ${err}`);
+        assert.equal(code, 0, `expected a resolved head, got exit ${code}: ${err || out}`);
+        assert.deepEqual(JSON.parse(out), { ok: true, target: { kind: "issue", number: 9 }, source: "next-up" });
+      } finally {
+        process.env.PATH = prevPath;
+      }
     });
   });
 

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -767,7 +767,8 @@ if (q.includes("fields(first")) data({ node: { fields: { nodes: [{ name: "Status
 if (argv[0] === "api" && argv[1] === "user") { process.stdout.write(JSON.stringify({ login: "shim-viewer" })); process.exit(0); }
 if ((argv[0] === "issue" || argv[0] === "pr") && argv[1] === "view") { process.stdout.write(JSON.stringify({ assignees: [] })); process.exit(0); }
 if ((argv[0] === "issue" || argv[0] === "pr") && argv[1] === "edit") { process.stdout.write("{}"); process.exit(0); }
-data({ node: { items: { nodes: [{ id: "I_NU_9", fieldValues: { nodes: [{ field: { name: "Status" }, name: "Next Up" }] }, content: { __typename: "Issue", number: 9, title: "Head", url: "https://example.test", id: "C_9" } }], pageInfo: { hasNextPage: false, endCursor: null } } } });
+if (q.includes("items(first") || q.includes("fieldValues")) data({ node: { items: { nodes: [{ id: "I_NU_9", fieldValues: { nodes: [{ field: { name: "Status" }, name: "Next Up" }] }, content: { __typename: "Issue", number: 9, title: "Head", url: "https://example.test", id: "C_9" } }], pageInfo: { hasNextPage: false, endCursor: null } } } });
+process.stderr.write("shim: unexpected gh argv: " + JSON.stringify(argv)); process.exit(1);
 `;
       const ghPath = nodePath.join(binDir, "gh");
       writeFileSync(ghPath, shim);

--- a/test/projects/resolve-active-board-item.test.mjs
+++ b/test/projects/resolve-active-board-item.test.mjs
@@ -757,7 +757,7 @@ describe("board resolution from .devloops without --project (#1459)", () => {
     await withTempCwd("queue:\n  board:\n    number: 7\n", async (cwd) => {
       const binDir = nodePath.join(cwd, "stub-bin");
       mkdirSync(binDir, { recursive: true });
-      const shim = `#!/usr/bin/env node
+      const shim = `#!${process.execPath}
 const argv = process.argv.slice(2);
 const q = argv.find((a) => a.startsWith("query=")) ?? "";
 const data = (d) => { process.stdout.write(JSON.stringify({ data: d })); process.exit(0); };
@@ -772,26 +772,28 @@ data({ node: { items: { nodes: [{ id: "I_NU_9", fieldValues: { nodes: [{ field: 
       const ghPath = nodePath.join(binDir, "gh");
       writeFileSync(ghPath, shim);
       chmodSync(ghPath, 0o755);
-      const prevPath = process.env.PATH;
-      process.env.PATH = `${binDir}:${prevPath}`;
+      // Inject only env (never runChild): the default runChild passes env to
+      // spawn, so a PATH scoped to the shim reaches the child without mutating
+      // this process's own environment.
+      const shimEnv = { ...process.env, PATH: `${binDir}${nodePath.delimiter}${process.env.PATH ?? ""}` };
+      let out = "";
+      let err = "";
+      const prev = process.exitCode;
+      process.exitCode = undefined;
       try {
-        let out = "";
-        let err = "";
-        const prev = process.exitCode;
-        process.exitCode = undefined;
         await runCli(["--repo", "o/r"], {
           stdout: { write: (s2) => { out += s2; } },
           stderr: { write: (s2) => { err += s2; } },
+          env: shimEnv,
           cwd,
         });
-        const code = process.exitCode;
-        process.exitCode = prev;
-        assert.ok(!String(err).includes("runChild is not a function"), `must not crash on the missing default: ${err}`);
-        assert.equal(code, 0, `expected a resolved head, got exit ${code}: ${err || out}`);
-        assert.deepEqual(JSON.parse(out), { ok: true, target: { kind: "issue", number: 9 }, source: "next-up" });
       } finally {
-        process.env.PATH = prevPath;
+        var code = process.exitCode;
+        process.exitCode = prev;
       }
+      assert.ok(!String(err).includes("runChild is not a function"), `must not crash on the missing default: ${err}`);
+      assert.equal(code, 0, `expected a resolved head, got exit ${code}: ${err || out}`);
+      assert.deepEqual(JSON.parse(out), { ok: true, target: { kind: "issue", number: 9 }, source: "next-up" });
     });
   });
 


### PR DESCRIPTION
Closes #1545

## Summary

`resolve-active-board-item.mjs` crashed with `runChild is not a function` on every direct CLI run that reached the Next Up pickup path: `runCli` and `main` declared `runChild` in their deps objects with no default and the module never imported one. The In Progress short-circuit masked the gap — the crash only fired once that column emptied and the resolver had to traverse the ownership path (viewer login, assignee reads, claim edits). That killed bare `/loop-continue` pickup.

## Scope and context

Boundary: the resolver's two CLI entry points and their regression coverage.

- `scripts/projects/resolve-active-board-item.mjs` — import the shared `runChild` from `_cli-primitives.mjs` and default it at `main` and `runCli`; injected deps still win, so every existing test keeps stubbing it.
- `test/projects/resolve-active-board-item.test.mjs` — a regression test drives `runCli` with NO `runChild` injection through a PATH `gh` shim that emulates the board, viewer-login, and assignee reads, so the run must traverse the ownership path through the default. It fails on the pre-fix crash (mutation-checked).

Out of boundary: pickup/ownership semantics are unchanged.

## Acceptance criteria

- [x] A direct CLI run with zero In Progress items and a non-empty Next Up resolves the head (ownership claim path included) instead of crashing.
- [x] `runChild` defaults to the shared `_cli-primitives` implementation at both `main` and `runCli`, and injected deps still win.

## Definition of done

- [x] A regression test drives `runCli` without injecting `runChild` past the point that crashed.
- [x] Full verify green.

## AC/DoD/Non-goals matrix

| Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
|---|---|---|---|---|
| Direct CLI run resolves the Next Up head through the ownership path | AC | Met | Regression test with PATH gh shim; live run resolved issue 1451 | |
| Default is the shared implementation; injected deps win | AC | Met | All 43 pre-existing stub-injecting tests unchanged and green | |
| Regression test past the crash point without injection | DoD | Met | Test fails 1/1 when the defaults are removed (mutation-checked) | |
| Full verify green | DoD | Met | npm run verify all suites | |
| No pickup/ownership semantic changes | Non-goal | Met | Only entry-point defaults + test added | |

## Non-goals

- Changing the pickup/ownership semantics.

## Open questions and risks

- None. The change is two parameter defaults matching the sibling scripts' established pattern; the only risk considered (a test silently gaining a real gh spawn) is closed by the fact that every pre-existing test injects a stub and the new test scopes gh through an env-injected PATH shim.

## Validation

```
node --test test/projects/resolve-active-board-item.test.mjs
npm run verify
```

