### PR TITLE
feat(gate): generalize the sanctioned same-head sentinel retry (--same-head-retry)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -393,8 +393,8 @@ manual chore:
 - **Within one round the contamination guard is preserved:** a same-scope + same-head
   re-entry still fails closed (`fresh: false`, exit 1) — that is genuine main-agent /
   cross-session state bleed. (The one sanctioned same-head exception is the opt-in
-  `--pr-body-fix-retry` overwrite documented below, gated on a matching prefix hash; it is
-  not state bleed.)
+  `--same-head-retry` overwrite documented below — `--pr-body-fix-retry` is its deprecated
+  alias — gated on a matching prefix hash; it is not state bleed.)
 - The orchestrator **MUST NOT** need to manually clear sentinels between rounds, and
   **MUST NOT** clear the sentinels of carried-forward clean angles (Phase 5's re-fan
   re-invokes the surface-touched angles, every angle that produced `findings_present`, and
@@ -403,26 +403,38 @@ manual chore:
 - Stale pre-round sentinels (the old scope-only name) never collide with a head-keyed round
   and are simply ignored.
 
-**Sanctioned same-head PR-body-fix retry.** A PR-body/description-only fix (e.g. adding a
-missing acceptance-criteria matrix to satisfy `pr-checklist-matrix`) does not change the head
-SHA, so it earns no new round key on its own — a plain re-invocation of the fixed angle
-collides with its own pass-1 sentinel and fails closed exactly like genuine contamination
-would. `verify-fresh-review-context.mjs --pr-body-fix-retry` is the sanctioned escape hatch
-for exactly this case: it overwrites the existing sentinel for that scope+round, but **only**
-when the given `--prefix-hash`/`--prefix-file` matches the existing sentinel's recorded prefix
-hash **exactly**. An identical hash proves the seeded briefing bytes were NOT rebuilt, so the
-byte-identity invariant (`GATE-EXEC-BRIEFING-PREFIX`) stays fully intact for every other
-sentinel of the same round — the previously-clean angles' sentinels are left untouched and
-still verify against the same on-disk record, so `verify-briefing-prefixes.mjs` needs no full
-re-fan of clean angles and no manual sentinel deletion. A hash mismatch (the context-builder
-genuinely rebuilt the briefing) or an existing sentinel recording no prefix hash still fails
-closed — this flag is a narrow, auditable exception for one documented scenario, never a
-general bypass of the contamination guard. Practically: re-brief the retried reviewer with the
-UNCHANGED, byte-identical invariant prefix (do not re-run `write-gate-context.mjs`) plus an
-angle-specific instruction to fetch the CURRENT PR body/description live (e.g. `gh pr view`)
-rather than trust the prefix's now-stale inlined copy, since the point of the retry is to
-re-check the just-edited description. See `verify-fresh-review-context.mjs --help` for the
-flag's exact semantics and exit codes.
+**Sanctioned same-head retry.** Some legitimate re-runs never earn a new round key, so a
+plain re-invocation of the same angle collides with its own pass-1 sentinel and fails closed
+exactly like genuine contamination would. The sanctioned scenarios are:
+
+- **PR-body/description-only fix** (e.g. adding a missing acceptance-criteria matrix to
+  satisfy `pr-checklist-matrix`): a body edit never changes the head SHA, so the round key
+  stays the same.
+- **Interrupted reviewer**: a reviewer killed or interrupted AFTER running the sentinel
+  check but BEFORE writing its findings artifact burned the (scope, round) sentinel while
+  producing nothing; the re-dispatched reviewer for the same scope+head is a retry, not
+  state bleed.
+- **Harness crash** mid-round, same shape as the interrupted reviewer.
+
+`verify-fresh-review-context.mjs --same-head-retry` (deprecated alias: `--pr-body-fix-retry`)
+is the sanctioned escape hatch for all of them: it overwrites the existing sentinel for that
+scope+round, but **only** when the given `--prefix-hash`/`--prefix-file` matches the existing
+sentinel's recorded prefix hash **exactly**. An identical hash proves the seeded briefing
+bytes were NOT rebuilt, so the byte-identity invariant (`GATE-EXEC-BRIEFING-PREFIX`) stays
+fully intact for every other sentinel of the same round — the previously-clean angles'
+sentinels are left untouched and still verify against the same on-disk record, so
+`verify-briefing-prefixes.mjs` needs no full re-fan of clean angles and no manual sentinel
+deletion. The retry's REASON never enters the decision; the hash equality is the entire
+safety argument, which is why one mechanical guard covers every scenario above. A hash
+mismatch (the context-builder genuinely rebuilt the briefing) or an existing sentinel
+recording no prefix hash still fails closed — this flag is a narrow, auditable exception,
+never a general bypass of the contamination guard. Practically: re-brief the retried
+reviewer with the UNCHANGED, byte-identical invariant prefix (do not re-run
+`write-gate-context.mjs`); for the PR-body-fix case additionally instruct the reviewer to
+fetch the CURRENT PR body/description live (e.g. `gh pr view`) rather than trust the
+prefix's now-stale inlined copy, since the point of that retry is to re-check the
+just-edited description. See `verify-fresh-review-context.mjs --help` for the flag's exact
+semantics and exit codes.
 
 ### Phase 3 — Consolidation: fan-in synthesis and disposition ledger
 

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -60,10 +60,12 @@ Options:
                   hashes its raw bytes (sha256) and records the digest same
                   as --prefix-hash. Fails closed (exit 1) if the file is
                   missing. Mutually exclusive with --prefix-hash.
-  --pr-body-fix-retry  Sanctioned same-head retry for a PR-body/description-only
-                  fix (e.g. satisfying pr-checklist-matrix) that does NOT
-                  change the head SHA and therefore does not earn a fresh
-                  round key on its own. Requires --prefix-hash/--prefix-file.
+  --same-head-retry  Sanctioned same-head retry for any scenario that re-runs a
+                  reviewer for the SAME scope+head without a rebuilt briefing:
+                  a PR-body/description-only fix (which never changes the head
+                  SHA), a reviewer interrupted or killed after sentinel
+                  creation but before writing its findings artifact, or a
+                  harness crash. Requires --prefix-hash/--prefix-file.
                   When a sentinel already exists for this exact scope+round
                   (the normal contamination trip), this flag permits
                   overwriting it ONLY when the given prefix hash matches the
@@ -71,32 +73,36 @@ Options:
                   the seeded briefing bytes (GATE-EXEC-BRIEFING-PREFIX) were
                   NOT rebuilt, so the round's byte-identity invariant is
                   fully preserved and other clean angles' sentinels from the
-                  same round stay valid (no full re-fan required). A hash
-                  MISMATCH (the context-builder WAS re-run) or an existing
-                  sentinel with no recorded prefix hash still fails closed —
-                  this is a narrow escape hatch for one documented scenario,
-                  never a general bypass of the contamination guard. See
-                  "Sentinel lifecycle" in skills/docs/gate-review-sub-loop-contract.md.
+                  same round stay valid (no full re-fan required). The reason
+                  for the retry never matters; the hash equality is the whole
+                  safety argument. A hash MISMATCH (the context-builder WAS
+                  re-run) or an existing sentinel with no recorded prefix hash
+                  still fails closed — never a general bypass of the
+                  contamination guard. See "Sentinel lifecycle" in
+                  skills/docs/gate-review-sub-loop-contract.md.
+  --pr-body-fix-retry  Deprecated alias for --same-head-retry (identical
+                  semantics; kept for existing callers).
 Output (stdout, JSON):
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "<headSha|null>" }
   { "ok": true, "fresh": true, "sentinelCreated": true, "round": "...", "gateContextPath": "...", "gateContextPresent": true }
