### PR TITLE
fix(gate): track unparseable findings so a blocking severity cannot pass the clean-verdict cross-check (#1526)

### DIFF
--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -113,7 +113,21 @@ Required:
                                             "operator_acknowledged"; every other
                                             disposition (missing, "accepted-for-fix",
                                             "deferred", "needs-answer", or an unrecognized string)
-                                            still trips this check.
+                                            still trips this check. A finding the
+                                            normalizer cannot interpret (no usable
+                                            summary, or not an object) is never
+                                            dropped: it is tallied as UNPARSEABLE
+                                            and counts toward this clean-verdict
+                                            check on its severity alone (no
+                                            disposition to resolve against), so a
+                                            blocking severity cannot pass silently
+                                            by being unparseable (#1526). The
+                                            resolved-disposition rule above and
+                                            this tally operate on the same
+                                            representation, where "could not
+                                            interpret this finding" is
+                                            distinguishable from "this finding is
+                                            not blocking".
   --next-action <text>
 Optional:
   --findings-ledger <path>                  Path to this round's
@@ -711,21 +725,62 @@ function looksLikeFlatFinding(item) {
 // rendered under a `general` fallback label (consistent with the flat-grouping
 // angleless→`general` bucket). Dropping it would let a non-empty structured
 // payload silently degrade to the free-text path and hide findings.
+//
+// A finding that normalization CANNOT interpret (no usable summary, or not an
+// object) is NEVER silently dropped (#1526): it is tracked on the section's
+// `unparseable` list so the clean-verdict cross-check can still see a blocking
+// severity it carries, and the rendered comment can surface it explicitly as
+// unparseable. The tally must operate on a representation where "could not
+// interpret this finding" is distinguishable from "this finding is not
+// blocking" — a dropped finding is neither, so it is kept here. The severity is
+// the one field read straight off the raw finding (when present) so the
+// cross-check can decide blocking without broadening what normalizeStructuredFinding
+// accepts (the non-goal: the question is what happens to what it rejects, not
+// whether it should reject less).
 function buildAngleSectionFromNested(raw) {
   const trimmedAngle = typeof raw.angle === "string" ? raw.angle.trim() : "";
   const angle = trimmedAngle.length > 0 ? trimmedAngle : "general";
   const findings = [];
+  const unparseable = [];
   for (const f of raw.findings) {
     const entry = normalizeStructuredFinding(f);
     if (entry) {
       findings.push(entry);
+    } else if (f !== undefined) {
+      // normalizeStructuredFinding rejected this entry (no usable summary, or
+      // not an object). A bare `null` still counts: something occupied a
+      // findings slot the guard cannot interpret, and dropping it silently is
+      // exactly the fail-open this list exists to close. `undefined` (a sparse
+      // array hole) is the one non-finding value skipped, since nothing was
+      // emitted there at all.
+      unparseable.push({ severity: readRawSeverity(f) });
+    }
+  }
+  // renderGateReviewCommentBody re-normalizes an already-normalized section
+  // (its structuredFindings argument); preserve any unparseable entries carried
+  // on the input so re-normalization can never silently re-drop them (#1526).
+  if (Array.isArray(raw.unparseable)) {
+    for (const u of raw.unparseable) {
+      if (u && typeof u === "object") unparseable.push({ severity: u.severity ?? "" });
     }
   }
   sortStructuredFindings(findings);
   const verdict = typeof raw.verdict === "string" && raw.verdict.trim().length > 0
     ? raw.verdict.trim()
-    : (findings.length > 0 ? "findings_present" : "clean");
-  return { angle, verdict, findings };
+    : (findings.length > 0 || unparseable.length > 0 ? "findings_present" : "clean");
+  return { angle, verdict, findings, unparseable };
+}
+// Read the severity off a raw finding the normalizer rejected, so the
+// clean-verdict cross-check can still decide whether an unparseable finding
+// carries a blocking severity (#1526). Returns the normalized severity string
+// (or "" when none is readable); an unknown/typo'd value normalizes to itself
+// and then matches no blocking severity, same as a parseable unknown severity.
+function readRawSeverity(f) {
+  if (!f || typeof f !== "object") return "";
+  if (typeof f.severity === "string" && f.severity.trim().length > 0) {
+    return /** @type {string} */ (normalizeSeverity(f.severity.trim()));
+  }
+  return "";
 }
 // Group a FLAT per-finding array into per-angle sections, keyed by each
 // finding's `.angle` field (findings without an angle are grouped under a
@@ -755,6 +810,12 @@ function groupFlatFindingsByAngle(input) {
       angle,
       verdict: findings.length > 0 ? "findings_present" : "clean",
       findings,
+      // Flat per-finding input that lacks a usable summary is rejected by
+      // normalizeStructuredFindings' unrecognized-item guard before this grouping
+      // runs, so a flat section never carries an unparseable entry. Kept as an
+      // empty array so the section shape matches the nested path and consumers
+      // can read `angle.unparseable` uniformly (#1526).
+      unparseable: [],
     });
   }
   return angles;
@@ -850,7 +911,7 @@ export function normalizeStructuredFindings(input) {
 // it (see consolidate-fanin.mjs's fitsRenderBudget).
 export function renderStructuredFindings(angles) {
   const lines = [];
-  for (const { angle, verdict, findings } of angles) {
+  for (const { angle, verdict, findings, unparseable } of angles) {
     // severity/verdict/disposition are enum labels, never prose — rendered
     // inside a backtick code span (like the angle label and file ref already
     // are) rather than bare, so a reviewer-supplied value crafted to look like
@@ -876,6 +937,15 @@ export function renderStructuredFindings(angles) {
         : "";
       lines.push(`  - [\`${severity}\`] ${summary}${location}${dispositionSuffix}`);
     }
+    // A finding the normalizer could not interpret is reported explicitly as
+    // unparseable — never dropped (#1526). Its severity (when readable) is
+    // rendered so a reader can see whether it sat at a blocking severity;
+    // the `unparseable` label itself distinguishes "could not interpret this
+    // finding" from a normal `[severity]` finding that is simply not blocking.
+    for (const u of unparseable ?? []) {
+      const sev = sanitizeStructuredCodeSpan(u.severity) || "none";
+      lines.push(`  - [\`unparseable\`] finding could not be interpreted (severity: \`${sev}\` — counted toward the clean-verdict tally, not dropped)`);
+    }
   }
   return enforcePostedCommentLimit(lines.join("\n"), MAX_GATE_COMMENT_TEXT_LENGTH, "--findings-json structured findings render");
 }
@@ -887,8 +957,12 @@ export function renderStructuredFindings(angles) {
 // budget the way a full breakdown can.
 export function renderAngleVerdictDigest(angles) {
   return angles
-    .map(({ angle, verdict, findings }) => {
-      const count = findings.length;
+    .map(({ angle, verdict, findings, unparseable }) => {
+      // An unparseable finding still occupies a finding slot, so it counts
+      // toward the per-angle total — otherwise the digest would undercount a
+      // round that the clean-verdict tally and the rendered breakdown both see
+      // (#1526).
+      const count = findings.length + (Array.isArray(unparseable) ? unparseable.length : 0);
       const suffix = count === 0 ? "" : ` (${count} finding${count === 1 ? "" : "s"})`;
       return `- \`${sanitizeStructuredCodeSpan(angle)}\` → \`${sanitizeStructuredCodeSpan(verdict)}\`${suffix}`;
     })
@@ -918,7 +992,10 @@ export function renderAngleVerdictDigest(angles) {
 // breakdown below it still lists real findings. Only known severity keys are
 // summed — an unrecognized/typo'd key must not inflate the posted total.
 function buildStructuredFindingsDigest(angles, severityCounts) {
-  const angleTotal = angles.reduce((sum, a) => sum + a.findings.length, 0);
+  // Unparseable findings occupy a finding slot too, so they count toward the
+  // per-angle total — the digest must not undercount a round whose tally and
+  // rendered breakdown both see the unparseable entries (#1526).
+  const angleTotal = angles.reduce((sum, a) => sum + a.findings.length + (Array.isArray(a.unparseable) ? a.unparseable.length : 0), 0);
   const countedTotal = severityCounts && typeof severityCounts === "object" && !Array.isArray(severityCounts)
     ? Object.entries(severityCounts).reduce((sum, [key, n]) => {
         // Keys normalize through the legacy alias map so a "defer"-keyed count
@@ -1464,6 +1541,14 @@ function roundCarriesBlockingSeverity({ verdict, structuredFindings, findingsSev
         if (RESOLVED_DISPOSITIONS.has(f.disposition)) continue;
         if (blocking.includes(/** @type {string} */ (normalizeSeverity(f.severity)))) return true;
       }
+      // An unparseable finding carries no disposition to resolve against, so
+      // it is judged on its severity alone — the same representation the
+      // clean-verdict tally uses, so an inline round that surfaces an
+      // unparseable blocking finding escalates gate:full just as it would
+      // block a clean verdict (#1526).
+      for (const u of angle.unparseable ?? []) {
+        if (blocking.includes(/** @type {string} */ (normalizeSeverity(u.severity)))) return true;
+      }
     }
     return false;
   }
@@ -1837,11 +1922,26 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     && activeGateConfig.blockCleanOnFindingSeverities.length > 0
   ) {
     const observedCounts = Object.fromEntries(SEVERITY_ORDER.map((sev) => [sev, 0]));
+    // Track whether any blocking-severity hit came from an UNPARSEABLE finding,
+    // so the refusal message can name the real cause (#1526): a finding the
+    // normalizer dropped used to pass this cross-check silently; now it is
+    // tallied from the section's `unparseable` list and fails the verdict
+    // exactly as a parseable blocking finding would. An unparseable finding
+    // carries no disposition to resolve against, so it is judged on its
+    // severity alone — a blocking severity fails, any other value (including
+    // none at all) is reported explicitly as unparseable in the rendered
+    // comment rather than blocking the clean verdict.
+    let unparseableBlocking = false;
     for (const angle of structuredFindings) {
       for (const f of angle.findings) {
         if (RESOLVED_DISPOSITIONS.has(f.disposition)) continue;
         const sev = /** @type {string} */ (normalizeSeverity(f.severity));
         if (Object.hasOwn(observedCounts, sev)) observedCounts[sev] += 1;
+      }
+      for (const u of angle.unparseable ?? []) {
+        const sev = /** @type {string} */ (normalizeSeverity(u.severity));
+        if (Object.hasOwn(observedCounts, sev)) observedCounts[sev] += 1;
+        if (activeGateConfig.blockCleanOnFindingSeverities.includes(sev)) unparseableBlocking = true;
       }
     }
     const blockingObserved = activeGateConfig.blockCleanOnFindingSeverities.filter(
@@ -1849,7 +1949,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     );
     if (blockingObserved.length > 0) {
       throw new Error(
-        `Cannot set verdict "clean" for ${options.gate}: --findings-json's own per-angle findings show unresolved findings at blocking severities [${blockingObserved.join(", ")}], regardless of --findings-severity-counts. Fix these findings and re-gate before declaring clean.`,
+        `Cannot set verdict "clean" for ${options.gate}: --findings-json's own per-angle findings show unresolved findings at blocking severities [${blockingObserved.join(", ")}], regardless of --findings-severity-counts.${unparseableBlocking ? " At least one of these is an UNPARSEABLE finding (no usable summary) the normalizer would otherwise have dropped silently (#1526)." : ""} Fix these findings and re-gate before declaring clean.`,
       );
     }
   }

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -759,9 +759,14 @@ function buildAngleSectionFromNested(raw) {
   // renderGateReviewCommentBody re-normalizes an already-normalized section
   // (its structuredFindings argument); preserve any unparseable entries carried
   // on the input so re-normalization can never silently re-drop them (#1526).
+  // The severity is re-read through readRawSeverity (not copied verbatim) so a
+  // non-string severity on a hand-crafted/producer-drift section is coerced to
+  // the same canonical vocabulary first-creation uses — never carried as a
+  // non-string that normalizeSeverity would skip and the renderer would emit as
+  // `[object Object]` (Copilot review feedback on #1526).
   if (Array.isArray(raw.unparseable)) {
     for (const u of raw.unparseable) {
-      if (u && typeof u === "object") unparseable.push({ severity: u.severity ?? "" });
+      if (u && typeof u === "object") unparseable.push({ severity: readRawSeverity(u) });
     }
   }
   sortStructuredFindings(findings);

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -1192,7 +1192,7 @@ export async function consolidateGateFanin(options) {
       // review at this head) so a reader of --out/the emitted result — not
       // just the ledger's provenance.perAngle — can tell carried from fresh.
       // upsert-checkpoint-verdict.mjs's buildAngleSectionFromNested only reads
-      // angle/verdict/findings, so this extra field never affects the
+      // angle/verdict/findings/unparseable, so this extra field never affects the
       // rendered gate comment.
       ...(typeof a.carriedFromHead === "string" ? { carriedFromHead: a.carriedFromHead } : {}),
     };

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2530,6 +2530,172 @@ test("upsert-checkpoint-verdict rejects a clean verdict whose only blocking-seve
   }
 });
 
+// ---------------------------------------------------------------------------
+// #1526 (variant 3): normalizeStructuredFinding returns null for a finding it
+// cannot interpret (no usable summary, or not an object). The clean-verdict
+// cross-check tallies the NORMALIZED findings, so a dropped finding was
+// invisible to the guard — a blocking severity could pass silently by being
+// unparseable rather than by being absent. The fix tracks such findings as
+// UNPARSEABLE on the per-angle section and tallies them on their severity
+// alone (no disposition to resolve against), so a blocking severity fails the
+// clean verdict and a non-blocking one is reported explicitly as unparseable
+// rather than dropped. These tests fail if the guard reverts to dropping.
+// ---------------------------------------------------------------------------
+
+test("normalizeStructuredFindings tracks an unparseable finding (no summary) on the section instead of dropping it (#1526)", () => {
+  const angles = normalizeStructuredFindings([
+    { angle: "correctness", verdict: "findings_present", findings: [{ severity: "must-fix", summary: "real finding" }, { severity: "must-fix" }] },
+    { angle: "pr-description", verdict: "clean", findings: [] },
+  ]);
+  // The parseable finding is still rendered; the summary-less one is NOT dropped.
+  assert.equal(angles[0].findings.length, 1);
+  assert.equal(angles[0].findings[0].summary, "real finding");
+  assert.ok(Array.isArray(angles[0].unparseable));
+  assert.equal(angles[0].unparseable.length, 1);
+  // The severity is read off the raw finding so the tally can decide blocking.
+  assert.equal(angles[0].unparseable[0].severity, "high"); // "must-fix" normalizes to "high"
+  // A flat section (no nested findings path) still carries the uniform shape.
+  assert.ok(Array.isArray(angles[1].unparseable));
+  assert.equal(angles[1].unparseable.length, 0);
+});
+
+test("normalizeStructuredFindings tracks a non-object finding entry as unparseable instead of dropping it (#1526)", () => {
+  const angles = normalizeStructuredFindings([
+    { angle: "correctness", verdict: "findings_present", findings: ["bogus", null, { severity: "nice-to-have" }] },
+  ]);
+  assert.equal(angles[0].findings.length, 0);
+  assert.equal(angles[0].unparseable.length, 3);
+  // A non-object and null carry no readable severity; an object without summary
+  // still exposes its severity.
+  assert.equal(angles[0].unparseable[0].severity, "");
+  assert.equal(angles[0].unparseable[1].severity, "");
+  assert.equal(angles[0].unparseable[2].severity, "low"); // "nice-to-have" -> "low"
+});
+
+test("normalizeStructuredFindings preserves unparseable entries through render's re-normalization (#1526)", () => {
+  // renderGateReviewCommentBody re-normalizes an already-normalized section;
+  // the unparseable list must survive that pass or the rendered body re-drops it.
+  const angles = normalizeStructuredFindings([
+    { angle: "correctness", verdict: "findings_present", findings: [{ severity: "must-fix" }] },
+  ]);
+  const body = renderGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234000000000000000000000000000000000",
+    verdict: "findings_present",
+    findingsSummary: "ignored",
+    nextAction: "fix",
+    executionMode: "fanout_fanin",
+    structuredFindings: angles,
+  });
+  assert.match(body, /\[`unparseable`\]/);
+  assert.match(body, /severity: `high`/);
+});
+
+test("renderGateReviewCommentBody reports an unparseable finding explicitly in the per-angle breakdown (#1526)", () => {
+  const angles = normalizeStructuredFindings([
+    { angle: "correctness", verdict: "findings_present", findings: [{ severity: "nice-to-have", summary: "ok" }, { severity: "nice-to-have" }] },
+  ]);
+  const body = renderGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234000000000000000000000000000000000",
+    verdict: "findings_present",
+    findingsSummary: "ignored",
+    nextAction: "fix",
+    executionMode: "fanout_fanin",
+    structuredFindings: angles,
+  });
+  // The unparseable entry is distinguishable from a non-blocking parseable finding.
+  assert.match(body, /\[`unparseable`\] finding could not be interpreted/);
+  assert.match(body, /severity: `low`/);
+  // The digest counts the unparseable finding so it is not undercounted.
+  assert.match(body, /1 angle reviewed; 2 findings/);
+});
+
+test("upsert-checkpoint-verdict rejects a clean verdict whose --findings-json carries an unparseable finding at a blocking severity (no summary) (#1526)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-clean-unparseable-blocking-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        {
+          angle: "correctness",
+          verdict: "findings_present",
+          // No `summary` -> normalizeStructuredFinding returns null -> formerly dropped.
+          findings: [{ severity: "must-fix" }],
+        },
+        { angle: "pr-description", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, buildGateCoordinationEntries({
+      isDraft: true,
+      statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+    }));
+
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "clean", "--findings-json", findingsPath,
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"nice-to-have":0}',
+      "--next-action", "mark ready for review", "--execution-mode", "fanout_fanin",
+    ], { env });
+
+    assert.equal(result.code, 1);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Cannot set verdict "clean"/);
+    assert.match(payload.error, /blocking severities \[high\]/);
+    assert.match(payload.error, /UNPARSEABLE/i);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict allows a clean verdict whose --findings-json carries an unparseable finding WITHOUT a blocking severity, and reports it as unparseable (#1526)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-clean-unparseable-nonblocking-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        {
+          angle: "correctness",
+          verdict: "findings_present",
+          // No `summary` -> unparseable, but severity is non-blocking (low).
+          findings: [{ severity: "nice-to-have" }],
+        },
+        { angle: "pr-description", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: true,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      }),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        // The clean verdict is posted AND the unparseable finding is surfaced in the body.
+        assertStdinIncludes: ["**Verdict:** clean", "unparseable"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "clean", "--findings-json", findingsPath,
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"nice-to-have":0}',
+      "--next-action", "mark ready for review", "--execution-mode", "fanout_fanin",
+    ], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("upsert-checkpoint-verdict rejects clean verdict when --findings-severity-counts is missing and blocking severities are configured", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-gate-review-missing-counts-"));
 

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2591,6 +2591,36 @@ test("normalizeStructuredFindings preserves unparseable entries through render's
   assert.match(body, /severity: `high`/);
 });
 
