### PR TITLE
fix(gate): enforce no-rebuild-mid-fan-out rule (#1537)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -654,11 +654,7 @@ semantics and exit codes.
 **Sanctioned rebuild-and-retire.**
 
 <!-- rule: GATE-EXEC-ROUND-RETIREMENT -->
-`GATE-EXEC-ROUND-RETIREMENT`: When the gate-context bundle is legitimately REBUILT at the
-same head (the builder resolves PR/issue inputs itself, and correcting bad or stale
-seeding is a legitimate rebuild; rebuilding while reviewers are still running remains
-forbidden — see the conductor rule in Phase 1), the new briefing-prefix bytes hash
-differently, so every
+`GATE-EXEC-ROUND-RETIREMENT`: A legitimate rebuild at the same head (the builder resolves PR/issue inputs itself, and correcting bad or stale seeding is a legitimate rebuild) now REQUIRES retiring the round FIRST: under the #1537 enforcement in Phase 1, `write-gate-context.mjs` REFUSES a rebuild that would change the prefix bytes while any of this gate's reviewer sentinels for that head are still live, so the rebuild cannot strand them in the first place — retire-THEN-rebuild is the sanctioned path (rebuilding while reviewers are still running remains forbidden). The recovery framing below — a round whose sentinels were already invalidated and fail closed forever — applies to rounds stranded BEFORE that enforcement landed, or stranded by a path other than `write-gate-context.mjs` (e.g. a sentinel whose recorded hash no longer matches after an out-of-band prefix change): the new briefing-prefix bytes hash differently, so every
 existing sentinel of that round fails closed forever — including under `--same-head-retry`,
 whose hash-equality gate a rebuild destroys by design. The sanctioned recovery is retiring
 the round explicitly: `node scripts/github/retire-gate-round.mjs --gate <gate> --head-sha <sha>

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -180,10 +180,22 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
     the recorded bytes. Because the resolved PR/issue text is embedded in the rendered
     prefix, a same-head rebuild after a live description edit yields different prefix bytes,
     which would split one fan-out across two prefix hashes — so a conductor MUST NOT rebuild
-    the context while reviewers for that head are still running. This does not affect the
-    frozen artifact of an already-completed gate pass. Round retirement
+    the context while reviewers for that head are still running. This is now ENFORCED, not
+    merely stated in prose (#1537): `write-gate-context.mjs` REFUSES (throws, exit 1, no
+    bytes written) a same-head rebuild that would change the recorded prefix bytes while
+    this gate's reviewer sentinels for that head are still live (a fan-out is in flight).
+    The refusal names the in-flight head and points at the reviewers already briefed on
+    the prior bytes (their sentinel files + recorded prefix hash). A sentinel scan that
+    fails for any reason other than a missing tmp/ dir (EACCES, ENOTDIR, ...) cannot
+    rule out an in-flight fan-out, so it is REFUSED too (fail-closed) rather than allowed
+    through a broken scan that could hide live sentinels; only an unreadable EXISTING
+    prefix (which cannot be proven to differ) stays advisory. A rebuild after the
+    round has retired — no live sentinels — is unaffected: the frozen artifact of an
+    already-completed gate pass is not the case being protected. Round retirement
     (`GATE-EXEC-ROUND-RETIREMENT`) does not relax this: it recovers a round AFTER a rebuild
-    stranded it, and never licenses rebuilding mid-flight.
+    stranded it, and never licenses rebuilding mid-flight; the sanctioned rebuild path is
+    retire-THEN-rebuild (retire the round, moving its sentinels out of the live namespace,
+    THEN rebuild at the same head).
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
   (e.g. `context-build/request-and-scope.md`, `context-build/codebase-and-patterns.md`,
@@ -656,9 +668,11 @@ the round explicitly: `node scripts/github/retire-gate-round.mjs --gate <gate> -
 directory (`tmp/retired-gate-rounds/<sha>/round-<n>/` with a `retirement.json` record; the
 other gate's live round at the same head is never touched), so a
 FRESH fan-out can run at the same head with every reviewer of the new round agreeing on the
-one new hash. Retirement MUST be explicit — `write-gate-context.mjs` warns (naming this
-command) when a rebuild overwrites a differing prefix at a head with live sentinels, and
-never retires as a side effect. The caller MUST pass `--findings-dir` whenever the retired
+one new hash. Retirement MUST be explicit — `write-gate-context.mjs` REFUSES a same-head
+rebuild that would change the recorded prefix bytes while this gate's reviewer sentinels
+for that head are still live (#1537, naming this command in the refusal); it never retires
+as a side effect. An operator who needs to rebuild at a head with a live round MUST retire
+first (retire-THEN-rebuild), so the rebuild sees no live sentinels and proceeds. The caller MUST pass `--findings-dir` whenever the retired
 round wrote artifacts: at the same head they would pass the `GATE-EXEC-ARTIFACT-HEAD-STAMP` guard and
 silently mix into the new round's fan-in; retiring them is the explicit discard. This is
 now ENFORCED, not just advised (#1626): when `--findings-dir` is omitted and

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -2045,7 +2045,7 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
     // enforcement must not be bypassable by a broken scan — fail closed by
     // refusing the rebuild (the operator can fix the scan or retire first).
     if (scanError !== null) {
-      throw new Error(`Refusing to rebuild the briefing prefix with DIFFERENT bytes at head ${options.headSha} (${options.gate}): the live-sentinel scan failed (${scanError.code ?? scanError.message}) — cannot rule out an in-flight fan-out for this head, and a rebuild that splits a live round must not be allowed through a broken scan. The existing prefix hash is ${priorPrefixHash}. Retire the round explicitly before rebuilding: ${retireCommand}`);
+      throw new Error(`Refusing to rebuild the briefing prefix with DIFFERENT bytes at head ${options.headSha} (${options.gate}): the live-sentinel scan failed (${scanError.code ?? scanError.message}) — cannot rule out an in-flight fan-out for this head, and a rebuild that splits a live round must not be allowed through a broken scan. The existing (recorded) prefix hash is ${priorPrefixHash}; the attempted rebuild would write hash ${newPrefixHash}. Fix the scan first (make tmp/ listable again — restore read permission on the tmp/ directory or remove a file/blocker masquerading as it), then either retire the round explicitly before rebuilding (retire-gate-round moves sentinels out of the live namespace, so a rebuild then sees no live sentinels) or confirm no fan-out is in flight: ${retireCommand}`);
     } else if (liveSentinelNames.length > 0) {
       // AC2: name the in-flight head and point at the reviewers already briefed
       // on the prior bytes (their sentinel files + the recorded hash they carry).

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1984,73 +1984,76 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
   // leave a complete-looking artifact pointing at a missing prefix file.
   const fullPrefixPath = path.resolve(repoRoot, briefingPrefixPath);
   await mkdir(path.dirname(fullPrefixPath), { recursive: true });
-  // Rebuild detection: overwriting a DIFFERENT prefix at a head that already
-  // has reviewer sentinels invalidates every one of them (their recorded hash
-  // can never match the new bytes), stranding the round.
+  // No-rebuild-mid-fan-out enforcement (#1537). The contract has always
+  // stated in prose that a conductor MUST NOT rebuild the context while
+  // reviewers for that head are still running: a same-head rebuild after a
+  // live PR/issue description edit yields DIFFERENT prefix bytes and splits one
+  // fan-out across two prefix hashes (every existing sentinel's recorded hash
+  // can never match the new bytes), stranding the round after the reviewer
+  // spend. #1626 made the detection ADVISORY (warn, never refuse) because the
+  // rebuild was treated as the sanctioned first step of rebuild-and-retire.
+  // #1537 ENFORCES the rule instead of relying on conductor discipline: a
+  // rebuild that would CHANGE the recorded prefix bytes while a fan-out for
+  // that head is IN FLIGHT (this gate's reviewer sentinels still live) is
+  // REFUSED, not warned. The refusal throws BEFORE any bytes are written, so
+  // the existing prefix and its in-flight reviewers are left intact.
   //
-  // rebuildWarning contract (#1626 — decided advisory-by-design, NOT a refusal):
-  // The context rebuild is the sanctioned FIRST step of
-  // GATE-EXEC-ROUND-RETIREMENT (rebuild context → retire round → re-fan). The
-  // rebuild itself is legitimate, so each of the three warning branches below is
-  // ADVISORY rather than a refusal; each names the explicit recovery command
-  // (retire-gate-round) so an operator following up is never left stranded.
-  // These are NOT "MUSTs degraded to a warning": the MUST (round retirement
-  // before re-fan) is enforced separately by verify-fresh-review-context.mjs,
-  // which fails closed on a sentinel whose recorded prefix hash no longer
-  // matches — a retired round has no live sentinels, so a re-fan at the same
-  // head proceeds; an un-retired invalidated round's sentinels fail closed and
-  // block consolidation. The warning here only surfaces the consequence EARLY,
-  // at the moment of invalidation, because that is genuinely advisory context
-  // (the operator may retire immediately or continue and retire next).
-  let rebuildWarning = null;
+  // The sanctioned rebuild path is retire-THEN-rebuild (retire-gate-round moves
+  // this gate's sentinels out of the live namespace first), so a rebuild after
+  // the round has retired — no live sentinels — proceeds unchanged (AC3: the
+  // frozen artifact of a finished pass is not the case being protected). An
+  // idempotent same-bytes rerun never reaches the byte-differ branch at all.
+  // The readError case (existing prefix exists but is unreadable, so the bytes
+  // cannot be compared) stays ADVISORY: #1537 refuses only the DETECTED
+  // mid-flight byte change, and an unreadable existing prefix cannot be proven
+  // to differ, so it is surfaced as a warning rather than a refusal.
+  const retireCommand = `node scripts/github/retire-gate-round.mjs --gate ${options.gate} --head-sha <full sha> --reason "<why>" [--findings-dir <round artifacts dir>] [--repo <owner/name> --pr <N> | --no-findings-artifacts]`;
   let existingBytes = null;
   let readError = null;
-  // ONE copy of the operator-facing recovery command: the three warning
-  // branches below differ only in what went wrong, never in the remedy.
-  const retireHint = (lead) => `${lead}. Verify and retire the round explicitly before re-fanning: node scripts/github/retire-gate-round.mjs --gate ${options.gate} --head-sha <full sha> --reason "<why>" [--findings-dir <round artifacts dir>] [--repo <owner/name> --pr <N> | --no-findings-artifacts]`;
-  const warn = (text) => {
-    rebuildWarning = text;
-    process.stderr.write(`WARNING: ${rebuildWarning}\n`);
-  };
   try {
     existingBytes = await readFile(fullPrefixPath);
   } catch (err) {
-    // ENOENT is the normal first-build case. Any other read failure means the
-    // rebuild-vs-identical comparison cannot run — surface that AS a warning
-    // (the rebuild is never refused — GATE-EXEC-ROUND-RETIREMENT).
     if (err.code !== "ENOENT") readError = err;
   }
+  let rebuildWarning = null;
   if (readError !== null) {
-    warn(retireHint(`Could not read the existing briefing prefix (${readError.code ?? readError.message}) before overwriting it — if the new bytes differ and reviewer sentinels of ${options.gate} exist for head ${options.headSha}, every one of them now fails closed`));
-  } else if (existingBytes !== null) {
-    if (!existingBytes.equals(prefixBytes)) {
-      // Scoped to THIS gate's sentinels (the other gate's live round at the
-      // same head is not invalidated by this rebuild), and matched on the
-      // trailing full-SHA filename component with startsWith so a legitimately
-      // abbreviated --head-sha still detects them.
-      const sentinelScopePrefix = `${CHECKPOINT_SENTINEL_PREFIX}${gateScopePrefix(options.gate)}`;
-      const headPrefix = String(options.headSha).trim().toLowerCase();
-      // Only a missing tmp/ dir means "no sentinels". Any other scan failure
-      // (EACCES, ENOTDIR, ...) must neither be swallowed (it could hide live
-      // sentinels) nor refuse the rebuild (the rebuild is never refused —
-      // GATE-EXEC-ROUND-RETIREMENT): it surfaces AS the warning.
-      let scanError = null;
-      const tmpDirEntries = await readdir(path.resolve(repoRoot, "tmp"), { withFileTypes: true }).catch((err) => {
-        if (err.code === "ENOENT") return [];
-        scanError = err;
-        return [];
-      });
-      const liveSentinels = tmpDirEntries.filter((e) => {
-        if (!e.isFile() || !e.name.startsWith(sentinelScopePrefix) || !e.name.endsWith(".json")) return false;
-        const shaComponent = e.name.slice(0, -".json".length).split("-").at(-1) ?? "";
-        return /^[0-9a-f]{40}$/.test(shaComponent) && shaComponent.startsWith(headPrefix);
-      }).length;
-      if (scanError !== null) {
-        warn(retireHint(`Rebuilt the briefing prefix with DIFFERENT bytes but the live-sentinel scan failed (${scanError.code ?? scanError.message}) — if reviewer sentinels of ${options.gate} exist for head ${options.headSha}, every one of them now fails closed`));
-      } else if (liveSentinels > 0) {
-        warn(retireHint(`Rebuilt the briefing prefix with DIFFERENT bytes while ${liveSentinels} reviewer sentinel(s) of ${options.gate} for head ${options.headSha} exist — every one of them now fails closed (recorded hash can no longer match)`));
-      }
+    rebuildWarning = `Could not read the existing briefing prefix (${readError.code ?? readError.message}) before overwriting it — if the new bytes differ and reviewer sentinels of ${options.gate} exist for head ${options.headSha}, every one of them now fails closed. Retire the round explicitly before re-fanning: ${retireCommand}`;
+    process.stderr.write(`WARNING: ${rebuildWarning}\n`);
+  } else if (existingBytes !== null && !existingBytes.equals(prefixBytes)) {
+    // The rebuild would CHANGE the recorded prefix bytes. Scan THIS gate's live
+    // reviewer sentinels for the head (the other gate's live round at the same
+    // head is not invalidated by this rebuild), matched on the trailing
+    // full-SHA filename component with startsWith so a legitimately abbreviated
+    // --head-sha still detects them.
+    const sentinelScopePrefix = `${CHECKPOINT_SENTINEL_PREFIX}${gateScopePrefix(options.gate)}`;
+    const headPrefix = String(options.headSha).trim().toLowerCase();
+    let scanError = null;
+    const tmpDirEntries = await readdir(path.resolve(repoRoot, "tmp"), { withFileTypes: true }).catch((err) => {
+      if (err.code === "ENOENT") return [];
+      scanError = err;
+      return [];
+    });
+    const liveSentinelNames = tmpDirEntries.filter((e) => {
+      if (!e.isFile() || !e.name.startsWith(sentinelScopePrefix) || !e.name.endsWith(".json")) return false;
+      const shaComponent = e.name.slice(0, -".json".length).split("-").at(-1) ?? "";
+      return /^[0-9a-f]{40}$/.test(shaComponent) && shaComponent.startsWith(headPrefix);
+    }).map((e) => e.name);
+    const priorPrefixHash = createHash("sha256").update(existingBytes).digest("hex");
+    const newPrefixHash = createHash("sha256").update(prefixBytes).digest("hex");
+    // Only a missing tmp/ dir means "no sentinels". Any other scan failure
+    // (EACCES, ENOTDIR, ...) could hide live sentinels, and #1537's
+    // enforcement must not be bypassable by a broken scan — fail closed by
+    // refusing the rebuild (the operator can fix the scan or retire first).
+    if (scanError !== null) {
+      throw new Error(`Refusing to rebuild the briefing prefix with DIFFERENT bytes at head ${options.headSha} (${options.gate}): the live-sentinel scan failed (${scanError.code ?? scanError.message}) — cannot rule out an in-flight fan-out for this head, and a rebuild that splits a live round must not be allowed through a broken scan. The existing prefix hash is ${priorPrefixHash}. Retire the round explicitly before rebuilding: ${retireCommand}`);
+    } else if (liveSentinelNames.length > 0) {
+      // AC2: name the in-flight head and point at the reviewers already briefed
+      // on the prior bytes (their sentinel files + the recorded hash they carry).
+      throw new Error(`Refusing to rebuild the briefing prefix with DIFFERENT bytes while a fan-out for head ${options.headSha} is in flight (${options.gate}): ${liveSentinelNames.length} reviewer sentinel(s) of ${options.gate} for head ${options.headSha} exist — every one was briefed on the prior prefix hash ${priorPrefixHash} and would fail closed on the new hash ${newPrefixHash}, splitting the round. Reviewers already briefed on the prior bytes: ${liveSentinelNames.map((n) => `tmp/${n}`).sort().join(", ")}. Retire the round explicitly before rebuilding: ${retireCommand}`);
     }
+    // liveSentinelNames.length === 0: the round is not in flight (already
+    // retired or never fanned out). AC3: a rebuild after the round has
+    // completed is unaffected — proceed to overwrite the frozen artifact.
   }
   await writeFile(fullPrefixPath, prefixBytes);
   const prefixHash = createHash("sha256").update(prefixBytes).digest("hex");

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -654,11 +654,7 @@ semantics and exit codes.
 **Sanctioned rebuild-and-retire.**
 
 <!-- rule: GATE-EXEC-ROUND-RETIREMENT -->
-`GATE-EXEC-ROUND-RETIREMENT`: When the gate-context bundle is legitimately REBUILT at the
-same head (the builder resolves PR/issue inputs itself, and correcting bad or stale
-seeding is a legitimate rebuild; rebuilding while reviewers are still running remains
-forbidden — see the conductor rule in Phase 1), the new briefing-prefix bytes hash
-differently, so every
+`GATE-EXEC-ROUND-RETIREMENT`: A legitimate rebuild at the same head (the builder resolves PR/issue inputs itself, and correcting bad or stale seeding is a legitimate rebuild) now REQUIRES retiring the round FIRST: under the #1537 enforcement in Phase 1, `write-gate-context.mjs` REFUSES a rebuild that would change the prefix bytes while any of this gate's reviewer sentinels for that head are still live, so the rebuild cannot strand them in the first place — retire-THEN-rebuild is the sanctioned path (rebuilding while reviewers are still running remains forbidden). The recovery framing below — a round whose sentinels were already invalidated and fail closed forever — applies to rounds stranded BEFORE that enforcement landed, or stranded by a path other than `write-gate-context.mjs` (e.g. a sentinel whose recorded hash no longer matches after an out-of-band prefix change): the new briefing-prefix bytes hash differently, so every
 existing sentinel of that round fails closed forever — including under `--same-head-retry`,
 whose hash-equality gate a rebuild destroys by design. The sanctioned recovery is retiring
 the round explicitly: `node scripts/github/retire-gate-round.mjs --gate <gate> --head-sha <sha>

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -180,10 +180,22 @@ gitignored, worktree-local `tmp/gate-context` bundle it writes is present for th
     the recorded bytes. Because the resolved PR/issue text is embedded in the rendered
     prefix, a same-head rebuild after a live description edit yields different prefix bytes,
     which would split one fan-out across two prefix hashes — so a conductor MUST NOT rebuild
-    the context while reviewers for that head are still running. This does not affect the
-    frozen artifact of an already-completed gate pass. Round retirement
+    the context while reviewers for that head are still running. This is now ENFORCED, not
+    merely stated in prose (#1537): `write-gate-context.mjs` REFUSES (throws, exit 1, no
+    bytes written) a same-head rebuild that would change the recorded prefix bytes while
+    this gate's reviewer sentinels for that head are still live (a fan-out is in flight).
+    The refusal names the in-flight head and points at the reviewers already briefed on
+    the prior bytes (their sentinel files + recorded prefix hash). A sentinel scan that
+    fails for any reason other than a missing tmp/ dir (EACCES, ENOTDIR, ...) cannot
+    rule out an in-flight fan-out, so it is REFUSED too (fail-closed) rather than allowed
+    through a broken scan that could hide live sentinels; only an unreadable EXISTING
+    prefix (which cannot be proven to differ) stays advisory. A rebuild after the
+    round has retired — no live sentinels — is unaffected: the frozen artifact of an
+    already-completed gate pass is not the case being protected. Round retirement
     (`GATE-EXEC-ROUND-RETIREMENT`) does not relax this: it recovers a round AFTER a rebuild
-    stranded it, and never licenses rebuilding mid-flight.
+    stranded it, and never licenses rebuilding mid-flight; the sanctioned rebuild path is
+    retire-THEN-rebuild (retire the round, moving its sentinels out of the live namespace,
+    THEN rebuild at the same head).
 - reference the pi-subagents `parallel context-build` technique when applicable:
   run parallel `context-builder` agents from fresh context with distinct output paths
   (e.g. `context-build/request-and-scope.md`, `context-build/codebase-and-patterns.md`,
@@ -656,9 +668,11 @@ the round explicitly: `node scripts/github/retire-gate-round.mjs --gate <gate> -
 directory (`tmp/retired-gate-rounds/<sha>/round-<n>/` with a `retirement.json` record; the
 other gate's live round at the same head is never touched), so a
 FRESH fan-out can run at the same head with every reviewer of the new round agreeing on the
-one new hash. Retirement MUST be explicit — `write-gate-context.mjs` warns (naming this
-command) when a rebuild overwrites a differing prefix at a head with live sentinels, and
-never retires as a side effect. The caller MUST pass `--findings-dir` whenever the retired
+one new hash. Retirement MUST be explicit — `write-gate-context.mjs` REFUSES a same-head
+rebuild that would change the recorded prefix bytes while this gate's reviewer sentinels
+for that head are still live (#1537, naming this command in the refusal); it never retires
+as a side effect. An operator who needs to rebuild at a head with a live round MUST retire
+first (retire-THEN-rebuild), so the rebuild sees no live sentinels and proceeds. The caller MUST pass `--findings-dir` whenever the retired
 round wrote artifacts: at the same head they would pass the `GATE-EXEC-ARTIFACT-HEAD-STAMP` guard and
 silently mix into the new round's fan-in; retiring them is the explicit discard. This is
 now ENFORCED, not just advised (#1626): when `--findings-dir` is omitted and

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -3458,6 +3458,8 @@ test("writeGateContext REFUSES on a broken live-sentinel scan (fail-closed: cann
         assert.match(err.message, /Refusing to rebuild the briefing prefix with DIFFERENT bytes at head abc1234567890def/);
         assert.match(err.message, /live-sentinel scan failed/);
         assert.match(err.message, /cannot rule out an in-flight fan-out/);
+        assert.match(err.message, /existing \(recorded\) prefix hash is [0-9a-f]{64}; the attempted rebuild would write hash [0-9a-f]{64}/);
+        assert.match(err.message, /make tmp\/ listable again/);
         assert.match(err.message, /retire-gate-round\.mjs --gate draft_gate/);
         return true;
       },

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -3140,6 +3140,51 @@ test("CLI: a rebuild at the SAME head re-resolves the spec-of-record, so the art
   }
 });
 
+test("#1537 regression: an ALLOWED rebuild re-resolves the spec-of-record so the artifact never regresses to a null AC (the mixed case that broke the first attempt)", async () => {
+  // PR #1515 reused the on-disk prefix to prevent a mid-fan-out split, but that
+  // reuse path skipped resolvePrSpecContext while still rebuilding the JSON
+  // artifact, writing scope.acceptanceCriteria: null with no source — the exact
+  // fail-open state #1496 removed. #1537 refuses mid-flight rebuilds instead
+  // of reusing, so an ALLOWED rebuild (no in-flight fan-out) must re-resolve
+  // the spec just like the first build. This test covers the mixed case: build,
+  // rebuild, assert BOTH the prefix bytes AND the artifact's spec fields.
+  const { repoRoot, baseSha, headSha } = await makeBaseDiffRepo();
+  try {
+    const build = (prBody) => main([
+      "--repo", "owner/repo", "--pr", "81", "--gate", "draft_gate",
+      "--head-sha", headSha, "--angles", '["scope"]', "--base", baseSha,
+    ], { repoRoot, run: specStubRun({ prBody, closing: [{ number: 42 }], issueBody: "## Acceptance criteria\n- a\n\n## Definition of done\n- b" }) });
+
+    const first = await build("first-build body");
+    assert.equal(process.exitCode, 0, "first build exited clean");
+    process.exitCode = 0;
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 81, gate: "draft_gate", headSha });
+    const firstPrefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(firstPrefix.includes("first-build body"), "first build wrote its PR body into the prefix bytes");
+    const firstArtifact = await readGateContext({ repo: "owner/repo", pr: 81, gate: "draft_gate", headSha }, { repoRoot });
+    assert.equal(firstArtifact.scope.acceptanceCriteria, "#42");
+    assert.equal(firstArtifact.scope.acceptanceCriteriaSource, "linked-issue");
+
+    // Rebuild at the same head with NO live sentinels (round not in flight) —
+    // this is the ALLOWED path, and it must re-resolve the spec-of-record.
+    await build("second-build body");
+    assert.equal(process.exitCode, 0, "rebuild exited clean");
+    process.exitCode = 0;
+
+    // AC5: assert BOTH the prefix bytes...
+    const rebuiltPrefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(rebuiltPrefix.includes("second-build body"), "rebuild wrote the NEW PR body into the prefix bytes (no stale reuse)");
+    assert.ok(!rebuiltPrefix.includes("first-build body"), "the prior body was overwritten, not preserved by a reuse path");
+    // ...AND the artifact's spec fields (AC4: no reuse path skips resolvePrSpecContext).
+    const rebuiltArtifact = await readGateContext({ repo: "owner/repo", pr: 81, gate: "draft_gate", headSha }, { repoRoot });
+    assert.equal(rebuiltArtifact.scope.acceptanceCriteria, "#42", "rebuild re-resolved the linked-issue pointer (not null)");
+    assert.equal(rebuiltArtifact.scope.acceptanceCriteriaSource, "linked-issue", "rebuild carried the same source as the build it reuses from");
+    assert.notEqual(rebuiltArtifact.prefixMode, "file", "no reuse-via-prefix-file path was introduced");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("resolvePrSpecContext: a programmatic caller that OMITS the spec fields still gets them resolved", async () => {
   // Only the CLI defaults these to null. An exported-API caller omitting them
   // leaves undefined, which must not read as "the caller provided this".
@@ -3325,12 +3370,12 @@ test("#1603: scoped briefing variants omit the source-read invariant when worktr
   });
   assert.ok(!text.includes("## Reviewer source-read invariant"));
 });
-test("writeGateContext warns, naming the retirement command, when a rebuild overwrites a differing prefix at a head with live sentinels", async () => {
-  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-warn-"));
+test("writeGateContext REFUSES, naming the retirement command and the briefed reviewers, when a rebuild would change the prefix bytes at a head with live sentinels (#1537)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-refuse-"));
   const fullSha = "abc1234567890def".padEnd(40, "0");
   try {
     // --head-sha may legitimately be abbreviated; the sentinel filename always
-    // embeds the FULL sha, and the warning must still fire (matched on the
+    // embeds the FULL sha, and the refusal must still fire (matched on the
     // trailing full-SHA component with startsWith).
     const baseArgs = [
       "--repo", "owner/repo", "--pr", "9", "--gate", "draft_gate",
@@ -3344,26 +3389,141 @@ test("writeGateContext warns, naming the retirement command, when a rebuild over
     await writeFile(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-draft-gate-scope-${fullSha}.json`), "{}\n", "utf8");
     // The OTHER gate's sentinel at the same head must not count.
     await writeFile(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-pre-approval-gate-yagni-${fullSha}.json`), "{}\n", "utf8");
-    const rebuilt = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot });
-    assert.match(rebuilt.warning, /retire-gate-round\.mjs --gate draft_gate/);
-    assert.match(rebuilt.warning, /1 reviewer sentinel/);
-    // Same-bytes rewrite never warns (idempotent rerun, no invalidation).
-    const idempotent = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot });
+    // AC1: a rebuild that would CHANGE the prefix bytes while a fan-out is in
+    // flight is REFUSED, not warned — the existing prefix is left intact.
+    await assert.rejects(
+      writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot }),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /Refusing to rebuild the briefing prefix with DIFFERENT bytes while a fan-out for head abc1234567890def is in flight/);
+        assert.match(err.message, /retire-gate-round\.mjs --gate draft_gate/);
+        // AC2: names the in-flight head and points at the reviewers already
+        // briefed on the prior bytes (their sentinel file + prior prefix hash).
+        assert.match(err.message, /1 reviewer sentinel/);
+        assert.match(err.message, /tmp\/checkpoint-context-sentinel-draft-gate-scope-[0-9a-f]+\.json/);
+        assert.match(err.message, /prior prefix hash [0-9a-f]{64}/);
+        assert.match(err.message, /new hash [0-9a-f]{64}/);
+        return true;
+      },
+    );
+    // The refusal wrote NOTHING: the original prefix bytes are untouched.
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 9, gate: "draft_gate", headSha: "abc1234567890def" });
+    const survivingPrefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(survivingPrefix.includes("Original body."), "the refusal left the existing prefix bytes intact");
+    assert.ok(!survivingPrefix.includes("Corrected body."), "no partial write of the refused bytes");
+    // Same-bytes rewrite never refuses (idempotent rerun, no byte change).
+    const idempotent = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Original body."]), { repoRoot });
     assert.equal(idempotent.warning, undefined);