-  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "...", "prBodyFixRetry": true, "prefixHash": "..." }
+  { "ok": true, "fresh": true, "sentinelCreated": true, "round": "...", "sameHeadRetry": true, "prBodyFixRetry": true, "prefixHash": "..." }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "reason": "..." }
   { "ok": true, "fresh": false, "sentinelCreated": false, "round": "...", "gateContextPath": "...", "gateContextPresent": false, "reason": "..." }
   On error (stderr, JSON):
   { "ok": false, "error": "...", "usage": "..." }
 ${JQ_OUTPUT_USAGE}
 Exit codes:
-  0  Clean (first run), OR a sanctioned --pr-body-fix-retry whose prefix hash
-     matches the existing sentinel's recorded hash
+  0  Clean (first run), OR a sanctioned --same-head-retry (or its alias
+     --pr-body-fix-retry) whose prefix hash matches the existing sentinel's
+     recorded hash
   1  Refuse to review: contaminated (prior session detected), OR (with
      --context-path) the seeded gate-context artifact is missing or resolves
      outside the reviewer's working directory, OR (with --prefix-file) the
-     prefix file is missing, OR (with --pr-body-fix-retry) the existing
+     prefix file is missing, OR (with --same-head-retry) the existing
      sentinel's recorded prefix hash does not match the given one (or records
      none at all)
   2  Usage or internal error, invalid --jq filter, invalid/conflicting
