### PR TITLE
fix(test): enforce core-runtime-boundary test and add orphan-test coverage contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "verify": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop test:workflows",
     "test": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack",
-    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
+    "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/core-runtime-boundary.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:doc-guard": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/extension-pi-adapter.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs test/cli-deps-less-checkout-preflight.test.mjs",
     "test:scripts": "GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=core.fsync GIT_CONFIG_VALUE_0=none GIT_CONFIG_KEY_1=core.fsyncObjectFiles GIT_CONFIG_VALUE_1=false node --test --test-reporter ./test/failure-summary-reporter.mjs test/github/*.test.mjs test/loop/*.test.mjs test/docs/*.test.mjs test/projects/*.test.mjs test/pages/*.test.mjs",

--- a/test/contracts/orphan-test-coverage.test.mjs
+++ b/test/contracts/orphan-test-coverage.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+// Every test/**/*.test.mjs must be matched by at least one package.json
+// test:* suite, or it silently drops out of `npm run verify` — a red test
+// nobody runs documents an invariant the repo stopped honoring
+// (test/core-runtime-boundary.test.mjs sat red and unrun exactly this way).
+
+const repoRoot = new URL("../../", import.meta.url);
+
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const child = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(child);
+      continue;
+    }
+    yield child;
+  }
+}
+
+const globToRegExp = (glob) =>
+  new RegExp(
+    `^${glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`,
+  );
+
+test("every test/**/*.test.mjs is covered by a package.json test suite", async () => {
+  const pkg = JSON.parse(await readFile(new URL("package.json", repoRoot), "utf8"));
+  const patterns = [];
+  for (const command of Object.values(pkg.scripts)) {
+    for (const token of command.split(/\s+/)) {
+      if (/^test\/.*\.test\.mjs$/.test(token)) {
+        patterns.push(globToRegExp(token));
+      }
+    }
+  }
+  assert.ok(patterns.length > 0, "expected test file tokens in package.json scripts");
+
+  const testRoot = path.join(repoRoot.pathname, "test");
+  const orphans = [];
+  for await (const file of walk(testRoot)) {
+    if (!file.endsWith(".test.mjs")) continue;
+    const relative = path.relative(repoRoot.pathname, file);
+    if (!patterns.some((pattern) => pattern.test(relative))) {
+      orphans.push(relative);
+    }
+  }
+
+  assert.deepEqual(
+    orphans.sort(),
+    [],
+    "test files not matched by any package.json suite — wire them into a test:* script",
+  );
+});

--- a/test/contracts/orphan-test-coverage.test.mjs
+++ b/test/contracts/orphan-test-coverage.test.mjs
@@ -9,14 +9,14 @@ import test from "node:test";
 // nobody runs documents an invariant the repo stopped honoring
 // (test/core-runtime-boundary.test.mjs sat red and unrun exactly this way).
 // Coverage is computed from the scripts transitively reachable from the
