### PR TITLE
refactor(core): one canonical SUBMITTED_REVIEW_STATES

### DIFF
--- a/packages/core/src/loop/copilot-loop-iterations.mjs
+++ b/packages/core/src/loop/copilot-loop-iterations.mjs
@@ -1,7 +1,6 @@
-import { isCopilotLogin, normalizeTimestamp } from "../github/copilot-helpers.mjs";
+import { SUBMITTED_REVIEW_STATES, isCopilotLogin, normalizeTimestamp } from "../github/copilot-helpers.mjs";
 
 const ACTIVE_COPILOT_REVIEW_REQUEST_STATUSES = new Set(["requested", "already-requested"]);
-const SUBMITTED_REVIEW_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
 
 function normalizeReviewRequestEvents(events) {
   if (!Array.isArray(events)) {

--- a/packages/core/src/loop/reviewer-loop-state.mjs
+++ b/packages/core/src/loop/reviewer-loop-state.mjs
@@ -106,8 +106,6 @@ const VALID_LOCAL_RUN_STATUSES = new Set(["none", "running", "completed", "faile
 const VALID_LOCAL_MERGE_STATUSES = new Set(["none", "ready", "failed"]);
 const VALID_DRAFT_NOTIFICATION_STATUSES = new Set(["none", "notified"]);
 const VALID_SUBMISSION_STATUSES = new Set(["none", "submitted", "failed"]);
-// The canonical whitelist lives in copilot-helpers; alias kept to avoid call-site churn.
-const VALID_SUBMITTED_REVIEW_STATES = SUBMITTED_REVIEW_STATES;
 
 const SUPPORTED_REVIEW_ANGLES = Object.freeze([
   "correctness",
@@ -145,7 +143,7 @@ function normalizeSubmittedReviewState(value) {
   }
 
   const normalized = value.trim().toUpperCase();
-  return VALID_SUBMITTED_REVIEW_STATES.has(normalized) ? normalized : null;
+  return SUBMITTED_REVIEW_STATES.has(normalized) ? normalized : null;
 }
 
 /**

--- a/packages/core/src/loop/reviewer-loop-state.mjs
+++ b/packages/core/src/loop/reviewer-loop-state.mjs
@@ -1,6 +1,7 @@
 /**
  * Deterministic state machine and bounded planning/merge contracts for reviewer-side PR loops.
  */
+import { SUBMITTED_REVIEW_STATES } from "../github/copilot-helpers.mjs";
 
 export const REVIEWER_STATE = Object.freeze({
   WAITING_FOR_REVIEW_REQUEST: "waiting_for_review_request",
@@ -105,7 +106,8 @@ const VALID_LOCAL_RUN_STATUSES = new Set(["none", "running", "completed", "faile
 const VALID_LOCAL_MERGE_STATUSES = new Set(["none", "ready", "failed"]);
 const VALID_DRAFT_NOTIFICATION_STATUSES = new Set(["none", "notified"]);
 const VALID_SUBMISSION_STATUSES = new Set(["none", "submitted", "failed"]);
-const VALID_SUBMITTED_REVIEW_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
+// The canonical whitelist lives in copilot-helpers; alias kept to avoid call-site churn.
+const VALID_SUBMITTED_REVIEW_STATES = SUBMITTED_REVIEW_STATES;
 
 const SUPPORTED_REVIEW_ANGLES = Object.freeze([
   "correctness",

--- a/packages/core/test/submitted-review-states-agreement.test.mjs
+++ b/packages/core/test/submitted-review-states-agreement.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SUBMITTED_REVIEW_STATES, summarizeCopilotReviews } from "../src/github/copilot-helpers.mjs";
+import { summarizeCopilotLoopIterations } from "../src/loop/copilot-loop-iterations.mjs";
+import { normalizeReviewerSnapshot } from "../src/loop/reviewer-loop-state.mjs";
+
+// The submitted-review-state whitelist has one canonical declaration
+// (copilot-helpers). Both loop modules must consume THAT set, not a copy: a
+// state added to the canonical set becomes observable at each former call
+// site, which a drifted private copy would not show.
+test("the canonical SUBMITTED_REVIEW_STATES drives every former call site", (t) => {
+  assert.deepEqual([...SUBMITTED_REVIEW_STATES].sort(), ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
+
+  SUBMITTED_REVIEW_STATES.add("AGREEMENT_PROBE");
+  t.after(() => SUBMITTED_REVIEW_STATES.delete("AGREEMENT_PROBE"));
+
+  // reviewer-loop-state: the probe state normalizes instead of nulling out.
+  const snapshot = normalizeReviewerSnapshot({
+    prExists: true,
+    prNumber: 1,
+    submittedReviewState: "agreement_probe",
+  });
+  assert.equal(snapshot.submittedReviewState, "AGREEMENT_PROBE");
+
+  // copilot-loop-iterations: a review in the probe state counts as submitted.
+  const summary = summarizeCopilotLoopIterations({
+    reviewRequestEvents: [
+      { createdAt: "2026-05-01T09:59:00Z", requestedReviewerLogin: "copilot-pull-request-reviewer[bot]" },
+    ],
+    reviews: [
+      { state: "AGREEMENT_PROBE", submittedAt: "2026-05-01T10:05:00Z", authorLogin: "copilot-pull-request-reviewer[bot]", commitSha: "sha-1" },
+    ],
+    reviewComments: [],
+    commits: [],
+    reviewThreadSummary: {},
+  });
+  assert.equal(summary.completedCopilotReviewRounds, 1);
+
+  // copilot-helpers' own summarizer: the probe state counts as a completed round.
+  const helperSummary = summarizeCopilotReviews([
+    { state: "AGREEMENT_PROBE", submittedAt: "2026-05-01T10:05:00Z", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "sha-1" } },
+  ], { headSha: "sha-1" });
+  assert.equal(helperSummary.completedCopilotReviewRounds, 1);
+  assert.equal(helperSummary.hasSubmittedReviewOnCurrentHead, true);
+});

--- a/packages/core/test/submitted-review-states-agreement.test.mjs
+++ b/packages/core/test/submitted-review-states-agreement.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { SUBMITTED_REVIEW_STATES, summarizeCopilotReviews } from "../src/github/copilot-helpers.mjs";
@@ -6,10 +7,10 @@ import { summarizeCopilotLoopIterations } from "../src/loop/copilot-loop-iterati
 import { normalizeReviewerSnapshot } from "../src/loop/reviewer-loop-state.mjs";
 
 // The submitted-review-state whitelist has one canonical declaration
-// (copilot-helpers). Both loop modules must consume THAT set, not a copy: a
-// state added to the canonical set becomes observable at each former call
-// site, which a drifted private copy would not show.
-test("the canonical SUBMITTED_REVIEW_STATES drives every former call site", (t) => {
+// (copilot-helpers). The two importing loop modules and copilot-helpers' own
+// summarizer must all consume THAT set: a state added to it becomes observable
+// at each, which a drifted private copy would not show.
+test("the canonical SUBMITTED_REVIEW_STATES drives the three core call sites", (t) => {
   assert.deepEqual([...SUBMITTED_REVIEW_STATES].sort(), ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
 
   SUBMITTED_REVIEW_STATES.add("AGREEMENT_PROBE");
@@ -37,10 +38,20 @@ test("the canonical SUBMITTED_REVIEW_STATES drives every former call site", (t) 
   });
   assert.equal(summary.completedCopilotReviewRounds, 1);
 
-  // copilot-helpers' own summarizer: the probe state counts as a completed round.
+  // copilot-helpers' summarizer: pins that it keeps consuming the canonical
+  // set rather than growing back a private copy of its own.
   const helperSummary = summarizeCopilotReviews([
     { state: "AGREEMENT_PROBE", submittedAt: "2026-05-01T10:05:00Z", author: { login: "copilot-pull-request-reviewer[bot]" }, commit: { oid: "sha-1" } },
   ], { headSha: "sha-1" });
   assert.equal(helperSummary.completedCopilotReviewRounds, 1);
   assert.equal(helperSummary.hasSubmittedReviewOnCurrentHead, true);
+});
+
+// detect-reviewer-loop-state.mjs consumes the set inside a module-private gh
+// read the probe above cannot reach, so its call site is pinned at the source
+// level: it imports the canonical export and re-declares no state literal.
+test("detect-reviewer-loop-state consumes the canonical set, not a copy", async () => {
+  const source = await readFile(new URL("../../../scripts/loop/detect-reviewer-loop-state.mjs", import.meta.url), "utf8");
+  assert.match(source, /import \{ SUBMITTED_REVIEW_STATES \} from "@dev-loops\/core\/github\/copilot-helpers"/);
+  assert.doesNotMatch(source, /"APPROVED"\s*,/);
 });

--- a/packages/core/test/submitted-review-states-agreement.test.mjs
+++ b/packages/core/test/submitted-review-states-agreement.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { SUBMITTED_REVIEW_STATES, summarizeCopilotReviews } from "../src/github/copilot-helpers.mjs";
@@ -47,11 +46,6 @@ test("the canonical SUBMITTED_REVIEW_STATES drives the three core call sites", (
   assert.equal(helperSummary.hasSubmittedReviewOnCurrentHead, true);
 });
 
-// detect-reviewer-loop-state.mjs consumes the set inside a module-private gh
-// read the probe above cannot reach, so its call site is pinned at the source
-// level: it imports the canonical export and re-declares no state literal.
-test("detect-reviewer-loop-state consumes the canonical set, not a copy", async () => {
-  const source = await readFile(new URL("../../../scripts/loop/detect-reviewer-loop-state.mjs", import.meta.url), "utf8");
-  assert.match(source, /import \{ SUBMITTED_REVIEW_STATES \} from "@dev-loops\/core\/github\/copilot-helpers"/);
-  assert.doesNotMatch(source, /"APPROVED"\s*,/);
-});
+// The fourth consumer, scripts/loop/detect-reviewer-loop-state.mjs, is pinned
+// behaviorally in its own suite (test/loop/detect-reviewer-loop-state.test.mjs:
+// "counts only canonical submitted-review states").

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { SUBMITTED_REVIEW_STATES } from "@dev-loops/core/github/copilot-helpers";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import {
   interpretReviewerLoopState,
@@ -154,7 +155,7 @@ function isReviewInScope(review, reviewerLogin) {
   return login.toLowerCase() === reviewerLogin.toLowerCase();
 }
 function isSubmittedReviewState(state) {
-  return ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"].includes(state);
+  return SUBMITTED_REVIEW_STATES.has(state);
 }
 function pickLatestById(items) {
   if (!Array.isArray(items) || items.length === 0) return null;

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -154,9 +154,6 @@ function isReviewInScope(review, reviewerLogin) {
     : (typeof review?.author?.login === "string" ? review.author.login : "");
   return login.toLowerCase() === reviewerLogin.toLowerCase();
 }
-function isSubmittedReviewState(state) {
-  return SUBMITTED_REVIEW_STATES.has(state);
-}
 function pickLatestById(items) {
   if (!Array.isArray(items) || items.length === 0) return null;
   return items.filter(Boolean).slice().sort((a, b) => {
@@ -185,7 +182,7 @@ async function fetchReviewState({ repo, pr, reviewerLogin }, deps) {
     scoped.filter((review) => String(review?.state || "").toUpperCase() === "PENDING"),
   );
   const submittedReview = pickLatestById(
-    scoped.filter((review) => isSubmittedReviewState(String(review?.state || "").toUpperCase())),
+    scoped.filter((review) => SUBMITTED_REVIEW_STATES.has(String(review?.state || "").toUpperCase())),
   );
   return {
     draftReviewPosted: Boolean(pendingReview),

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -363,6 +363,49 @@ test.skip("detect-reviewer-loop-state auto-detect marks stale draft as review_in
   }
 });
 
+test("detect-reviewer-loop-state counts only canonical submitted-review states", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-states-"));
+
+  try {
+    const { env } = await writeGhStub(tempDir, [
+      {
+        assertArgs: ["pr", "view", "17", "--repo", "owner/repo"],
+        stdout: JSON.stringify({ isDraft: false, state: "OPEN", number: 17, headRefOid: "abc123" }) + "\n",
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+        stdout: '{"users":[],"teams":[]}\n',
+      },
+      {
+        assertArgs: ["api", "repos/owner/repo/pulls/17/reviews"],
+        stdout: JSON.stringify([
+          { id: 300, state: "NOT_A_REVIEW_STATE", user: { login: "pi-reviewer" }, commit_id: "abc123" },
+          { id: 301, state: "COMMENTED", user: { login: "pi-reviewer" }, commit_id: "abc123" },
+        ]) + "\n",
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "17",
+    ], { env });
+
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    // The whitelisted review counts as the submitted one; the unknown state never does.
+    assert.equal(output.snapshot.submittedReviewPresent, true);
+    assert.equal(output.snapshot.submittedReviewState, "COMMENTED");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-reviewer-loop-state auto-detect fails when gh stub call budget is exceeded", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reviewer-auto-budget-"));
 

--- a/test/loop/detect-reviewer-loop-state.test.mjs
+++ b/test/loop/detect-reviewer-loop-state.test.mjs
@@ -383,8 +383,11 @@ test("detect-reviewer-loop-state counts only canonical submitted-review states",
       {
         assertArgs: ["api", "repos/owner/repo/pulls/17/reviews"],
         stdout: JSON.stringify([
-          { id: 300, state: "NOT_A_REVIEW_STATE", user: { login: "pi-reviewer" }, commit_id: "abc123" },
-          { id: 301, state: "COMMENTED", user: { login: "pi-reviewer" }, commit_id: "abc123" },
+          // The non-canonical state gets the higher id: without the whitelist
+          // filter it would win pickLatestById, so this test fails if the
+          // filter is dropped.
+          { id: 300, state: "COMMENTED", user: { login: "pi-reviewer" }, commit_id: "abc123" },
+          { id: 301, state: "NOT_A_REVIEW_STATE", user: { login: "pi-reviewer" }, commit_id: "abc123" },
         ]) + "\n",
       },
     ]);


### PR DESCRIPTION
Closes #1503

## Summary

`SUBMITTED_REVIEW_STATES` (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`) was declared three times in core: the exported canonical set in `copilot-helpers.mjs` plus private copies in `copilot-loop-iterations.mjs` and `reviewer-loop-state.mjs`. The two private copies are deleted; both modules now import the canonical export.

## Scope and context

Two loop modules and one script swap a private declaration for an import. One new focused test file. No behavior change: the three sets were identical.

## Change

- `copilot-loop-iterations.mjs` imports `SUBMITTED_REVIEW_STATES` from `copilot-helpers.mjs`; the private declaration is deleted.
- `reviewer-loop-state.mjs` imports the same export and uses it directly at its single call site (no alias).
- `scripts/loop/detect-reviewer-loop-state.mjs` replaces its inline four-state array in `isSubmittedReviewState` with the canonical set.
- New `packages/core/test/submitted-review-states-agreement.test.mjs` pins the canonical content and proves all three former call sites observe a state added to the canonical set (reviewer snapshot normalization, `summarizeCopilotLoopIterations` round counting, `summarizeCopilotReviews` round counting); the fourth consumer `scripts/loop/detect-reviewer-loop-state.mjs` is pinned behaviorally by a new case in `test/loop/detect-reviewer-loop-state.test.mjs` (a non-canonical state ordered to win without the filter never counts as submitted; a canonical one does).

## Acceptance criteria

- [x] AC1 — `copilot-loop-iterations.mjs` and `reviewer-loop-state.mjs` import the set instead of declaring it.
- [x] AC2 — no module outside `copilot-helpers.mjs` declares the four-state set (repo-wide grep of non-test sources clean).
- [x] AC3 — a test pins that the three former call sites agree: adding a state to the canonical set is observable at each.

## Definition of done

- [x] Full verify green.
- [x] No behavior change (existing suites unchanged and green).

## AC/DoD/non-goals matrix

| Item | Type | Status | Evidence | Notes |
| --- | --- | --- | --- | --- |
| Both modules import the canonical set | AC1 | Met | diff of both modules; private consts deleted | no alias retained |
| No duplicate declaration repo-wide | AC2 | Met | repo-wide grep for the four-state literal across non-test sources: only copilot-helpers.mjs:13 | includes scripts/loop/detect-reviewer-loop-state.mjs consolidation |
| Agreement test across three call sites | AC3 | Met | submitted-review-states-agreement.test.mjs: probe state observed by snapshot normalization + both summarizers | probe removed via t.after |
| Full verify green | DoD | Met | all suites 0 failures | |
| No behavior change | DoD | Met | copilot-loop-iterations/reviewer-loop-state/copilot-helpers suites 85/85 | |
| No state-set semantics change | Non-goal | Respected | set content identical | |
| REVIEW_THREADS_QUERY stays out of core | Non-goal | Respected | untouched | |

## Non-goals

- Changing the set's content or the normalization semantics of any consumer.
- Moving `REVIEW_THREADS_QUERY` into core (tracked separately if a third consumer appears).

## Validation

`npm run verify` green. Direct: `node --test packages/core/test/submitted-review-states-agreement.test.mjs packages/core/test/copilot-loop-iterations.test.mjs packages/core/test/reviewer-loop-state.test.mjs packages/core/test/copilot-helpers.test.mjs`.
