### PR TITLE
fix(gate): accept the fan-in synthetic pr-checklist-matrix angle in foreign-angle validation

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1074,9 +1074,14 @@ disabled entry still a hard ceiling. A delta-suffixed angle (`<angle>-delta-at-.
 to only the current head's delta) counts toward its base angle for both checks.
 Fan-in synthetic angles (`FANIN_SYNTHETIC_ANGLES` from `@dev-loops/core/loop/gate-fanin`;
 currently `pr-checklist-matrix`, the entry `consolidate-fanin --pr-checklist-matrix clean`
-upserts) are always legal in the foreign-angle check regardless of pool config or
-`gates.rejectForeignAngles` — they are fan-in-mandated, not pool-configured, so a repo
-never has to list them per-gate.
+upserts) are always legal in the foreign-angle check, regardless of pool config,
+`gates.rejectForeignAngles`, or an `enabled: false` entry for the angle. The entry is
+minted by the fan-in itself, never dispatched from the pool, so a gate whose pool omits
+the angle (e.g. the shipped draft pool) accepts it without listing it per-gate; the
+disabled-entry ceiling above still governs pool WIDENING (dynamic dispatch), while this
+exemption covers only the fan-in-minted recorded entry. The angle may additionally be
+pool-configured where a gate wants it reviewed as a real angle — the shipped preApproval
+pool lists `pr-checklist-matrix` as mandatory.
 This is independent of `requireFanoutProvenance`, and is exempt for
 `inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
 data to validate). At merge-evidence time, when a gate configures any mandatory

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1072,6 +1072,11 @@ angles minus disabled entries), widened to the global lens catalog
 dynamic resolution may legitimately dispatch catalog angles then, with a
 disabled entry still a hard ceiling. A delta-suffixed angle (`<angle>-delta-at-...`, e.g. a re-review scoped
 to only the current head's delta) counts toward its base angle for both checks.
+Fan-in synthetic angles (`FANIN_SYNTHETIC_ANGLES` from `@dev-loops/core/loop/gate-fanin`;
+currently `pr-checklist-matrix`, the entry `consolidate-fanin --pr-checklist-matrix clean`
+upserts) are always legal in the foreign-angle check regardless of pool config or
+`gates.rejectForeignAngles` — they are fan-in-mandated, not pool-configured, so a repo
+never has to list them per-gate.
 This is independent of `requireFanoutProvenance`, and is exempt for
 `inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
 data to validate). At merge-evidence time, when a gate configures any mandatory

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -232,8 +232,9 @@ export function baseAngleName(angle) {
 /**
  * Validate a recorded fan-out angle list against a gate's configured angle
  * contract: every mandatory angle must be represented, and — when a pool is
- * supplied — every recorded angle must be a member of it (delta-suffixed
- * angles count toward their {@link baseAngleName}). Pure; shared by the write
+ * supplied — every recorded angle must be a member of it or of
+ * {@link FANIN_SYNTHETIC_ANGLES} (delta-suffixed angles count toward their
+ * {@link baseAngleName}). Pure; shared by the write
  * path (write-gate-findings-log's `provenance.perAngle`, upsert-checkpoint-verdict's
  * `--findings-json` per-angle results) and the merge-evidence read path
  * (detect-checkpoint-evidence re-validating the ledger's `provenance.perAngle`)
@@ -242,7 +243,7 @@ export function baseAngleName(angle) {
  * @param {unknown} recordedAngles — array of `{ angle: string, ... }` entries (provenance.perAngle or normalized per-angle findings)
  * @param {object} [gateAngleContract]
  * @param {string[]} [gateAngleContract.mandatoryAngles] — angles that must always be represented
- * @param {string[]|null} [gateAngleContract.pool] — configured angle pool; null/omitted skips the foreign-angle check
+ * @param {string[]|null} [gateAngleContract.pool] — configured angle pool; null/omitted skips the foreign-angle check; {@link FANIN_SYNTHETIC_ANGLES} are unioned in before membership is checked
  * @returns {{ missingMandatory: string[], foreignAngles: string[] }}
  */
 export function checkFanoutAngleCoverage(recordedAngles, { mandatoryAngles = [], pool = null } = {}) {

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -243,7 +243,7 @@ export function baseAngleName(angle) {
  * @param {unknown} recordedAngles — array of `{ angle: string, ... }` entries (provenance.perAngle or normalized per-angle findings)
  * @param {object} [gateAngleContract]
  * @param {string[]} [gateAngleContract.mandatoryAngles] — angles that must always be represented
- * @param {string[]|null} [gateAngleContract.pool] — configured angle pool; null/omitted skips the foreign-angle check; {@link FANIN_SYNTHETIC_ANGLES} are unioned in before membership is checked
+ * @param {string[]|null} [gateAngleContract.pool] — configured angle pool; null/omitted/empty skips the foreign-angle check; {@link FANIN_SYNTHETIC_ANGLES} are unioned in before membership is checked
  * @returns {{ missingMandatory: string[], foreignAngles: string[] }}
  */
 export function checkFanoutAngleCoverage(recordedAngles, { mandatoryAngles = [], pool = null } = {}) {

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -255,11 +255,20 @@ export function checkFanoutAngleCoverage(recordedAngles, { mandatoryAngles = [],
   const missingMandatory = mandatoryAngles.filter((a) => !recordedBases.has(a));
   let foreignAngles = [];
   if (Array.isArray(pool) && pool.length > 0) {
-    const poolSet = new Set(pool);
+    const poolSet = new Set([...pool, ...FANIN_SYNTHETIC_ANGLES]);
     foreignAngles = [...new Set(recorded.filter((a) => !poolSet.has(baseAngleName(a))))];
   }
   return { missingMandatory, foreignAngles };
 }
+
+/**
+ * Angles the fan-in itself mandates and may synthesize (consolidate-fanin's
+ * `--pr-checklist-matrix clean` upsert) without them appearing in any gate's
+ * configured `angles` pool. Always legal in the foreign-angle check above —
+ * requiring every consumer repo to also list them per-gate would make the two
+ * tools contradict the shared contract they implement.
+ */
+export const FANIN_SYNTHETIC_ANGLES = Object.freeze(["pr-checklist-matrix"]);
 
 /**
  * Default cap on parallel fan-out reviewers when a caller does not supply one.

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -422,4 +422,12 @@ describe("checkFanoutAngleCoverage (#1196 — mandatory angles + angle-pool memb
     );
     assert.deepEqual(result.foreignAngles, ["made-up-angle"]);
   });
+
+  test("delta-suffixed fan-in synthetic angle is never foreign when the pool omits its base", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "pr-checklist-matrix-delta-at-current-head" }],
+      { mandatoryAngles: [], pool: ["dry", "kiss"] },
+    );
+    assert.deepEqual(result.foreignAngles, []);
+  });
 });

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -414,4 +414,12 @@ describe("checkFanoutAngleCoverage (#1196 — mandatory angles + angle-pool memb
     assert.deepEqual(checkFanoutAngleCoverage(undefined, { mandatoryAngles: ["a"] }).missingMandatory, ["a"]);
     assert.deepEqual(checkFanoutAngleCoverage([null, { angle: "" }, "nope"], { mandatoryAngles: [] }).foreignAngles, []);
   });
+
+  test("fan-in synthetic angle (pr-checklist-matrix) is never foreign, even when absent from the pool", () => {
+    const result = checkFanoutAngleCoverage(
+      [{ angle: "pr-checklist-matrix" }, { angle: "made-up-angle" }],
+      { mandatoryAngles: [], pool: ["dry", "kiss"] },
+    );
+    assert.deepEqual(result.foreignAngles, ["made-up-angle"]);
+  });
 });

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -56,7 +56,7 @@ import { GATE_NAMES } from "../github/_gate-names.mjs";
 import { isPostedCommentLimitError, normalizeStructuredFindings, renderStructuredFindings } from "../github/upsert-checkpoint-verdict.mjs";
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
-import { SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
+import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
 
 const USAGE = `Usage: consolidate-fanin.mjs --findings-dir <dir> [--gate <draft_gate|pre_approval_gate>] [--out <path>] [--ledger-out <path>] [--pr-checklist-matrix clean] [--carried-angles <json> --carry-forward-plan <json>] [--repo-root <path>]
 Consolidate the per-angle *.json findings artifacts a gate-review fan-out wrote into
@@ -679,7 +679,7 @@ function resolvePrChecklistMatrixUpsert(rawValue) {
   if (rawValue.trim().toLowerCase() !== "clean") {
     throw new Error('--pr-checklist-matrix accepts only "clean"');
   }
-  return { angle: "pr-checklist-matrix", verdict: "clean", findings: [] };
+  return { angle: FANIN_SYNTHETIC_ANGLES[0], verdict: "clean", findings: [] };
 }
 
 export async function consolidateGateFanin(options) {
@@ -770,7 +770,7 @@ export async function consolidateGateFanin(options) {
 
   if (options.prChecklistMatrix !== undefined) {
     const hasPrChecklistMatrix = rawArtifacts.some(
-      (a) => typeof a.angle === "string" && a.angle.trim() === "pr-checklist-matrix",
+      (a) => typeof a.angle === "string" && a.angle.trim() === FANIN_SYNTHETIC_ANGLES[0],
     );
     if (!hasPrChecklistMatrix) {
       rawArtifacts.push(resolvePrChecklistMatrixUpsert(options.prChecklistMatrix));

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1074,9 +1074,14 @@ disabled entry still a hard ceiling. A delta-suffixed angle (`<angle>-delta-at-.
 to only the current head's delta) counts toward its base angle for both checks.
 Fan-in synthetic angles (`FANIN_SYNTHETIC_ANGLES` from `@dev-loops/core/loop/gate-fanin`;
 currently `pr-checklist-matrix`, the entry `consolidate-fanin --pr-checklist-matrix clean`
-upserts) are always legal in the foreign-angle check regardless of pool config or
-`gates.rejectForeignAngles` — they are fan-in-mandated, not pool-configured, so a repo
-never has to list them per-gate.
+upserts) are always legal in the foreign-angle check, regardless of pool config,
+`gates.rejectForeignAngles`, or an `enabled: false` entry for the angle. The entry is
+minted by the fan-in itself, never dispatched from the pool, so a gate whose pool omits
+the angle (e.g. the shipped draft pool) accepts it without listing it per-gate; the
+disabled-entry ceiling above still governs pool WIDENING (dynamic dispatch), while this
+exemption covers only the fan-in-minted recorded entry. The angle may additionally be
+pool-configured where a gate wants it reviewed as a real angle — the shipped preApproval
+pool lists `pr-checklist-matrix` as mandatory.
 This is independent of `requireFanoutProvenance`, and is exempt for
 `inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
 data to validate). At merge-evidence time, when a gate configures any mandatory

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1072,6 +1072,11 @@ angles minus disabled entries), widened to the global lens catalog
 dynamic resolution may legitimately dispatch catalog angles then, with a
 disabled entry still a hard ceiling. A delta-suffixed angle (`<angle>-delta-at-...`, e.g. a re-review scoped
 to only the current head's delta) counts toward its base angle for both checks.
+Fan-in synthetic angles (`FANIN_SYNTHETIC_ANGLES` from `@dev-loops/core/loop/gate-fanin`;
+currently `pr-checklist-matrix`, the entry `consolidate-fanin --pr-checklist-matrix clean`
+upserts) are always legal in the foreign-angle check regardless of pool config or
+`gates.rejectForeignAngles` — they are fan-in-mandated, not pool-configured, so a repo
+never has to list them per-gate.
 This is independent of `requireFanoutProvenance`, and is exempt for
 `inline_single_agent` verdicts (light-mode inline runs carry no per-angle fan-out
 data to validate). At merge-evidence time, when a gate configures any mandatory

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -1479,6 +1479,25 @@ test("buildPreMergeGateCheck WARNS (does not fail) on a foreign angle when rejec
   assert.match(result.warnings[0], /rejectForeignAngles is false/);
 });
 
+test("buildPreMergeGateCheck accepts the fan-in synthetic pr-checklist-matrix angle when the pool omits it (#1494)", () => {
+  const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
+    required: true,
+    gates: [
+      {
+        name: "draft_gate",
+        executionMode: "fanout_fanin",
+        ledgerPath: "tmp/b.json",
+        ledgerExists: true,
+        provenance: { distinctReviewers: 2, perAngle: [{ angle: "dry", reviewer: "review-a" }, { angle: "pr-checklist-matrix", reviewer: "review-b" }] },
+        mandatoryAngles: [],
+        anglePool: ["dry", "kiss"],
+      },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.failures));
+  assert.deepEqual(result.warnings ?? [], []);
+});
+
 test("buildPreMergeGateCheck accepts a delta-suffixed angle as covering its base mandatory angle", () => {
   const result = buildPreMergeGateCheck(cleanEvidence(), 0, null, {
     required: true,

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -4069,6 +4069,62 @@ test("upsert-checkpoint-verdict rejects a fanout_fanin verdict whose --findings-
   }
 });
 
+test("upsert-checkpoint-verdict accepts the fan-in synthetic pr-checklist-matrix angle outside the gate's configured pool (#1494)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angle-coverage-synthetic-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    // consolidate-fanin --out shape: draft-pool angles plus the synthetic
+    // matrix entry its --pr-checklist-matrix clean flag upserts. draft_gate's
+    // pool does not list pr-checklist-matrix; the upsert must not reject it.
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        { angle: "pr-description", verdict: "clean", findings: [] },
+        { angle: "scope", verdict: "clean", findings: [] },
+        { angle: "pr-checklist-matrix", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "number,state,isDraft,headRefOid,mergeable,mergeStateStatus,body,title,closingIssuesReferences,reviews,statusCheckRollup,files"],
+        stdout: JSON.stringify({ number: 17, state: "OPEN", isDraft: true, headRefOid: "abc1234000000000000000000000000000000000", body: DEFAULT_TEST_PR_BODY, closingIssuesReferences: [], reviews: [], statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }] }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "pr=17"],
+        stdout: '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n',
+      },
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"],
+        stdout: '{"headRefOid":"abc1234000000000000000000000000000000000"}\n',
+      },
+      {
+        assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"],
+        stdout: '[]\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/issues/17/comments", "-f"],
+        assertArgContains: ["body=### Gate review: `draft_gate`", "**Reviewed head SHA:** `abc1234000000000000000000000000000000000`"],
+        stdout: '{"id":102,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-102"}\n',
+      },
+    ]);
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "clean", "--findings-json", findingsPath,
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"defer":0}',
+      "--next-action", "mark ready for review", "--execution-mode", "fanout_fanin",
+    ], { env });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).ok, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict rejects an angle-less flat finding in fanout mode with a dedicated error (not a confusing `general` pool error)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-angleless-"));
   try {

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -886,6 +886,20 @@ test("checkProvenanceAngleCoverage rejects an angle outside the configured pool 
   });
 });
 
