### PR TITLE
fix(config): surface visible warning on schema-rejected gate layer (#1578)

### DIFF
--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1431,6 +1431,35 @@ async function applyLayer(merged, basePaths, layer, warnings, errors, options = 
   // is an existing, separate concern.
   const validation = FileConfigSchema.safeParse(data);
   if (!validation.success) {
+    // Surface a visible WARNING (not just the structured error) so the
+    // whole-layer drop is never silent (#1578): many consumers destructure
+    // only `config` (or `config` + `warnings`) and never read `errors`, so a
+    // schema-rejected layer would vanish without a trace. Naming the
+    // offending keys here lets a stale raw-key config (e.g.
+    // gates.<gate>.mandatoryAngles/excludeAngles) point at the canonical
+    // angle-entry migration path.
+    const offendingKeys = validation.error.issues
+      .flatMap((i) => {
+        if (i.code === "unrecognized_keys" && Array.isArray(i.keys) && i.keys.length) {
+          const prefix = i.path.length ? `${i.path.join(".")}.` : "";
+          return i.keys.map((k) => `${prefix}${k}`);
+        }
+        return i.path.length ? [i.path.join(".")] : [];
+      });
+    // Gate the raw-key migration hint: only append it when the offending
+    // keys actually include the pre-redesign mandatoryAngles/excludeAngles
+    // names, so an unrelated schema failure (e.g. a type error) does not get
+    // misleading raw-key migration guidance. (#1578)
+    const hasRawGateKey = offendingKeys.some((k) => /mandatoryAngles|excludeAngles/.test(k));
+    const migrationHint = hasRawGateKey
+      ? ` Migrate raw gates.<gate>.mandatoryAngles/excludeAngles to the canonical angle-entry shape ` +
+        `(gates.<gate>.angles with { name, mandatory: true } / { name, enabled: false }).`
+      : ` Fix or remove the offending key(s) to restore this config layer.`;
+    warnings.push(
+      `${path.basename(filePath)}: config layer rejected by schema — the whole layer was dropped, so this layer's overrides are not applied (previously merged layers remain in effect). ` +
+      `Offending key(s): ${offendingKeys.length ? offendingKeys.join(", ") : "(unknown)"}.` +
+      migrationHint
+    );
     errors.push({
       path: filePath,
       message: `${path.basename(filePath)}: Schema validation failed: ${validation.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -632,6 +632,50 @@ describe("loader — graceful degradation", () => {
     }
   });
 
+  // #1578: a config layer carrying raw gates.<gate>.mandatoryAngles/
+  // excludeAngles keys is rejected by the strict GateConfig schema. The
+  // whole layer is dropped (packaged defaults remain), but the drop MUST NOT
+  // be silent — a visible warning naming the offending keys is pushed to the
+  // `warnings` channel (consistent with existing config warnings), not just
+  // the `errors` channel that many consumers ignore.
+  test("#1578: a raw-key gate layer is dropped with a visible warning naming the offending keys", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-raw-gate-keys-"));
+    try {
+      await writeFile(
+        path.join(tmpDir, ".devloops"),
+        [
+          "version: 1",
+          "gates:",
+          "  preApproval:",
+          "    angles: [dry]",
+          "    mandatoryAngles: [pr-checklist-matrix]",
+          "    excludeAngles: [yagni]",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      // The layer was rejected — errors is non-empty.
+      assert.ok(Array.isArray(result.errors) && result.errors.length > 0, "raw-key layer should populate errors");
+      // A visible warning names the offending keys — not a silent drop.
+      // Assert the full prefixed key paths appear (e.g.
+      // gates.preApproval.mandatoryAngles) — the migration hint uses the
+      // placeholder form gates.<gate>.mandatoryAngles, so matching the real
+      // gate name proves the key-extraction worked, not the boilerplate. (#1578)
+      assert.ok(
+        result.warnings.some((w) =>
+          /Offending key\(s\):/.test(w) &&
+          /gates\.preApproval\.mandatoryAngles/.test(w) &&
+          /gates\.preApproval\.excludeAngles/.test(w),
+        ),
+        "warnings should name the offending raw keys with their full path in the Offending key(s) segment",
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("L1b: a plain consumer (no .devloops) defaults the retrospective gate OFF (#841)", async () => {
     // The retrospective is a dev-loop-development artifact; shipped defaults must be permissive so
     // an ordinary consumer's product PRs do not carry the meta-process gate. extension-defaults

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1241,20 +1241,41 @@ test("checkProvenanceAngleCoverage passes for a fully-covered draft_gate and pre
   });
 });
 
-test("checkProvenanceAngleCoverage: excluding a mandatory angle does not deadlock the write (excludeAngles filters mandatoryAngles)", async () => {
+test("checkProvenanceAngleCoverage: a mandatory angle disabled via enabled:false does not deadlock the write", async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-findings-exclude-deadlock-"));
   try {
-    // The deadlock config: yagni is mandatory AND excluded. Without filtering,
-    // every write would fail — missing-mandatory if omitted, foreign if recorded.
+    // The deadlock config: yagni is mandatory AND disabled (enabled: false).
+    // Without filtering, every write would fail — missing-mandatory if omitted,
+    // foreign if recorded. The disabled entry is excluded from the mandatory
+    // check, so the write succeeds with yagni absent from the provenance.
+    // Uses the canonical angle-entry shape (#1578): raw mandatoryAngles/
+    // excludeAngles keys are rejected by the strict gate schema and would be
+    // silently dropped, making this test pin behavior against packaged
+    // defaults rather than the override it names.
     await writeFile(path.join(repoRoot, ".devloops"), [
       "version: 1",
       "gates:",
       "  preApproval:",
-      "    angles: [dry, kiss]",
-      "    mandatoryAngles: [pr-checklist-matrix, yagni]",
-      "    excludeAngles: [yagni]",
+      "    angles:",
+      "      - dry",
+      "      - kiss",
+      "      - name: pr-checklist-matrix",
+      "        mandatory: true",
+      "      - name: yagni",
+      "        mandatory: true",
+      "        enabled: false",
       "",
     ].join("\n"), "utf8");
+    // Assert the override actually loaded (not silently dropped against
+    // packaged defaults — #1578): a schema-rejected layer would surface a
+    // warning from applyLayer. Its absence proves this override took effect,
+    // making the coverage assertion below non-vacuous.
+    const { loadDevLoopConfig } = await import("@dev-loops/core/config");
+    const cfgResult = await loadDevLoopConfig({ repoRoot });
+    assert.ok(
+      !cfgResult.warnings.some((w) => /config layer rejected by schema/.test(w)),
+      "the override layer must load without schema rejection",
+    );
     const result = await checkProvenanceAngleCoverage(
       { perAngle: [{ angle: "dry" }, { angle: "pr-checklist-matrix" }] },
       "pre_approval_gate",


### PR DESCRIPTION
## Summary

Fixes #1578.

`GateConfig`'s strict zod schema rejects raw `mandatoryAngles`/`excludeAngles` keys under `gates.<gate>`. When a config layer carries those keys, `applyLayer` dropped the **whole layer** silently — the schema-validation failure went only to the `errors` channel, which many consumers (e.g. `write-gate-findings-log.mjs`) never destructure, so the drop left packaged defaults in effect with no visible signal.

## Changes

- **`packages/core/src/config/config.mjs`** — `applyLayer` now pushes a **visible warning** to the `warnings` channel (in addition to the existing structured `errors` entry) when `FileConfigSchema.safeParse` fails. The warning names the offending keys explicitly (`unrecognized_keys` issues carry them in `.keys`), so a stale raw-key config points at the canonical angle-entry migration path.
- **`test/github/write-gate-findings-log.test.mjs`** — rewrites the vacuous "excludeAngles filters mandatoryAngles" test with the schema-valid angle-entry shape (`{ name, mandatory: true }` / `{ name, enabled: false }`). The old test used raw keys that were silently dropped, so its assertion passed against packaged defaults rather than the override it named.
- **`packages/core/test/config.test.mjs`** — adds a regression pin proving a raw-key layer produces the warning (and populates `errors`).

## Acceptance criteria

- [x] A config layer rejected by the gate schema surfaces a visible warning naming the offending keys, never a silent whole-layer drop without signal.
- [x] The vacuous test is rewritten with a schema-valid override (angle entries with `mandatory: true` / `enabled: false`).
- [x] A regression pin proves a raw-key layer produces the warning.

## Non-goals

- Widening the schema to accept the raw keys (the angle-entry form is the canonical shape).

Closes #1578