-// `verify` and `test` scripts only: a token in an unreachable script (e.g. a
-// standalone helper suite) does not count as coverage.
+// `verify` script only: a token in an unreachable script (e.g. a standalone
+// helper suite) does not count as coverage.
 
 const repoRootPath = fileURLToPath(new URL("../../", import.meta.url));
 
 async function coveredTestFiles() {
   const pkg = JSON.parse(await readFile(path.join(repoRootPath, "package.json"), "utf8"));
-  const queue = ["verify", "test"];
+  const queue = ["verify"];
   const visited = new Set();
   const covered = new Set();
   while (queue.length > 0) {

--- a/test/contracts/orphan-test-coverage.test.mjs
+++ b/test/contracts/orphan-test-coverage.test.mjs
@@ -1,49 +1,70 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
+import { glob, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-// Every test/**/*.test.mjs must be matched by at least one package.json
-// test:* suite, or it silently drops out of `npm run verify` — a red test
+// Every test/**/*.test.mjs must be matched by a suite that `npm run verify`
+// actually reaches, or it silently drops out of enforcement — a red test
 // nobody runs documents an invariant the repo stopped honoring
 // (test/core-runtime-boundary.test.mjs sat red and unrun exactly this way).
+// Coverage is computed from the scripts transitively reachable from the
+// `verify` and `test` scripts only: a token in an unreachable script (e.g. a
+// standalone helper suite) does not count as coverage.
 
-const repoRoot = new URL("../../", import.meta.url);
+const repoRootPath = fileURLToPath(new URL("../../", import.meta.url));
 
-async function* walk(dir) {
-  for (const entry of await readdir(dir, { withFileTypes: true })) {
-    const child = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walk(child);
-      continue;
-    }
-    yield child;
-  }
-}
-
-const globToRegExp = (glob) =>
-  new RegExp(
-    `^${glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`,
-  );
-
-test("every test/**/*.test.mjs is covered by a package.json test suite", async () => {
-  const pkg = JSON.parse(await readFile(new URL("package.json", repoRoot), "utf8"));
-  const patterns = [];
-  for (const command of Object.values(pkg.scripts)) {
-    for (const token of command.split(/\s+/)) {
+async function coveredTestFiles() {
+  const pkg = JSON.parse(await readFile(path.join(repoRootPath, "package.json"), "utf8"));
+  const queue = ["verify", "test"];
+  const visited = new Set();
+  const covered = new Set();
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (visited.has(name) || !pkg.scripts[name]) continue;
+    visited.add(name);
+    for (const token of pkg.scripts[name].split(/\s+/)) {
+      if (/^test:[\w:-]+$/.test(token)) {
+        queue.push(token);
+        continue;
+      }
       if (/^test\/.*\.test\.mjs$/.test(token)) {
-        patterns.push(globToRegExp(token));
+        for await (const match of glob(token, { cwd: repoRootPath })) {
+          covered.add(match.split(path.sep).join("/"));
+        }
       }
     }
   }
-  assert.ok(patterns.length > 0, "expected test file tokens in package.json scripts");
+  assert.ok(covered.size > 0, "expected test file tokens in verify-reachable scripts");
+  return covered;
+}
 
-  const testRoot = path.join(repoRoot.pathname, "test");
+test("coverage detection resolves real tokens and rejects unknown files", async () => {
+  const covered = await coveredTestFiles();
+  assert.ok(
+    covered.has("test/dev-loop-init-phase-smoke.test.mjs"),
+    "explicit test:assets token should be covered",
+  );
+  assert.ok(
+    covered.has("test/contracts/orphan-test-coverage.test.mjs"),
+    "glob test:assets token should cover this very file",
+  );
+  assert.ok(!covered.has("test/__fabricated-orphan__.test.mjs"));
+});
+
+test("every test/**/*.test.mjs is covered by a verify-reachable suite", async () => {
+  const covered = await coveredTestFiles();
   const orphans = [];
-  for await (const file of walk(testRoot)) {
-    if (!file.endsWith(".test.mjs")) continue;
-    const relative = path.relative(repoRoot.pathname, file);
-    if (!patterns.some((pattern) => pattern.test(relative))) {
+  for (const entry of await readdir(path.join(repoRootPath, "test"), {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (!entry.isFile() || !entry.name.endsWith(".test.mjs")) continue;
+    const relative = path
+      .relative(repoRootPath, path.join(entry.parentPath, entry.name))
+      .split(path.sep)
+      .join("/");
+    if (!covered.has(relative)) {
       orphans.push(relative);
     }
   }
@@ -51,6 +72,6 @@ test("every test/**/*.test.mjs is covered by a package.json test suite", async (
   assert.deepEqual(
     orphans.sort(),
     [],
-    "test files not matched by any package.json suite — wire them into a test:* script",
+    "test files not reachable from `npm run verify` — wire them into a reachable test:* script",
   );
 });

--- a/test/core-runtime-boundary.test.mjs
+++ b/test/core-runtime-boundary.test.mjs
@@ -8,9 +8,15 @@ const RUNTIME_ROOTS = ["scripts", "lib", "cli", "extension"];
 // the @dev-loops/core package entry, never deep into packages/core/src. Only
 // import/export/require specifiers count — comments, doc prose, and
 // filesystem-path constants (asset copiers, atlas source labels) may name
-// packages/core/src freely.
+// packages/core/src freely. The static branch is anchored to a line-leading
+// import/export keyword (the STATIC_SPECIFIER_RE shape from
+// test/contracts/no-package-escaping-imports.test.mjs) so prose like
+// `copied from "packages/core/src/x.mjs"` cannot match; the binding-list char
+// class spans newlines for multiline import blocks. Residual known gap: a
+// comment embedding a quoted `import(...)`/`require(...)` code sample would
+// still match the dynamic branches.
 const deepImportPattern =
-  /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|^\s*import\s+)["'][^"']*packages\/core\/src\//m;
+  /(?:^[ \t]*(?:import\s*(?:[\w$*,{}\s]*?\bfrom\s*)?|export\s*[\w$*,{}\s]*?\bfrom\s*)|\bimport\s*\(\s*|\brequire\s*\(\s*)["'][^"']*packages\/core\/src\//m;
 
 async function* walk(dirUrl) {
   const { readdir } = await import("node:fs/promises");
@@ -26,10 +32,14 @@ async function* walk(dirUrl) {
 
 test("deep-import pattern catches real import specifiers only", () => {
   assert.match(`import { x } from "../../packages/core/src/config/config.mjs";`, deepImportPattern);
+  assert.match(`import "../../packages/core/src/register-globals.mjs";`, deepImportPattern);
+  assert.match(`import {\n  a,\n  b,\n} from "../../packages/core/src/config/config.mjs";`, deepImportPattern);
   assert.match(`const m = await import("packages/core/src/loop/run-context.mjs");`, deepImportPattern);
   assert.match(`const m = require("../packages/core/src/x.mjs");`, deepImportPattern);
   assert.match(`export { y } from "../../packages/core/src/y.mjs";`, deepImportPattern);
   assert.doesNotMatch(`// synced from packages/core/src/loop/run-context.mjs`, deepImportPattern);
+  assert.doesNotMatch(`// copied from "packages/core/src/config/default.json"`, deepImportPattern);
+  assert.doesNotMatch(`// e.g. import { x } from "packages/core/src/y.mjs"`, deepImportPattern);
   assert.doesNotMatch(`const source = "packages/core/src/loop/run-context.mjs";`, deepImportPattern);
 });
 

--- a/test/core-runtime-boundary.test.mjs
+++ b/test/core-runtime-boundary.test.mjs
@@ -4,7 +4,13 @@ import path from "node:path";
 import test from "node:test";
 
 const RUNTIME_ROOTS = ["scripts", "lib", "cli", "extension"];
-const deepImportPattern = /packages\/core\/src\//;
+// The boundary is about module resolution: runtime surfaces must import via
+// the @dev-loops/core package entry, never deep into packages/core/src. Only
+// import/export/require specifiers count — comments, doc prose, and
+// filesystem-path constants (asset copiers, atlas source labels) may name
+// packages/core/src freely.
+const deepImportPattern =
+  /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|^\s*import\s+)["'][^"']*packages\/core\/src\//m;
 
 async function* walk(dirUrl) {
   const { readdir } = await import("node:fs/promises");
@@ -17,6 +23,15 @@ async function* walk(dirUrl) {
     yield childUrl;
   }
 }
+
+test("deep-import pattern catches real import specifiers only", () => {
+  assert.match(`import { x } from "../../packages/core/src/config/config.mjs";`, deepImportPattern);
+  assert.match(`const m = await import("packages/core/src/loop/run-context.mjs");`, deepImportPattern);
+  assert.match(`const m = require("../packages/core/src/x.mjs");`, deepImportPattern);
+  assert.match(`export { y } from "../../packages/core/src/y.mjs";`, deepImportPattern);
+  assert.doesNotMatch(`// synced from packages/core/src/loop/run-context.mjs`, deepImportPattern);
+  assert.doesNotMatch(`const source = "packages/core/src/loop/run-context.mjs";`, deepImportPattern);
+});
 
 test("runtime surfaces use the @dev-loops/core boundary instead of deep packages/core/src imports", async () => {
   const offenders = [];

--- a/test/core-runtime-boundary.test.mjs
+++ b/test/core-runtime-boundary.test.mjs
@@ -12,9 +12,10 @@ const RUNTIME_ROOTS = ["scripts", "lib", "cli", "extension"];
 // import/export keyword (the STATIC_SPECIFIER_RE shape from
 // test/contracts/no-package-escaping-imports.test.mjs) so prose like
 // `copied from "packages/core/src/x.mjs"` cannot match; the binding-list char
-// class spans newlines for multiline import blocks. Residual known gap: a
-// comment embedding a quoted `import(...)`/`require(...)` code sample would
-// still match the dynamic branches.
+// class spans newlines for multiline import blocks. Residual known gap:
+// comment-embedded code samples still match when they look like real
+// specifiers — a quoted `import(...)`/`require(...)` sample anywhere, or a
+// block-comment line that itself leads with `import`/`export`.
 const deepImportPattern =
   /(?:^[ \t]*(?:import\s*(?:[\w$*,{}\s]*?\bfrom\s*)?|export\s*[\w$*,{}\s]*?\bfrom\s*)|\bimport\s*\(\s*|\brequire\s*\(\s*)["'][^"']*packages\/core\/src\//m;
 


### PR DESCRIPTION
Closes #1493

## Summary

`test/core-runtime-boundary.test.mjs` was red AND unrun: no package.json suite covered it, so `npm run verify` never executed it, and its detection regex flagged 11 false positives (any textual mention of `packages/core/src/`, including comments and path constants). This PR corrects the detection to real import specifiers, wires the test into `test:assets`, and adds a meta contract so no test file can silently drop out of `npm run verify` again.

## Scope and context

Touches only the boundary test's detection rule (`test/core-runtime-boundary.test.mjs`), the `test:assets` wiring in `package.json`, and the new meta contract `test/contracts/orphan-test-coverage.test.mjs`. No runtime code changes.

## Change

- Tighten the boundary test's detection to real import/export/require specifiers. The static branch reuses the anchored shape proven in `test/contracts/no-package-escaping-imports.test.mjs` (line-leading `import`/`export`, multiline binding lists), so doc prose like `copied from "packages/core/src/x.mjs"` cannot match. A self-check test pins the pattern against positive cases (static, bare, multiline, dynamic `import()`, `require()`, `export … from`) and negative comment/prose cases. The offender list is empty under the corrected rule — no allowlist entries needed.
- Wire `test/core-runtime-boundary.test.mjs` into the `test:assets` explicit file list so `npm run verify` enforces it.
- Add `test/contracts/orphan-test-coverage.test.mjs`: fails when any `test/**/*.test.mjs` is not matched by a suite transitively reachable from the `verify` script (tokens in unreachable scripts do not count). Glob tokens expand via stdlib `fs.promises.glob`. A companion test pins the coverage detection itself (known-covered explicit token, known-covered glob token, fabricated orphan rejected). Verified red on the orphan before the package.json wiring.

## Acceptance criteria

- [x] AC1 — boundary test passes and runs via `test:assets` in `npm run verify`.
- [x] AC2 — all 11 offenders resolved: none is a real deep import; the rule was corrected to specifier-level detection instead of allowlisting false positives.
- [x] AC3 — the meta contract fails on any `test/**/*.test.mjs` not reachable from `npm run verify`.

## Definition of done

- [x] Full verify green with the boundary test enforced.

## Non-goals

- Changing the runtime-boundary rule beyond what offender triage justifies: the issue sanctioned updating the test's rule "if the boundary rule legitimately evolved"; triage showed all 11 offenders were textual mentions, not imports, so the rule change is the per-entry triage outcome (false-positive class eliminated at the rule level).
- Widening `test:scripts` or restructuring suite layout.
- Covering non-`test/` suites (e.g. `packages/core/test`, skill-local tests) in the meta contract.

## AC/DoD/non-goals matrix

| Acceptance criterion | Definition of done | Non-goal boundary respected |
| --- | --- | --- |
| AC1: boundary test runs and passes via `test:assets` | Full verify green with the test enforced | Suite layout unchanged beyond the one explicit `test:assets` entry |
| AC2: all 11 offenders triaged (rule corrected, no real deep imports) | Self-check pins the corrected pattern | Rule change limited to what offender triage justified (false-positive class) |
| AC3: meta contract fails on any verify-unreachable `test/**/*.test.mjs` | Detection pinned by companion test; verified red on the orphan | Non-`test/` suites (packages/core/test, skill-local) out of scope |

## Validation

`npm run verify` green (all node-test legs `fail 0`). Direct: `node --test test/core-runtime-boundary.test.mjs test/contracts/orphan-test-coverage.test.mjs`.
