### PR TITLE
test(packaged-install): cover queue sync-status regression (#1555)

### DIFF
--- a/test/packaged-install-smoke.test.mjs
+++ b/test/packaged-install-smoke.test.mjs
@@ -131,6 +131,13 @@ test("packaged install: every @dev-loops/core export resolves and the queue CLIs
       // upsert-checkpoint-verdict.mjs) from the installed tarball — no other
       // entry above loads that import graph.
       ["gate", "consolidate-fanin", "--help"],
+      // Regression for issue #1555: `queue sync-status` loads
+      // scripts/projects/sync-item-status.mjs -> @dev-loops/core/loop/queue-board-sync
+      // -> ../projects/move-queue-item.mjs. The pre-#1243 import escaped to
+      // ../../../../scripts/projects/move-queue-item.mjs and ERR_MODULE_NOT_FOUND'd
+      // from the installed tarball; this --help resolves that full chain from the
+      // installed tree so a re-escape is caught here, not in a published release.
+      ["queue", "sync-status", "--help"],
     ]) {
       // execFileSync throws on a non-zero exit, so reaching here already means
       // the command succeeded; additionally assert it printed real help (a


### PR DESCRIPTION
## Summary

Closes #1555

The published `dev-loops@1.0.0-rc.4` CLI crashed on `queue sync-status` with `ERR_MODULE_NOT_FOUND`: `@dev-loops/core/src/loop/queue-board-sync.mjs` imported `move-queue-item.mjs` via a path that escaped the package boundary and resolved to `node_modules/scripts/projects/move-queue-item.mjs` in the installed layout.

The escaping import was fixed in #1243 (`../../../../scripts/projects/move-queue-item.mjs` → `../projects/move-queue-item.mjs`, moving the mover logic inside `@dev-loops/core`), which also added the `no-package-escaping-imports` contract test and the `packaged-install-smoke`. But the packaged-install smoke never exercised `queue sync-status` — the exact entrypoint that broke. This PR closes that gap.

## Changes

- Add `queue sync-status --help` to the `packaged-install-smoke` args list. This resolves the full import chain (`scripts/projects/sync-item-status.mjs` → `@dev-loops/core/loop/queue-board-sync` → `../projects/move-queue-item.mjs`) from an installed tarball, so a re-escape of the core → `scripts/` boundary fails this packaged-install test rather than a published release.

## Acceptance criteria

- [x] `npx dev-loops queue sync-status --repo <o/r> --item <n> --to-column <c>` works from a global/npx install (no ERR_MODULE_NOT_FOUND) — verified by the packaged-install smoke, which packs, installs in a fresh dir, and runs `queue sync-status --help` from the installed tree.
- [x] No `@dev-loops/core` module imports from the repo-root `scripts/` tree — the `no-package-escaping-imports` contract test enforces this statically (and catches the pre-#1243 escaping import if reintroduced).
- [x] A packaged-install test fails if a core module resolves a repo-root `scripts/` path again — the new smoke entry covers the `queue sync-status` chain end-to-end from the installed tarball; the contract test covers the generic boundary.

## Definition of done

- [x] Contract tests green (`test:doc-guard` — 247 pass).
- [x] `packaged-install-smoke` green with the new entry.