-     --prefix-hash/--prefix-file, or --pr-body-fix-retry given without
+     --prefix-hash/--prefix-file, or --same-head-retry given without
      --prefix-hash/--prefix-file`.trim();
 const VALID_SCOPE_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
@@ -233,10 +239,10 @@ async function main(argv = process.argv.slice(2)) {
     )}\n`);
     return 2;
   }
-  const prBodyFixRetry = argv.includes("--pr-body-fix-retry");
-  if (prBodyFixRetry && prefixHashArg === null && prefixFileArg === null) {
+  const sameHeadRetry = argv.includes("--same-head-retry") || argv.includes("--pr-body-fix-retry");
+  if (sameHeadRetry && prefixHashArg === null && prefixFileArg === null) {
     process.stderr.write(`${formatCliError(
-      parseError("--pr-body-fix-retry requires --prefix-hash or --prefix-file (the sanctioned retry proves byte-identity by comparing prefix hashes, so a hash to compare is mandatory).")
+      parseError("--same-head-retry (alias --pr-body-fix-retry) requires --prefix-hash or --prefix-file (the sanctioned retry proves byte-identity by comparing prefix hashes, so a hash to compare is mandatory).")
     )}\n`);
     return 2;
   }
@@ -322,17 +328,21 @@ async function main(argv = process.argv.slice(2)) {
   }
   const existing = await checkSentinelExists(scope, round);
   if (existing.exists) {
-    // Sanctioned same-head PR-body-fix retry (skills/docs/gate-review-sub-loop-contract.md,
-    // "Sentinel lifecycle"): a PR-body/description-only fix does not earn a new
-    // round key (the round is keyed by head SHA, which a body edit never changes),
-    // so a same-scope + same-head re-entry would otherwise always trip the
+    // Sanctioned same-head retry (skills/docs/gate-review-sub-loop-contract.md,
+    // "Sentinel lifecycle"): some legitimate re-runs never earn a new round key
+    // — a PR-body/description-only fix (the round is keyed by head SHA, which a
+    // body edit never changes), a reviewer interrupted after sentinel creation
+    // but before writing its findings artifact, or a harness crash. In all of
+    // them a same-scope + same-head re-entry would otherwise trip the
     // contamination guard. Permit ONE narrow exception: overwrite the existing
     // sentinel ONLY when the given prefix hash matches its recorded one exactly —
     // proof the seeded briefing (GATE-EXEC-BRIEFING-PREFIX) was NOT rebuilt, so
     // the round's byte-identity invariant stays fully intact for every other
-    // sentinel of this round (no full re-fan needed). A mismatch (or an existing
-    // sentinel recording no prefix hash) still fails closed — never grandfathered.
-    if (prBodyFixRetry) {
+    // sentinel of this round (no full re-fan needed). The retry's REASON never
+    // enters the decision; the hash equality is the whole safety argument. A
+    // mismatch (or an existing sentinel recording no prefix hash) still fails
+    // closed — never grandfathered.
+    if (sameHeadRetry) {
       const existingPrefixHash = await readSentinelPrefixHash(existing.path);
       if (existingPrefixHash !== null && existingPrefixHash === prefixHash) {
         const sentinel = {
@@ -341,7 +351,7 @@ async function main(argv = process.argv.slice(2)) {
           ...(scope ? { scope } : {}),
           ...(round ? { round } : {}),
           prefixHash,
-          prBodyFixRetry: true,
+          sameHeadRetry: true,
         };
         try {
           await writeFile(existing.path, JSON.stringify(sentinel, null, 2) + "\n", "utf8");
@@ -353,6 +363,8 @@ async function main(argv = process.argv.slice(2)) {
           ok: true,
           fresh: true,
           sentinelCreated: true,
+          sameHeadRetry: true,
+          // Deprecated mirror of sameHeadRetry, kept while callers migrate.
           prBodyFixRetry: true,
           round: round ?? null,
           ...(contextPathArg !== null ? { gateContextPath: contextPathArg, gateContextPresent: true } : {}),
@@ -364,7 +376,7 @@ async function main(argv = process.argv.slice(2)) {
         fresh: false,
         sentinelCreated: false,
         round: round ?? null,
-        reason: `--pr-body-fix-retry refused: the existing sentinel${existingPrefixHash === null ? " recorded no prefix hash" : " recorded a DIFFERENT prefix hash"} — this sanctioned path only covers a same-head retry where the seeded briefing bytes are UNCHANGED (proven by an identical prefix hash). ${existingPrefixHash === null ? "A hashless sentinel is never grandfathered in." : "A changed hash means the context-builder WAS re-run; use the standard head-bump retry instead."}`,
+        reason: `--same-head-retry refused: the existing sentinel${existingPrefixHash === null ? " recorded no prefix hash" : " recorded a DIFFERENT prefix hash"} — this sanctioned path only covers a same-head retry where the seeded briefing bytes are UNCHANGED (proven by an identical prefix hash). ${existingPrefixHash === null ? "A hashless sentinel is never grandfathered in." : "A changed hash means the context-builder WAS re-run; use the standard head-bump retry instead."}`,
       }, false);
     }
     return finish({

--- a/scripts/github/verify-fresh-review-context.mjs
+++ b/scripts/github/verify-fresh-review-context.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { buildParseError, isDirectCliRun, formatCliError } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 const USAGE = `Usage: verify-fresh-review-context.mjs [--help] [--scope <name>] [--context-path <path>]
-       [--prefix-hash <sha256>|--prefix-file <path>] [--pr-body-fix-retry]
+       [--prefix-hash <sha256>|--prefix-file <path>] [--same-head-retry]
 Verify that the current scoped-reviewer session has fresh context.
 
 "Fresh" means the reviewer's context is the neutral gate-context builder
@@ -184,7 +184,7 @@ async function checkSentinelExists(scope, round, cwd = process.cwd()) {
   return { exists: false, path: sentinelPath, legacy: false };
 }
 // Read the recorded `prefixHash` off an existing sentinel file, for the
-// --pr-body-fix-retry comparison. Returns null on any read/parse failure or
+// --same-head-retry comparison. Returns null on any read/parse failure or
 // when the sentinel recorded no (or a malformed) hash — the caller treats
 // null as "never grandfathered in", same posture as verify-briefing-prefixes.mjs.
 async function readSentinelPrefixHash(sentinelPath) {

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -393,8 +393,8 @@ manual chore:
 - **Within one round the contamination guard is preserved:** a same-scope + same-head
   re-entry still fails closed (`fresh: false`, exit 1) — that is genuine main-agent /
   cross-session state bleed. (The one sanctioned same-head exception is the opt-in
-  `--pr-body-fix-retry` overwrite documented below, gated on a matching prefix hash; it is
-  not state bleed.)
+  `--same-head-retry` overwrite documented below — `--pr-body-fix-retry` is its deprecated
+  alias — gated on a matching prefix hash; it is not state bleed.)
 - The orchestrator **MUST NOT** need to manually clear sentinels between rounds, and
   **MUST NOT** clear the sentinels of carried-forward clean angles (Phase 5's re-fan
   re-invokes the surface-touched angles, every angle that produced `findings_present`, and
@@ -403,26 +403,38 @@ manual chore:
 - Stale pre-round sentinels (the old scope-only name) never collide with a head-keyed round
   and are simply ignored.
 
-**Sanctioned same-head PR-body-fix retry.** A PR-body/description-only fix (e.g. adding a
-missing acceptance-criteria matrix to satisfy `pr-checklist-matrix`) does not change the head
-SHA, so it earns no new round key on its own — a plain re-invocation of the fixed angle
-collides with its own pass-1 sentinel and fails closed exactly like genuine contamination
-would. `verify-fresh-review-context.mjs --pr-body-fix-retry` is the sanctioned escape hatch
-for exactly this case: it overwrites the existing sentinel for that scope+round, but **only**
-when the given `--prefix-hash`/`--prefix-file` matches the existing sentinel's recorded prefix
-hash **exactly**. An identical hash proves the seeded briefing bytes were NOT rebuilt, so the
-byte-identity invariant (`GATE-EXEC-BRIEFING-PREFIX`) stays fully intact for every other
-sentinel of the same round — the previously-clean angles' sentinels are left untouched and
-still verify against the same on-disk record, so `verify-briefing-prefixes.mjs` needs no full
-re-fan of clean angles and no manual sentinel deletion. A hash mismatch (the context-builder
-genuinely rebuilt the briefing) or an existing sentinel recording no prefix hash still fails
-closed — this flag is a narrow, auditable exception for one documented scenario, never a
-general bypass of the contamination guard. Practically: re-brief the retried reviewer with the
-UNCHANGED, byte-identical invariant prefix (do not re-run `write-gate-context.mjs`) plus an
-angle-specific instruction to fetch the CURRENT PR body/description live (e.g. `gh pr view`)
-rather than trust the prefix's now-stale inlined copy, since the point of the retry is to
-re-check the just-edited description. See `verify-fresh-review-context.mjs --help` for the
-flag's exact semantics and exit codes.
+**Sanctioned same-head retry.** Some legitimate re-runs never earn a new round key, so a
+plain re-invocation of the same angle collides with its own pass-1 sentinel and fails closed
+exactly like genuine contamination would. The sanctioned scenarios are:
+
+- **PR-body/description-only fix** (e.g. adding a missing acceptance-criteria matrix to
+  satisfy `pr-checklist-matrix`): a body edit never changes the head SHA, so the round key
+  stays the same.
+- **Interrupted reviewer**: a reviewer killed or interrupted AFTER running the sentinel
+  check but BEFORE writing its findings artifact burned the (scope, round) sentinel while
+  producing nothing; the re-dispatched reviewer for the same scope+head is a retry, not
+  state bleed.
+- **Harness crash** mid-round, same shape as the interrupted reviewer.
+
+`verify-fresh-review-context.mjs --same-head-retry` (deprecated alias: `--pr-body-fix-retry`)
+is the sanctioned escape hatch for all of them: it overwrites the existing sentinel for that
+scope+round, but **only** when the given `--prefix-hash`/`--prefix-file` matches the existing
+sentinel's recorded prefix hash **exactly**. An identical hash proves the seeded briefing
+bytes were NOT rebuilt, so the byte-identity invariant (`GATE-EXEC-BRIEFING-PREFIX`) stays
+fully intact for every other sentinel of the same round — the previously-clean angles'
+sentinels are left untouched and still verify against the same on-disk record, so
+`verify-briefing-prefixes.mjs` needs no full re-fan of clean angles and no manual sentinel
+deletion. The retry's REASON never enters the decision; the hash equality is the entire
+safety argument, which is why one mechanical guard covers every scenario above. A hash
+mismatch (the context-builder genuinely rebuilt the briefing) or an existing sentinel
+recording no prefix hash still fails closed — this flag is a narrow, auditable exception,
+never a general bypass of the contamination guard. Practically: re-brief the retried
+reviewer with the UNCHANGED, byte-identical invariant prefix (do not re-run
+`write-gate-context.mjs`); for the PR-body-fix case additionally instruct the reviewer to
+fetch the CURRENT PR body/description live (e.g. `gh pr view`) rather than trust the
+prefix's now-stale inlined copy, since the point of that retry is to re-check the
+just-edited description. See `verify-fresh-review-context.mjs --help` for the flag's exact
+semantics and exit codes.
 
 ### Phase 3 — Consolidation: fan-in synthesis and disposition ledger
 

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -609,3 +609,90 @@ test("--pr-body-fix-retry on a first run (no existing sentinel) behaves like a n
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
 });
+
+// ---------------------------------------------------------------------------
+// Generalized same-head retry (--same-head-retry): the escape hatch covers ANY
+// same-head re-run with unrebuilt briefing bytes — interrupted reviewer,
+// harness crash, or the original PR-body-fix case. --pr-body-fix-retry stays
+// as a deprecated alias with identical semantics.
+// ---------------------------------------------------------------------------
+
+test("--same-head-retry re-admits an interrupted reviewer when the prefix hash matches", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const hash = "c".repeat(64);
+
+    // Reviewer runs the sentinel, then dies before writing its findings artifact.
+    const first = runScript(["--scope", "interrupted-angle", "--prefix-hash", hash], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+
+    // The re-dispatched reviewer passes with the retry flag and the same hash.
+    const retry = runScript(
+      ["--scope", "interrupted-angle", "--prefix-hash", hash, "--same-head-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(retry.status, 0, retry.stderr);
+    const output = JSON.parse(retry.stdout.trim());
+    assert.equal(output.fresh, true);
+    assert.equal(output.sameHeadRetry, true);
+    assert.equal(output.prBodyFixRetry, true, "deprecated mirror field kept while callers migrate");
+    assert.equal(output.prefixHash, hash);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--same-head-retry fails closed on hash mismatch and on a hashless sentinel", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const hash = "d".repeat(64);
+
+    const first = runScript(["--scope", "mismatch-angle", "--prefix-hash", hash], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+
+    const mismatch = runScript(
+      ["--scope", "mismatch-angle", "--prefix-hash", "e".repeat(64), "--same-head-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(mismatch.status, 1);
+    assert.match(JSON.parse(mismatch.stdout.trim()).reason, /DIFFERENT prefix hash/);
+
+    // Hashless sentinel: create without a prefix hash, then retry with one.
+    const hashless = runScript(["--scope", "hashless-angle"], { cwd: tmpDir });
+    assert.equal(hashless.status, 0, hashless.stderr);
+    const retry = runScript(
+      ["--scope", "hashless-angle", "--prefix-hash", hash, "--same-head-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(retry.status, 1);
+    assert.match(JSON.parse(retry.stdout.trim()).reason, /recorded no prefix hash/);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("--same-head-retry without a prefix hash is a usage error, and the alias emits the new field", async () => {
+  const bare = runScript(["--scope", "findings-present", "--same-head-retry"]);
+  assert.equal(bare.status, 2);
+  assert.match(bare.stderr, /--same-head-retry \(alias --pr-body-fix-retry\) requires/);
+
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  try {
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    const hash = "f".repeat(64);
+    const first = runScript(["--scope", "alias-angle", "--prefix-hash", hash], { cwd: tmpDir });
+    assert.equal(first.status, 0, first.stderr);
+    const viaAlias = runScript(
+      ["--scope", "alias-angle", "--prefix-hash", hash, "--pr-body-fix-retry"],
+      { cwd: tmpDir },
+    );
+    assert.equal(viaAlias.status, 0, viaAlias.stderr);
+    const output = JSON.parse(viaAlias.stdout.trim());
+    assert.equal(output.sameHeadRetry, true, "the alias resolves to the same generalized retry");
+    assert.equal(output.prBodyFixRetry, true);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+});

--- a/test/github/verify-fresh-review-context.test.mjs
+++ b/test/github/verify-fresh-review-context.test.mjs
@@ -605,6 +605,7 @@ test("--pr-body-fix-retry on a first run (no existing sentinel) behaves like a n
     // The flag only changes behavior when a collision actually occurs; a plain
     // first run is unaffected and does not report prBodyFixRetry.
     assert.equal("prBodyFixRetry" in output, false);
+    assert.equal("sameHeadRetry" in output, false, "the retry marker never leaks into a first-run output");
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
@@ -619,7 +620,16 @@ test("--pr-body-fix-retry on a first run (no existing sentinel) behaves like a n
 
 test("--same-head-retry re-admits an interrupted reviewer when the prefix hash matches", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const git = makeGit(tmpDir);
   try {
+    // Real gate reviews run at a head-keyed round; exercise that path, not the
+    // scope-only git-unavailable fallback.
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t.dev"]);
+    git(["config", "user.name", "t"]);
+    await writeFile(path.join(tmpDir, "a.txt"), "1", "utf8");
+    git(["add", "-A"]);
+    git(["commit", "-qm", "c1"]);
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const hash = "c".repeat(64);
 
@@ -638,6 +648,7 @@ test("--same-head-retry re-admits an interrupted reviewer when the prefix hash m
     assert.equal(output.sameHeadRetry, true);
     assert.equal(output.prBodyFixRetry, true, "deprecated mirror field kept while callers migrate");
     assert.equal(output.prefixHash, hash);
+    assert.match(output.round ?? "", /^[0-9a-f]{40}$/, "the retry happened at the head-keyed round, not the scope-only fallback");
   } finally {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
@@ -645,7 +656,15 @@ test("--same-head-retry re-admits an interrupted reviewer when the prefix hash m
 
 test("--same-head-retry fails closed on hash mismatch and on a hashless sentinel", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const git = makeGit(tmpDir);
   try {
+    // Head-keyed round, same as the happy-path retry test.
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t.dev"]);
+    git(["config", "user.name", "t"]);
+    await writeFile(path.join(tmpDir, "a.txt"), "1", "utf8");
+    git(["add", "-A"]);
+    git(["commit", "-qm", "c1"]);
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const hash = "d".repeat(64);
 
@@ -679,7 +698,15 @@ test("--same-head-retry without a prefix hash is a usage error, and the alias em
   assert.match(bare.stderr, /--same-head-retry \(alias --pr-body-fix-retry\) requires/);
 
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-verify-fresh-"));
+  const git = makeGit(tmpDir);
   try {
+    // Head-keyed round, same as the other retry tests.
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t.dev"]);
+    git(["config", "user.name", "t"]);
+    await writeFile(path.join(tmpDir, "a.txt"), "1", "utf8");
+    git(["add", "-A"]);
+    git(["commit", "-qm", "c1"]);
     await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
     const hash = "f".repeat(64);
     const first = runScript(["--scope", "alias-angle", "--prefix-hash", hash], { cwd: tmpDir });


### PR DESCRIPTION
Closes #1487

## Summary

A gate reviewer interrupted after running `verify-fresh-review-context.mjs` but before writing its findings artifact burns the per-(scope, round) sentinel. The re-dispatched reviewer then fails closed even though nothing was contaminated. The escape hatch already existed but was documented as PR-body-fix-only. Per the issue's decided approach, the flag is generalized to `--same-head-retry`: the sentinel overwrite is permitted whenever the supplied prefix hash exactly matches the recorded one, because the byte-identity invariant is the entire safety argument regardless of why the retry happens. `--pr-body-fix-retry` stays as a deprecated alias.

## Scope and context

Boundary: the sentinel tool, its test file, and the owning gate-review contract doc.

- `scripts/github/verify-fresh-review-context.mjs` — `--same-head-retry` flag (alias kept), generalized help text, sentinel record and output carry `sameHeadRetry: true` (the output keeps `prBodyFixRetry: true` as a deprecated mirror while callers migrate), refusal message renamed.
- `skills/docs/gate-review-sub-loop-contract.md` (+ mirror) — the "Sanctioned same-head retry" section now enumerates the three sanctioned scenarios (PR-body-only fix, interrupted reviewer, harness crash) and names the alias.
- `test/github/verify-fresh-review-context.test.mjs` — new tests for the widened retry.

Out of boundary: sentinel garbage collection; the cross-hash contamination checks in verify-briefing-prefixes (both explicit non-goals, both untouched).

## Acceptance criteria

- [x] AC1 — A reviewer interrupted after sentinel creation can be re-dispatched for the same scope+head with `--same-head-retry` and passes verification when its prefix hash matches the recorded hash exactly.
- [x] AC2 — Hash mismatch and hashless-sentinel cases still fail closed.
- [x] AC3 — The gate-review contract documents interrupted-reviewer retry as a sanctioned same-head scenario.

## Definition of done

- [x] Unit tests for the widened retry (match passes, mismatch fails, no-hash fails, alias works).
- [x] Full verify green.

## AC/DoD/Non-goals matrix

| Item | Type (AC/DoD/Non-goal) | Status (Met/Partial/Unmet/Unverified) | Evidence | Notes |
|---|---|---|---|---|
| Interrupted reviewer re-admitted on exact hash match | AC | Met | Test: sentinel created, then --same-head-retry with the same hash passes with sameHeadRetry:true | |
| Mismatch and hashless sentinel fail closed | AC | Met | Tests: DIFFERENT-prefix-hash refusal (exit 1) and recorded-no-prefix-hash refusal (exit 1) | |
| Contract documents the scenario | AC | Met | gate-review-sub-loop-contract.md "Sanctioned same-head retry" enumerates the three scenarios and the alias | |
| Widened-retry unit tests incl. alias | DoD | Met | 3 new tests (36/36 green); alias test asserts sameHeadRetry:true via --pr-body-fix-retry | |
| Full verify green | DoD | Met | npm run verify green at this head (all sub-suites fail 0; one load-sensitive timing test flaked under parallel reviewer load and passes in isolation) | |
| No sentinel GC | Non-goal | Met | No deletion path added | |
| No weakening of verify-briefing-prefixes | Non-goal | Met | File untouched | |

## Non-goals

- Automatic sentinel garbage collection.
- Any weakening of the cross-hash contamination checks in verify-briefing-prefixes.

## Open questions and risks

- The output emits both `sameHeadRetry` and `prBodyFixRetry` on the retry path. The duplicate field is deliberate back-compat and can be dropped once no caller pins the old name.

## Validation

```
node --test test/github/verify-fresh-review-context.test.mjs
npm run test:docs
npm run verify
```

