### PR TITLE
ui-review: request-abort carve-out + pin PR head on provision

### DIFF
--- a/packages/core/src/loop/ui-review-drive.mjs
+++ b/packages/core/src/loop/ui-review-drive.mjs
@@ -44,6 +44,19 @@ export function isErrorResponseStatus(status) {
   return typeof status === "number" && (status < 200 || status >= 400);
 }
 
+/** The one owner of the request-abort carve-out: a request the browser itself
+ * aborted carries no defect signal. Navigating away cancels in-flight asset
+ * requests, so these appear on every multi-step flow. Matched per engine:
+ * WebKit reports "cancelled", Chromium "net::ERR_ABORTED", Firefox
+ * "NS_BINDING_ABORTED". Matching is case-insensitive and substring-based because
+ * engines wrap the token in longer text. A genuine DNS/connection/TLS failure
+ * carries a different token and is still classified must-fix. */
+export function isAbortedRequestFailure(failure) {
+  if (typeof failure !== "string") return false;
+  const f = failure.toLowerCase();
+  return f.includes("cancelled") || f.includes("canceled") || f.includes("err_aborted") || f.includes("ns_binding_aborted");
+}
+
 /** Bound the stack text carried onto a page-error failure so a runaway stack
  * (or a synthetic error with a huge stack) can't bloat the feed envelope. Keeps
  * the head — the top frames, where the throwing file:line sits. Exported so the
@@ -157,6 +170,16 @@ export function classifyFailures({
   }
 
   for (const f of requestFailures) {
+    // A request the BROWSER aborted is not evidence of a defect: navigating away
+    // cancels every asset request still in flight, so a flow with more than one
+    // `goto` manufactures one of these per unfinished image/font on the page it
+    // left. Measured on sofatutor 2026-08-05: a clean two-goto admin2 walk
+    // produced 13, all "cancelled", all classified must-fix — and since
+    // `ok: failures.length === 0`, they failed an otherwise passing drive and
+    // would have been posted as findings against the PR. This is the request-abort
+    // counterpart of the 3xx carve-out in isErrorResponseStatus: a real
+    // server/network fault still arrives with its own failure text and is kept.
+    if (isAbortedRequestFailure(f.failure)) continue;
     failures.push({
       kind: "request-failed",
       severity: MUST_FIX,

--- a/packages/core/src/loop/ui-review-provision.mjs
+++ b/packages/core/src/loop/ui-review-provision.mjs
@@ -37,6 +37,10 @@ const MUST_FIX = "must-fix";
  * @param {object} seams - Injected IO (all required except clock/log defaults).
  * @param {(a:{repoRoot:string,pr:number,branch?:string})=>Promise<{path:string,created:boolean,reused:boolean}>} seams.ensureWorktree
  * @param {(a:{worktreePath:string,repoRoot:string})=>{ok:boolean,message?:string,mainWorktreePath?:string|null}} seams.assertNotPrimary
+ * @param {(a:{worktreePath:string,repoRoot:string,pr:number})=>Promise<{ok:boolean,sha?:string|null,detail?:string}>} [seams.pinPrHead] -
+ *   Pin the worktree to the PR head and report the resolved SHA. Optional only
+ *   for back-compat: omitting it leaves the ref UNVERIFIED and is logged as such.
+ *   Runs after the primary-checkout guard, never before.
  * @param {(a:{repoRoot:string,worktreePath:string})=>Promise<{changed:boolean,detail:string}>} seams.detectDepDelta
  * @param {(a:{worktreePath:string})=>Promise<{ok:boolean,detail:string}>} seams.installDeps
  * @param {(worktreePath:string)=>Promise<object|null>} seams.resolveRunRecipe
@@ -58,6 +62,7 @@ export async function provisionAndBoot(
   {
     ensureWorktree,
     assertNotPrimary,
+    pinPrHead,
     detectDepDelta,
     installDeps,
     resolveRunRecipe,
@@ -109,6 +114,35 @@ export async function provisionAndBoot(
       { kind: "worktree-guard", severity: MUST_FIX, message: guard.message ?? "resolved worktree is the primary checkout" },
       { worktreePath },
     );
+  }
+
+  // 2b. Pin the worktree to the PR head, AFTER the primary-checkout guard above
+  //     (this checks out a ref, so it must never run in the primary checkout).
+  //     ensureWorktree's `branch` is a branch to CREATE off the default base when
+  //     no such local branch exists, so the default `pr-<n>` silently produces a
+  //     worktree sitting on origin/<default> — and provision used to return
+  //     ok:true for it, so every later stage reviewed the base branch as if it
+  //     were the PR head. Pin explicitly and record the resolved SHA.
+  let headSha = null;
+  if (pinPrHead) {
+    const pin = await pinPrHead({ worktreePath, repoRoot, pr });
+    if (!pin?.ok) {
+      return stop(
+        `cannot pin PR head: ${pin?.detail ?? "unknown failure"}`,
+        {
+          kind: "pr-head-unpinned",
+          severity: MUST_FIX,
+          message: `the worktree could not be pinned to PR #${pr}'s head, so it cannot be reviewed as that PR: ${pin?.detail ?? "unknown failure"}`,
+        },
+        { worktreePath },
+      );
+    }
+    headSha = pin.sha ?? null;
+    record(`worktree pinned to PR head ${headSha ?? "(sha unknown)"}${pin.detail ? ` (${pin.detail})` : ""}`);
+  } else {
+    // Never silent: a caller without the seam gets an unverified ref, which is
+    // exactly the failure mode this step exists to close.
+    record("WARNING: PR head not pinned (no pinPrHead seam) — worktree ref is UNVERIFIED");
   }
 
   // 3. Install only the dependency-lock delta vs. the primary checkout. No delta
@@ -256,6 +290,7 @@ export async function provisionAndBoot(
     worktreePath,
     created: wt.created,
     reused: wt.reused,
+    headSha,
     depInstall,
     migrations,
     boot: bootResult,

--- a/scripts/loop/ui-review-drive.mjs
+++ b/scripts/loop/ui-review-drive.mjs
@@ -29,7 +29,7 @@ import { parseArgs } from "node:util";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireTokenValue } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveUiReviewDriveRecipe } from "@dev-loops/core/config";
-import { driveUiReview, isErrorResponseStatus, PAGE_ERROR_STACK_MAX_CHARS, DRIVE_SESSION_HEADER } from "@dev-loops/core/loop/ui-review-drive";
+import { driveUiReview, isAbortedRequestFailure, isErrorResponseStatus, PAGE_ERROR_STACK_MAX_CHARS, DRIVE_SESSION_HEADER } from "@dev-loops/core/loop/ui-review-drive";
 import { captureNamedUiState, launchWebkit, toStopReason } from "./ui-review-capture.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -139,6 +139,11 @@ export function attachPageListeners(page) {
   page.on("requestfailed", (req) => {
     const url = typeof req.url === "function" ? req.url() : req.url;
     const failure = typeof req.failure === "function" ? req.failure()?.errorText : req.failure;
+    // Pre-filter browser-aborted requests here, mirroring the response listener's
+    // isErrorResponseStatus pre-filter above: bounds the buffer AND keeps
+    // navigation-cancelled assets out of each state's console.json, which shapes
+    // this same buffer. The classifier owns the policy (isAbortedRequestFailure).
+    if (isAbortedRequestFailure(failure)) return;
     requestFailures.push({ url, failure: failure ?? null });
   });
   page.on("pageerror", (err) => {

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -33,12 +33,15 @@ Required:
   --repo-root <p>                 Absolute path to the primary checkout.
   --pr <n>                        PR number whose head is provisioned.
 Optional:
-  --branch <name>                 Branch to check out (default: pr-<n>).
+  --branch <name>                 Branch used only to CREATE the worktree
+                                  (default: pr-<n>). The worktree is then pinned
+                                  DETACHED onto refs/pull/<n>/head regardless, so
+                                  this no longer decides which code is reviewed.
   --ack-destructive-migration     Acknowledge + unblock a destructive migration.
   -h, --help                      Show this help.
 Output (stdout, JSON):
   { "ok": bool, "stopped": bool, "stopReason": string|null,
-    "worktreePath": <p>, "depInstall": {...}, "migrations": {...},
+    "worktreePath": <p>, "headSha": <sha|null>, "depInstall": {...}, "migrations": {...},
     "boot": { "ready": bool, "attempts": n, ... }, "findings": [...], "logs": [...] }
 
 ${JQ_OUTPUT_USAGE}`.trim();
@@ -267,6 +270,43 @@ export function assertNotPrimary({ worktreePath, repoRoot }) {
   return { ok: true, mainWorktreePath };
 }
 
+/** Pin the worktree to the PR head via the origin's `refs/pull/<n>/head`.
+ *
+ * DETACHED on purpose. `ensureWorktree` takes a branch NAME, and git refuses to
+ * check out one branch in two worktrees at once — so re-attaching fails exactly
+ * when the primary checkout already holds the PR branch, which is the common
+ * case right after a `gh pr checkout`. A review never needs a branch, only the
+ * commit. Fetching `refs/pull/<n>/head` also covers fork PRs, whose head branch
+ * does not exist on origin at all.
+ *
+ * No `--force`: a checkout that would clobber real modifications fails closed
+ * with git's own reason instead of silently discarding someone's work. The
+ * gitignored files ensureWorktree provisions (database.yml, node_modules links)
+ * do not block a checkout.
+ *
+ * Exported for direct testing.
+ */
+export async function pinPrHead({ worktreePath, pr }) {
+  const git = (args) => execFileSync("git", args, { cwd: worktreePath, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  const reason = (err) => (err.stderr ?? err.message ?? "").toString().trim();
+  const ref = `refs/dev-loops/pr-${pr}/head`;
+  try {
+    git(["fetch", "--quiet", "origin", `+refs/pull/${pr}/head:${ref}`]);
+  } catch (err) {
+    return { ok: false, detail: `git fetch refs/pull/${pr}/head failed: ${reason(err)}` };
+  }
+  try {
+    git(["checkout", "--detach", ref]);
+  } catch (err) {
+    return { ok: false, detail: `git checkout --detach ${ref} failed: ${reason(err)}` };
+  }
+  try {
+    return { ok: true, sha: git(["rev-parse", "HEAD"]).trim(), detail: `detached at refs/pull/${pr}/head` };
+  } catch (err) {
+    return { ok: false, detail: `git rev-parse HEAD failed: ${reason(err)}` };
+  }
+}
+
 export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
   const options = parseUiReviewProvisionCliArgs(argv);
   if (options.help) {
@@ -283,6 +323,7 @@ export async function runCli(argv = process.argv.slice(2), { stdout = process.st
     {
       ensureWorktree: (a) => ensureWorktree(a).then((r) => ({ path: r.path, created: r.created, reused: r.reused })),
       assertNotPrimary,
+      pinPrHead,
       detectDepDelta,
       installDeps,
       resolveRunRecipe,

--- a/scripts/loop/ui-review-provision.mjs
+++ b/scripts/loop/ui-review-provision.mjs
@@ -35,7 +35,7 @@ Required:
 Optional:
   --branch <name>                 Branch used only to CREATE the worktree
                                   (default: pr-<n>). The worktree is then pinned
-                                  DETACHED onto refs/pull/<n>/head regardless, so
+                                  DETACHED onto a local mirror of refs/pull/<n>/head regardless, so
                                   this no longer decides which code is reviewed.
   --ack-destructive-migration     Acknowledge + unblock a destructive migration.
   -h, --help                      Show this help.
@@ -301,7 +301,7 @@ export async function pinPrHead({ worktreePath, pr }) {
     return { ok: false, detail: `git checkout --detach ${ref} failed: ${reason(err)}` };
   }
   try {
-    return { ok: true, sha: git(["rev-parse", "HEAD"]).trim(), detail: `detached at refs/pull/${pr}/head` };
+    return { ok: true, sha: git(["rev-parse", "HEAD"]).trim(), detail: `detached at refs/dev-loops/pr-${pr}/head (mirrors refs/pull/${pr}/head)` };
   } catch (err) {
     return { ok: false, detail: `git rev-parse HEAD failed: ${reason(err)}` };
   }

--- a/test/loop/ui-review-drive.test.mjs
+++ b/test/loop/ui-review-drive.test.mjs
@@ -10,6 +10,7 @@ import {
   selectFlows,
   classifyFailures,
   driveUiReview,
+  isAbortedRequestFailure,
   isErrorResponseStatus,
   PAGE_ERROR_STACK_MAX_CHARS,
 } from "@dev-loops/core/loop/ui-review-drive";
@@ -208,6 +209,44 @@ test("classifyFailures: a requestFailure becomes request-failed and a pageError 
   assert.match(byKind["page-error"].message, /uncaught page error: TypeError: boom/);
   // Stage 3 exception -> source-line mapping needs the stack on the feed entry.
   assert.match(byKind["page-error"].stack, /at app\.js:42:9/);
+});
+
+// Navigating away cancels in-flight asset requests, so a multi-goto flow emits one
+// requestfailed per unfinished image/font on the page it left. Those carried
+// severity must-fix and, since `ok: failures.length === 0`, failed an otherwise
+// clean drive — a real sofatutor two-goto admin2 walk produced 13, all "cancelled".
+test("classifyFailures: browser-aborted requests are not failures, real request failures still are", () => {
+  const failures = classifyFailures({
+    requestFailures: [
+      { url: "http://x/a.svg", failure: "cancelled" },
+      { url: "http://x/b.svg", failure: "net::ERR_ABORTED" },
+      { url: "http://x/c.svg", failure: "NS_BINDING_ABORTED" },
+      { url: "http://x/d.svg", failure: "net::ERR_CONNECTION_REFUSED" },
+    ],
+  });
+  assert.equal(failures.length, 1, "only the connection-refused failure survives");
+  assert.equal(failures[0].url, "http://x/d.svg");
+  assert.equal(failures[0].severity, "must-fix");
+});
+
+test("isAbortedRequestFailure: matches every engine's abort token, ignores non-strings and real faults", () => {
+  for (const token of ["cancelled", "Cancelled", "canceled", "net::ERR_ABORTED", "NS_BINDING_ABORTED"]) {
+    assert.equal(isAbortedRequestFailure(token), true, `${token} must count as aborted`);
+  }
+  for (const token of ["net::ERR_CONNECTION_REFUSED", "net::ERR_NAME_NOT_RESOLVED", "", null, undefined, 42]) {
+    assert.equal(isAbortedRequestFailure(token), false, `${String(token)} must not count as aborted`);
+  }
+});
+
+test("attachPageListeners: an aborted request never enters the buffer, so console.json stays clean too", () => {
+  const handlers = {};
+  const page = { on: (evt, fn) => { handlers[evt] = fn; } };
+  const { getCapturedEvents } = attachPageListeners(page);
+  handlers.requestfailed({ url: () => "http://app/late.svg", failure: () => ({ errorText: "cancelled" }) });
+  handlers.requestfailed({ url: () => "http://app/gone.svg", failure: () => ({ errorText: "net::ERR_CONNECTION_REFUSED" }) });
+  assert.deepEqual(getCapturedEvents().requestFailures, [
+    { url: "http://app/gone.svg", failure: "net::ERR_CONNECTION_REFUSED" },
+  ]);
 });
 
 test("classifyFailures: page-error stack is null when absent and bounded when huge", () => {

--- a/test/loop/ui-review-provision.test.mjs
+++ b/test/loop/ui-review-provision.test.mjs
@@ -133,6 +133,54 @@ function baseSeams(root, overrides = {}) {
   };
 }
 
+// ensureWorktree's `branch` is a branch to CREATE off the default base when no
+// such local branch exists, so the default `pr-<n>` yielded a worktree sitting on
+// origin/main while provision returned ok:true — every later stage then reviewed
+// the base branch as if it were the PR head. The pin must be authoritative.
+test("pinPrHead: a pin failure stops the route with a must-fix finding (never reviews an unpinned ref)", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  let booted = false;
+  const { seams } = baseSeams(root, {
+    pinPrHead: async () => ({ ok: false, detail: "refs/pull/9/head not found on origin" }),
+    bootApp: async () => { booted = true; return { pid: 1, detail: "spawned" }; },
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 9 }, seams);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.stopped, true);
+  assert.match(result.stopReason, /cannot pin PR head: refs\/pull\/9\/head not found on origin/);
+  assert.equal(result.findings[0].kind, "pr-head-unpinned");
+  assert.equal(result.findings[0].severity, "must-fix");
+  assert.equal(booted, false, "must not boot an app on an unverified ref");
+});
+
+test("pinPrHead: the resolved head SHA is recorded on the envelope and logged", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  const { seams, logs } = baseSeams(root, {
+    pinPrHead: async () => ({ ok: true, sha: "deadbeef", detail: "detached at refs/pull/9/head" }),
+    probe: async () => true,
+  });
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 9 }, seams);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.headSha, "deadbeef");
+  assert.ok(logs.some((l) => /pinned to PR head deadbeef/.test(l)));
+});
+
+test("pinPrHead: an absent seam leaves the ref unverified and says so out loud", async () => {
+  const root = makeFixture(RECIPE_YAML);
+  const { seams, logs } = baseSeams(root, { probe: async () => true });
+  delete seams.pinPrHead;
+
+  const result = await provisionAndBoot({ repoRoot: "/main", pr: 9 }, seams);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.headSha, null);
+  assert.ok(logs.some((l) => /UNVERIFIED/.test(l)), "an unpinned ref must never be silent");
+});
+
 test("parseUiReviewProvisionCliArgs: requires --repo-root and --pr", () => {
   assert.throws(() => parseUiReviewProvisionCliArgs(["--pr", "5"]), /repo-root/);
   assert.throws(() => parseUiReviewProvisionCliArgs(["--repo-root", "/r"]), /--pr/);


### PR DESCRIPTION
## Summary

Turns the captured ui-review request-abort carve-out (found as uncommitted local mods in the installed package) into a proper branch/PR. Resolves #1594.

## What changed

**Request-abort carve-out (`ui-review-drive.mjs`)**

Navigating away cancels in-flight asset requests, so every multi-step ui-review flow manufactured one `requestfailed` per unfinished image/font on the page it left. Those carried `must-fix` severity and, since `ok: failures.length === 0`, failed an otherwise clean drive (a real two-goto admin walk produced 13, all `cancelled`).

`isAbortedRequestFailure(failure)` matches the browser-abort token per engine, case-insensitive substring:

- WebKit → `cancelled` (also `canceled`)
- Chromium → `net::ERR_ABORTED`
- Firefox → `NS_BINDING_ABORTED`

A genuine DNS/connection/TLS failure carries a different token (`net::ERR_CONNECTION_REFUSED`, `net::ERR_NAME_NOT_RESOLVED`, …) and is still classified `must-fix`. This is the request-abort counterpart of the existing 3xx carve-out in `isErrorResponseStatus`.

Applied in two places:
- the classify loop (`classifyFailures`) — the policy owner
- a pre-filter in `attachPageListeners`'s `requestfailed` listener, mirroring the response listener's `isErrorResponseStatus` pre-filter, so the captured `console.json` buffer stays clean too

**Pin PR head on provision (`ui-review-provision.mjs`)**

`ensureWorktree`'s `branch` is a branch to *create* off the default base when no such local branch exists, so the default `pr-<n>` silently produced a worktree sitting on `origin/main` while provision returned `ok:true`. The worktree is now pinned **detached** onto a local mirror of `refs/pull/<n>/head` after the primary-checkout guard:

- a pin failure stops the route with a `must-fix` `pr-head-unpinned` finding (never reviews an unverified ref)
- the resolved head SHA is recorded on the envelope and logged
- an absent `pinPrHead` seam leaves the ref unverified and logs that out loud (never silent)

## Acceptance criteria

- [x] The patch applies cleanly on a worktree branched from `origin/main`.
- [x] Browser-aborted requests (`cancelled`/`ERR_ABORTED`/`NS_BINDING_ABORTED`) do NOT classify as must-fix defects; genuine DNS/connection/TLS failures still do.
- [x] Tests pass (`test/loop/ui-review-drive.test.mjs`, `test/loop/ui-review-provision.test.mjs`).
- [x] `npm run verify` introduces zero new failures vs baseline.
- [x] PR created, gates clean, merged.

## AC / DoD / non-goals matrix

| Acceptance criterion | Definition of done | Non-goals |
| --- | --- | --- |
| Patch applies cleanly on `origin/main` worktree | Carve-out merged to main as a proper PR | Changing the ui-review flow beyond the abort carve-out |
| Browser-aborted requests not must-fix; real faults still are | Installed package refreshable clean to main without losing work | Refreshing the installed package itself (separate step) |
| Focused tests pass (drive + provision) | Tests added/updated for abort carve-out + pin behavior | — |
| `npm run verify` zero new failures vs baseline | Validation confirms no regressions vs `origin/main` | — |
| PR created, gates clean, merged | Gates clean (draft + pre-approval); merged | — |

## Validation

- Focused tests pass: `node --test test/loop/ui-review-drive.test.mjs test/loop/ui-review-provision.test.mjs` (71/71)
- `npm run verify`: zero new failures vs `origin/main` baseline (failure sets identical with patch stashed vs applied; pre-existing Node 26 env-specific failures unaffected)
- `assets:check` passes (91 checked)
- CI green on current head (`verify` + `verify-suite`; `gate-evidence` excluded by #1531 loop-safe rollup)

## Non-goals

- Changing the ui-review flow beyond the abort carve-out.
- Refreshing the installed package itself (separate step after merge).

Closes #1594