+test("normalizeStructuredFindings coerces a non-string severity on a preserved unparseable entry to the canonical vocabulary (#1526)", () => {
+  // A hand-crafted/producer-drift section may carry a non-string severity on
+  // raw.unparseable; re-normalization must coerce it (never copy verbatim, which
+  // normalizeSeverity would skip and the renderer would emit as `[object Object]`).
+  const angles = normalizeStructuredFindings([
+    {
+      angle: "correctness",
+      verdict: "findings_present",
+      findings: [],
+      unparseable: [{ severity: 5 }, { severity: { x: 1 } }, { severity: "must-fix" }],
+    },
+  ]);
+  assert.equal(angles[0].unparseable.length, 3);
+  // Non-string severities coerce to "" (no readable severity); a string normalizes.
+  assert.equal(angles[0].unparseable[0].severity, "");
+  assert.equal(angles[0].unparseable[1].severity, "");
+  assert.equal(angles[0].unparseable[2].severity, "high");
+  // The renderer never emits `[object Object]` for the coerced entries.
+  const body = renderGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234000000000000000000000000000000000",
+    verdict: "findings_present",
+    findingsSummary: "ignored",
+    nextAction: "fix",
+    executionMode: "fanout_fanin",
+    structuredFindings: angles,
+  });
+  assert.ok(!body.includes("[object Object]"));
+});
+
 test("renderGateReviewCommentBody reports an unparseable finding explicitly in the per-angle breakdown (#1526)", () => {
   const angles = normalizeStructuredFindings([
     { angle: "correctness", verdict: "findings_present", findings: [{ severity: "nice-to-have", summary: "ok" }, { severity: "nice-to-have" }] },

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6326,6 +6326,46 @@ test("#1621: an inline CLEAN round does NOT apply the gate:full label", async ()
   }
 });
 
+// #1526: the roundCarriesBlockingSeverity unparseable branch (parallel tally to
+// the clean-verdict cross-check) must escalate gate:full for an inline round
+// that surfaces an UNPARSEABLE blocking finding, exactly as a parseable one
+// would. Fails if the guard reverts to dropping unparseable findings from
+// this tally too.
+test("#1526: an inline round that surfaces an UNPARSEABLE blocking finding applies the gate:full label (roundCarriesBlockingSeverity unparseable branch)", async () => {
+  const repoRoot = await stageConfigRepoRoot(true);
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-1526-unparseable-escalate-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        // No `summary` -> normalizeStructuredFinding returns null -> unparseable,
+        // but severity "must-fix" (-> "high") is read and is blocking.
+        { angle: "correctness", verdict: "findings_present", findings: [{ severity: "must-fix" }] },
+      ]),
+      "utf8",
+    );
+    const { runChild, calls } = makeAcRunChild({ isDraft: true });
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo", pr: 17, gate: "draft_gate", headSha: GATE_FULL_HEAD,
+      verdict: "findings_present", findingsJson: findingsPath,
+      findingsSummary: "an unparseable blocking finding remains",
+      findingsSeverityCounts: { high: 1, medium: 0, low: 0 },
+      nextAction: "stay draft and fix",
+      executionMode: "inline_single_agent", inlineReason: "inline unparseable blocking finding",
+    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    assert.equal(result.action, "created");
+    assert.equal(result.gateFullLabelApplied, true);
+    const labelCreate = calls.find((c) => c.args[0] === "label" && c.args[1] === "create" && c.args.includes("gate:full"));
+    assert.ok(labelCreate, "gate:full label resource was created for an unparseable blocking finding");
+    const addLabel = calls.find((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("--add-label") && c.args.includes("gate:full"));
+    assert.ok(addLabel, "gate:full label was added to the PR for an unparseable blocking finding");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("#1621: a clean pre_approval_gate verdict is REFUSED while the spec-of-record has unticked AC items", async () => {
   const repoRoot = await stageConfigRepoRoot(false);
   try {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2641,6 +2641,29 @@ test("renderGateReviewCommentBody reports an unparseable finding explicitly in t
   assert.match(body, /1 angle reviewed; 2 findings/);
 });
 
+test("renderGateReviewCommentBody's reduced per-angle digest (finding-surface round) counts unparseable findings (#1526)", () => {
+  // A round that carries its own finding surface (nonLocatableFindings is an array)
+  // renders the REDUCED per-angle digest (renderAngleVerdictDigest) instead of the
+  // full breakdown. That reduced digest must also count unparseable findings, or a
+  // finding-surface round would undercount the very findings it surfaces.
+  const angles = normalizeStructuredFindings([
+    { angle: "correctness", verdict: "findings_present", findings: [{ severity: "nice-to-have", summary: "ok" }, { severity: "nice-to-have" }] },
+  ]);
+  const body = renderGateReviewCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234000000000000000000000000000000000",
+    verdict: "findings_present",
+    findingsSummary: "ignored",
+    nextAction: "fix",
+    executionMode: "fanout_fanin",
+    structuredFindings: angles,
+    // An array (even empty) selects the reduced digest path.
+    nonLocatableFindings: [],
+  });
+  // 1 parseable + 1 unparseable = 2 findings in the reduced one-liner.
+  assert.match(body, /`correctness` → `findings_present` \(2 findings\)/);
+});
+
 test("upsert-checkpoint-verdict rejects a clean verdict whose --findings-json carries an unparseable finding at a blocking severity (no summary) (#1526)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-clean-unparseable-blocking-"));
   try {


### PR DESCRIPTION
## Summary

Closes #1526 — the final item of the rc.5 rule-enforcement cluster.

The clean-verdict cross-check in `upsert-checkpoint-verdict.mjs` tallied severities from the **normalized** structured findings, and `normalizeStructuredFinding` returns `null` for findings it cannot interpret (no usable summary, or not an object). A finding that normalization dropped was therefore invisible to the guard: a blocking severity could pass the cross-check silently by being **unparseable** rather than by being absent — a fail-open in a guard whose entire purpose is to fail closed. This is the third variant of that shape on PR 1513's gate.

## Change

Track such findings as **UNPARSEABLE** on the per-angle section (`buildAngleSectionFromNested`) instead of dropping them, and tally them on their severity alone (no disposition to resolve against):

- a blocking severity fails the clean verdict exactly as a parseable one would
- a non-blocking one is reported explicitly as unparseable in the rendered comment body — never dropped

The tally now operates on a representation where *"could not interpret this finding"* is distinguishable from *"this finding is not blocking"* (AC #2).

Also threaded for consistency (parallel tally / representation, no scope growth):
- `roundCarriesBlockingSeverity` — an unparseable blocking finding escalates `gate:full` just as it blocks a clean verdict
- per-angle digest + render counts — unparseable findings count toward the total so the digest never undercounts
- re-normalization — `renderGateReviewCommentBody` re-normalizes an already-normalized section; the `unparseable` list is preserved, not re-dropped
- `groupFlatFindingsByAngle` carries the uniform `unparseable: []` shape (flat unparseable input is already rejected by the unrecognized-item guard before grouping)

`--help` now documents the unparseable behavior alongside the (already consistent) resolved-disposition rule, so `--help` and the runtime state the same rule (AC #3).

## Non-goals (honored)

- Does **not** broaden what `normalizeStructuredFinding` accepts — the question is what happens to what it rejects, not whether it should reject less.
- Does **not** re-litigate the sanctioned disposition set (`disputed` / `operator_acknowledged`).

## Tests

- unparseable finding with a blocking severity → clean rejected
- unparseable finding without a blocking severity → clean allowed + rendered as unparseable
- each of the two sanctioned dispositions (existing) + an unrecognized disposition (existing) — unchanged
- representation / render / re-normalization unit tests that fail if the guard reverts to dropping (AC #4)

Builds on the prior cluster items (b3466c32, 64632d6d, 3195b49a, 33efb9a2); does not regress #1618's `--expected-dispatch-units` wiring (consolidate-fanin suite green, 109 pass).