-    // The pre-approval gate's own rebuild warns against ITS sentinel only.
+    // AC3: after the round retires (sentinels removed from the live namespace),
+    // a rebuild with different bytes is UNAFFECTED — it proceeds.
+    await rm(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-draft-gate-scope-${fullSha}.json`));
+    const rebuiltAfterRetire = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Retired-then-rebuilt body."]), { repoRoot });
+    assert.equal(rebuiltAfterRetire.warning, undefined);
+    assert.ok((await readFile(path.resolve(repoRoot, prefixPath), "utf8")).includes("Retired-then-rebuilt body."));
+    // The pre-approval gate's own rebuild refuses against ITS sentinel only.
     const paArgs = baseArgs.map((a) => (a === "draft_gate" ? "pre_approval_gate" : a));
     await writeGateContext(parseWriteGateContextCliArgs([...paArgs, "--pr-body", "PA body."]), { repoRoot });
-    const paRebuilt = await writeGateContext(parseWriteGateContextCliArgs([...paArgs, "--pr-body", "PA corrected."]), { repoRoot });
-    assert.match(paRebuilt.warning, /retire-gate-round\.mjs --gate pre_approval_gate/);
-    assert.match(paRebuilt.warning, /1 reviewer sentinel/);
+    await writeFile(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-pre-approval-gate-yagni-${fullSha}.json`), "{}\n", "utf8");
+    await assert.rejects(
+      writeGateContext(parseWriteGateContextCliArgs([...paArgs, "--pr-body", "PA corrected."]), { repoRoot }),
+      (err) => {
+        assert.match(err.message, /retire-gate-round\.mjs --gate pre_approval_gate/);
+        assert.match(err.message, /1 reviewer sentinel/);
+        return true;
+      },
+    );
   } finally {
     await rm(repoRoot, { recursive: true, force: true }).catch(() => {});
   }
 });
 