+test("checkProvenanceAngleCoverage accepts the fan-in synthetic pr-checklist-matrix angle when the gate's pool omits it (#1494)", async () => {
+  await withAngleContractRepo(async (repoRoot) => {
+    // draft's configured pool (scope, coverage, pr-description) does not list
+    // pr-checklist-matrix; the fan-in-synthetic exemption must let it through
+    // without a warning.
+    const result = await checkProvenanceAngleCoverage(
+      { perAngle: [{ angle: "scope", reviewer: "r1" }, { angle: "pr-description", reviewer: "r2" }, { angle: "pr-checklist-matrix", reviewer: "r3" }] },
+      "draft_gate",
+      { repoRoot },
+    );
+    assert.equal(result.warning ?? null, null);
+  });
+});
+
 test("checkProvenanceAngleCoverage warns (does not fail) on a foreign angle when gates.rejectForeignAngles is false", async () => {
   await withAngleContractRepo(async (repoRoot) => {
     const result = await checkProvenanceAngleCoverage(


### PR DESCRIPTION
Closes #1494

## Summary

`gate consolidate-fanin --pr-checklist-matrix clean` upserts a synthetic `pr-checklist-matrix` angle entry into its `--out` findingsJson, but `upsert-checkpoint-verdict.mjs` validated every angle against the gate's configured pool and failed closed on it as foreign (observed live on PR 1491 draft_gate round 1). The two tools contradicted the shared contract. The fix exempts fan-in-mandated synthetic angles from the foreign-angle check at the single shared validation point.

## Scope and context

One-line behavior change in `checkFanoutAngleCoverage` (`packages/core/src/loop/gate-fanin.mjs`) plus a documented `FANIN_SYNTHETIC_ANGLES` constant, now also consumed by `consolidate-fanin`'s mint/presence check (deduplicating the angle-name literal, same string). Because the write path (`write-gate-findings-log`), the findings-json path (`upsert-checkpoint-verdict`), and the merge-evidence read path (`detect-checkpoint-evidence`) all share this function, all three accept the synthetic angle identically with no config change. The `GATE-EXEC-ANGLE-COVERAGE` paragraph in `skills/docs/gate-review-sub-loop-contract.md` (and its generated `.claude` mirror) documents the exemption, per the issue's "update the contract doc" clause. Tests otherwise: two unit tests (synthetic angle, delta-suffixed synthetic angle), the upsert end-to-end regression, and one integration test each for the other two consumers.

## Change

- `checkFanoutAngleCoverage`: the foreign-angle check now unions the configured pool with `FANIN_SYNTHETIC_ANGLES` (`["pr-checklist-matrix"]`), a new exported, frozen constant documenting why the angle is always legal (fan-in-mandated, not pool-configured).
- Unit test: the synthetic angle is never foreign even when absent from the pool, while an unknown angle beside it is still rejected.
- Regression test (AC3): a consolidate-fanin `--out`-shaped findings-json for `draft_gate` (whose pool does not list `pr-checklist-matrix`) containing the synthetic clean entry passes `upsert-checkpoint-verdict` end to end with no config change.

## Acceptance criteria

- [x] AC1 — `upsert-checkpoint-verdict.mjs --findings-json <consolidate-fanin --out file>` succeeds with the `pr-checklist-matrix` entry present, no config change.
- [x] AC2 — foreign-angle validation still rejects genuinely unknown angles (existing rejection test unchanged and passing; new test pins both behaviors side by side).
- [x] AC3 — regression test covers a consolidate-fanin `--out` file with the matrix entry fed to upsert.

## Definition of done

- [x] Full verify green.

## AC/DoD/non-goals matrix

| Item | Type | Status | Evidence | Notes |
| --- | --- | --- | --- | --- |
| Upsert accepts synthetic matrix entry from consolidate-fanin --out | AC1 | Met | test/github/upsert-checkpoint-verdict.test.mjs `accepts the fan-in synthetic pr-checklist-matrix angle` (exit 0, draft_gate) | No config change |
| Unknown angles still rejected | AC2 | Met | existing `rejects ... outside the configured pool` test + new unit test rejecting `made-up-angle` beside the synthetic | Fail-closed preserved |
| Regression test for the --out shape | AC3 | Met | same new upsert test; input mirrors consolidate-fanin --out | |
| Full verify green | DoD | Met | `npm run verify` all node-test legs `fail 0` | |
| No change to matrix production/ledger | Non-goal | Respected | consolidate-fanin's mint/presence check now reads the shared constant but emits the identical `pr-checklist-matrix` string; ledger handling untouched; contract-doc prose edit only | |

## Non-goals

- Changing how the matrix entry is produced or its ledger handling.

## Validation

`npm run verify` green. Direct: `node --test packages/core/test/gate-fanin.test.mjs test/github/upsert-checkpoint-verdict.test.mjs test/github/write-gate-findings-log.test.mjs test/github/detect-checkpoint-evidence.test.mjs`.