-// ---------------------------------------------------------------------------
-// AC8 (#1572) — prefix hunk-collapse: collapsePureSubstitutionRuns
-// ---------------------------------------------------------------------------
+test("writeGateContext REFUSES on a broken live-sentinel scan (fail-closed: cannot rule out an in-flight fan-out) (#1537)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-scanerr-"));
+  try {
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "19", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890def",
+      "--angles", '["scope"]',
+      "--acceptance-criteria", "#19",
+    ];
+    await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Original body."]), { repoRoot });
+    // Make tmp/ listable-fail (execute-only: traversal to the prefix still works,
+    // but readdir cannot list). readFile of the existing prefix succeeds, so the
+    // rebuild reaches the byte-differ branch and then the sentinel scan fails.
+    await chmod(path.resolve(repoRoot, "tmp"), 0o111);
+    await assert.rejects(
+      writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot }),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /Refusing to rebuild the briefing prefix with DIFFERENT bytes at head abc1234567890def/);
+        assert.match(err.message, /live-sentinel scan failed/);
+        assert.match(err.message, /cannot rule out an in-flight fan-out/);
+        assert.match(err.message, /retire-gate-round\.mjs --gate draft_gate/);
+        return true;
+      },
+    );
+    // The refusal wrote NOTHING: the original prefix bytes are intact.
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 19, gate: "draft_gate", headSha: "abc1234567890def" });
+    await chmod(path.resolve(repoRoot, "tmp"), 0o755);
+    const survivingPrefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(survivingPrefix.includes("Original body."), "the refusal left the existing prefix bytes intact");
+    assert.ok(!survivingPrefix.includes("Corrected body."), "no partial write of the refused bytes");
+  } finally {
+    // Ensure tmp/ is restorable before rm so cleanup does not EACCES.
+    try { await chmod(path.join(repoRoot, "tmp"), 0o755); } catch {}
+    await rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("writeGateContext does NOT refuse when the only live sentinel is for a DIFFERENT head (#1537 startsWith boundary)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-otherhead-"));
+  const headSha = "abc1234567890def";
+  const otherHeadSha = "fedcba9876543210".padEnd(40, "1");
+  try {
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "29", "--gate", "draft_gate",
+      "--head-sha", headSha, "--angles", '["scope"]', "--acceptance-criteria", "#29",
+    ];
+    await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Original body."]), { repoRoot });
+    await mkdir(path.resolve(repoRoot, "tmp"), { recursive: true });
+    // A sentinel keyed by a DIFFERENT head must not count as in-flight for this head.
+    await writeFile(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-draft-gate-scope-${otherHeadSha}.json`), "{}\n", "utf8");
+    // Different bytes, but no in-flight sentinel for THIS head -> proceeds (AC3).
+    const rebuilt = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Other-head-safe rebuild."]), { repoRoot });
+    assert.equal(rebuilt.warning, undefined, "a sentinel at a different head does not make this an in-flight rebuild");
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 29, gate: "draft_gate", headSha });
+    assert.ok((await readFile(path.resolve(repoRoot, prefixPath), "utf8")).includes("Other-head-safe rebuild."));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("writeGateContext keeps the unreadable-existing-prefix (readError) case ADVISORY, not a refusal (#1537)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-readerr-"));
+  try {
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "39", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890def",
+      "--angles", '["scope"]', "--acceptance-criteria", "#39",
+    ];
+    await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Original body."]), { repoRoot });
+    // Make the EXISTING prefix file unreadable but still writable (write-only).
+    // readFile fails (EACCES, no read perm) so bytes cannot be compared, but the
+    // rebuild can still overwrite — this is the ADVISORY case (warning + proceed),
+    // not the detected mid-flight refusal.
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 39, gate: "draft_gate", headSha: "abc1234567890def" });
+    await chmod(path.resolve(repoRoot, prefixPath), 0o222);
+    const result = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot });
+    assert.match(result.warning, /Could not read the existing briefing prefix/, "the unreadable-prefix case surfaces an advisory warning");
+    assert.match(result.warning, /retire-gate-round\.mjs --gate draft_gate/);
+    assert.equal(result.ok, true, "the rebuild proceeds (advisory, not a refusal) — bytes cannot be proven to differ");
+    // Restore and confirm the new bytes landed (the advisory did not block the write).
+    await chmod(path.resolve(repoRoot, prefixPath), 0o644);
+    assert.ok((await readFile(path.resolve(repoRoot, prefixPath), "utf8")).includes("Corrected body."));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  }
+});
 
 test("collapsePureSubstitutionRuns: a lone (length-1) pure single-token substitution run stays below the collapse floor and renders in full", () => {
   const diff = [


### PR DESCRIPTION
## Summary

Enforces the no-rebuild-mid-fan-out rule that the gate-review contract has always stated in prose (#1537). Item 8 of the rc.5 end-to-end drive — #1 of the gate-hardening cluster (#1537, #1578, #1525).

## Scope and context

`scripts/github/write-gate-context.mjs` only. The change converts the previously advisory rebuild-detection (#1626) into an enforced refusal for the mid-fan-out case. The contract prose in `skills/docs/gate-review-sub-loop-contract.md` and the mirrored `.claude` tree are updated to point at the mechanism and reconcile `GATE-EXEC-ROUND-RETIREMENT` framing with retire-THEN-rebuild. No other gate machinery, prefix rendering, or fan-in logic is touched.

## Problem

`write-gate-context.mjs` builds the briefing prefix by embedding the resolved PR and issue text, so a rebuild at the same head after a live description edit produces different prefix bytes. If a conductor rebuilds the context while reviewers for that head are still running, the fan-out splits across two prefix hashes and `verify-briefing-prefixes.mjs` fails closed at fan-in — after the reviewer spend. PR #1515's first attempt reused the on-disk prefix via `options.prefixFile`, but that skipped `resolvePrSpecContext` while still rebuilding the JSON artifact, writing `scope.acceptanceCriteria: null` with no `acceptanceCriteriaSource` (the fail-open state #1496 removed). #1626 then made the detection advisory (warn, never refuse). Nothing enforced the rule.

## Change

`write-gate-context.mjs` now **REFUSES** (throws, exit 1, no bytes written) a same-head rebuild that would change the recorded prefix bytes while this gate's reviewer sentinels for that head are still live (a fan-out is in flight).

## Acceptance criteria → Definition of done mapping

| AC | Definition of done |
|---|---|
| AC1: a same-head rebuild that would change the prefix bytes while a fan-out is in flight is detected and refused | Enforcement lands with tests; `npm run verify` green (CI authoritative) |
| AC2: refusal names the in-flight head + reviewers already briefed (sentinel files + prior/new prefix hashes) + retire command | Enforcement lands with tests; `npm run verify` green (CI authoritative) |
| AC3: a rebuild after the round has retired (no live sentinels) is unaffected; idempotent same-bytes rerun never refuses | Enforcement lands with tests; `npm run verify` green (CI authoritative) |
| AC4: no reuse path skips `resolvePrSpecContext` — rebuilt artifact carries the same `scope.acceptanceCriteria` + `acceptanceCriteriaSource` | Enforcement lands with tests; `npm run verify` green (CI authoritative) |
| AC5: regression test for the mixed case (build, rebuild, assert prefix bytes + artifact spec fields) | Enforcement lands with tests; `npm run verify` green (CI authoritative) |
| — (contract) | The contract prose points at the mechanism instead of relying on conductor discipline |

## Definition of done

- Enforcement lands with tests, `npm run verify` green (CI authoritative; ~48 pre-existing environmental gh/run-id suite failures are green in CI and confirmed identical on `origin/main`).
- The contract prose points at the mechanism instead of relying on conductor discipline.

## Non-goals

- Changing how the prefix is rendered.
- Caching gate context across heads.
- Widening the sentinel SHA-component regex beyond SHA-1 (pre-existing; GitHub PRs are SHA-1 today) — tracked as a follow-up.
- Guarding the chmod-based refusal tests against a root-bypass environment (the tests pass as non-root in CI) — tracked as a follow-up.

## Validation

- `node --test test/github/write-gate-context.test.mjs` — green (180 tests; includes the refusal test, the broken-scan fail-closed test, the readError-advisory test, the different-head startsWith boundary, and the AC5 regression).
- `npm run test:doc-guard` — green (251 contract tests, including the byte-reproducibility check for the mirrored `.claude` tree).
- `npm run test:scripts` — 3747 tests, 3663 pass, 48 fail; the 48 failures are the known pre-existing environmental gh/run-id suites (copilot-pr-handoff, detect-checkpoint-evidence, reconcile-draft-gate, upsert-checkpoint-verdict, runWatchCycle — #1639), confirmed identical on `origin/main` baseline; this change adds zero new failures.

Closes #1537
