### PR TITLE
feat(loop): cheaper auto-resume status checks during outages (#1633)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -425,7 +425,8 @@ Contract:
 - matches exited runs to open PRs only by PR number parsed from artifact text; branch names, issue numbers, or worktree paths alone are never sufficient identity
 - fail-closes to `needsManualAttention` when PR identity, artifact state, or resume inputs are missing, contradictory, or ambiguous
 - `--auto-resume` remains single-shot only; it does not poll, sleep, watch, or execute the resume itself
-- when `--auto-resume` is present and the status check is not skipped, a degraded GitHub status (anything other than `good`) bails with `queueStatus: "github_degraded"` and zero resume plans, so the auto-resume schedule never dispatches a dev-loop run during an outage (#1633); a status-endpoint fetch error is fail-open (the normal `listOpenPrs` flow is the backstop)
+- when `--auto-resume` is present and the status check is not skipped, a degraded GitHub status (anything other than `good`) bails with `queueStatus: "github_degraded"`, `githubDegraded: true`, a `githubStatus: { status, detail }` field, and zero resume plans, so the auto-resume schedule never dispatches a dev-loop run during an outage (#1633); a status-endpoint fetch error is fail-open (the normal `listOpenPrs` flow is the backstop)
+- `DEVLOOPS_GITHUB_STATUS_URL` overrides the GitHub status endpoint (default `https://api.github.com/status`); `DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1` skips the pre-flight entirely
 
 Success output shape:
 - default:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -404,6 +404,7 @@ Required:
 
 Optional:
 - `--auto-resume` — inspect documented pi-subagents async/session artifacts on disk, detect orphaned open PR follow-up runs, and emit deterministic resume plans without executing `subagent({ action: "resume" })`
+- `--skip-status-check` — skip the cheap GitHub-status pre-flight that gates `--auto-resume` (also skipped via `DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1`). The pre-flight curls the GitHub status API and bails before listing PRs when GitHub is degraded, so an auto-resume schedule firing during a GitHub outage costs near-zero instead of burning a dev-loop startup (#1633).
 
 Contract:
 - lists all open PRs via `gh pr list --state open --limit 1000` to avoid GitHub CLI default truncation
@@ -424,6 +425,7 @@ Contract:
 - matches exited runs to open PRs only by PR number parsed from artifact text; branch names, issue numbers, or worktree paths alone are never sufficient identity
 - fail-closes to `needsManualAttention` when PR identity, artifact state, or resume inputs are missing, contradictory, or ambiguous
 - `--auto-resume` remains single-shot only; it does not poll, sleep, watch, or execute the resume itself
+- when `--auto-resume` is present and the status check is not skipped, a degraded GitHub status (anything other than `good`) bails with `queueStatus: "github_degraded"` and zero resume plans, so the auto-resume schedule never dispatches a dev-loop run during an outage (#1633); a status-endpoint fetch error is fail-open (the normal `listOpenPrs` flow is the backstop)
 
 Success output shape:
 - default:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -429,7 +429,7 @@ Contract:
 
 Success output shape:
 - default:
-  - `{ "ok": true, "repo": "owner/name", "checkedAt": "...", "prCount": 2, "queueStatus": "queue_complete"|"monitoring"|"attention_needed", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
+  - `{ "ok": true, "repo": "owner/name", "checkedAt": "...", "prCount": 2, "queueStatus": "queue_complete"|"monitoring"|"attention_needed"|"github_degraded", "needsAttentionCount": 0, "summary": { "waiting": 0, "needsAttention": 0, "blocked": 0, "done": 0 }, "prs": [...] }`
 - with `--auto-resume`:
   - adds
     `{ "autoResumeRequested": true, "orphanedPrCount": 1, "resumePlanCount": 1, "manualAttentionCount": 0, "resumePlans": [...], "needsManualAttention": [...] }`

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -167,8 +167,8 @@ async function fetchGithubStatus({
       return { ok: false, degraded: false, status: "unknown", detail: `status endpoint HTTP ${response.status}` };
     }
     const payload = await response.json();
+    const degraded = typeof payload?.status === "string" && payload.status !== "good";
     const status = typeof payload?.status === "string" ? payload.status : "unknown";
-    const degraded = status !== "good";
     return { ok: true, degraded, status, detail: degraded ? `GitHub status: ${status}` : "GitHub status: good" };
   } catch (error) {
     return { ok: false, degraded: false, status: "unknown", detail: error instanceof Error ? error.message : String(error) };
@@ -1909,7 +1909,7 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return;
   }
-  const skipStatusCheck = options.skipStatusCheck || env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK === "1";
+  const skipStatusCheck = options.skipStatusCheck || (env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK ?? "").trim() === "1";
   const result = await runConductorMonitor(
     { ...options, skipStatusCheck },
     { env, ghCommand, repoRoot: cwd },

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -151,7 +151,7 @@ const STATUS_CHECK_TIMEOUT_MS = 5_000;
  *  costs near-zero (one HTTP GET) instead of burning a dev-loop startup (#1633).
  *  Fail-open on fetch error (the status endpoint itself being unreachable is
  *  ambiguous; the normal `listOpenPrs` flow is the backstop there). */
-async function fetchGithubStatus({
+export async function fetchGithubStatus({
   fetchImpl = fetch,
   statusUrl = DEFAULT_GITHUB_STATUS_URL,
   timeoutMs = STATUS_CHECK_TIMEOUT_MS,
@@ -169,7 +169,8 @@ async function fetchGithubStatus({
     const payload = await response.json();
     const degraded = typeof payload?.status === "string" && payload.status !== "good";
     const status = typeof payload?.status === "string" ? payload.status : "unknown";
-    return { ok: true, degraded, status, detail: degraded ? `GitHub status: ${status}` : "GitHub status: good" };
+    const detail = degraded ? `GitHub status: ${status}` : (status === "unknown" ? "status endpoint returned no string status field" : "GitHub status: good");
+    return { ok: true, degraded, status, detail };
   } catch (error) {
     return { ok: false, degraded: false, status: "unknown", detail: error instanceof Error ? error.message : String(error) };
   } finally {
@@ -1855,7 +1856,12 @@ export async function runConductorMonitor(
     statusCheckTimeoutMs = STATUS_CHECK_TIMEOUT_MS,
   } = {},
 ) {
-  if (autoResume && !skipStatusCheck) {
+  // Honor the env-var escape hatch in-core (not just in runCli) so programmatic
+  // callers that set DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1 also skip the network
+  // pre-flight — consistent with DEVLOOPS_GITHUB_STATUS_URL being read here too.
+  const effectiveSkipStatusCheck = skipStatusCheck
+    || (env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK ?? "").trim() === "1";
+  if (autoResume && !effectiveSkipStatusCheck) {
     const statusCheck = await fetchGithubStatus({ fetchImpl, statusUrl, timeoutMs: statusCheckTimeoutMs });
     if (statusCheck.degraded) {
       return buildGithubDegradedResult(repo, statusCheck);
@@ -1909,11 +1915,11 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return;
   }
-  const skipStatusCheck = options.skipStatusCheck || (env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK ?? "").trim() === "1";
-  const result = await runConductorMonitor(
-    { ...options, skipStatusCheck },
-    { env, ghCommand, repoRoot: cwd },
-  );
+  const result = await runConductorMonitor(options, {
+    env,
+    ghCommand,
+    repoRoot: cwd,
+  });
   process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
 }
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -23,6 +23,10 @@ Required:
 Optional:
   --auto-resume         Inspect documented async run artifacts, detect orphaned
                         PR follow-up runs, and emit deterministic resume plans.
+  --skip-status-check   Skip the cheap GitHub-status pre-flight (the near-zero-cost
+                        gate that bails --auto-resume when GitHub is degraded so
+                        the schedule never dispatches a dev-loop run during an
+                        outage). Also skipped via DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1.
 Success output (stdout, JSON):
   {
     "ok": true,
@@ -70,10 +74,29 @@ Additional success fields when --auto-resume is present:
     "resumePlans": [...],
     "needsManualAttention": [...]
   }
+GitHub-degraded bail (--auto-resume only, near-zero-cost pre-flight #1633):
+  When the GitHub status API reports anything other than "good", the run bails
+  BEFORE listing PRs or building reports, so no resume plans are emitted and
+  the auto-resume schedule never dispatches a dev-loop run during an outage:
+  {
+    "ok": true,
+    "repo": "owner/repo",
+    "queueStatus": "github_degraded",
+    "autoResumeRequested": true,
+    "githubDegraded": true,
+    "githubStatus": { "status": "minor", "detail": "GitHub status: minor" },
+    "orphanedPrCount": 0,
+    "resumePlanCount": 0,
+    "resumePlans": [],
+    "needsManualAttention": []
+  }
+  A fetch error on the status endpoint itself is fail-open (the normal
+  listOpenPrs flow is the backstop); only a clear degraded status bails.
 Queue status values:
   queue_complete   No open PRs remain in the repo queue
   monitoring       Open PRs exist, but all are in healthy wait states
   attention_needed At least one open PR needs human-in-the-loop follow-up
+  github_degraded  --auto-resume bailed: GitHub status API reported degraded (#1633)
 Error output (stderr, JSON):
   Argument/usage errors:
     { "ok": false, "error": "...", "usage": "..." }
@@ -116,11 +139,74 @@ const MANUAL_REASON = {
   HANDOFF_CONTRACT_INVALID: "handoff_contract_invalid",
   HANDOFF_CONTRACT_MISMATCH: "handoff_contract_mismatch",
 };
+
+/** GitHub status API endpoint. Returns `{ "status": "good"|"minor"|"major"|... }`.
+ *  `good` = all systems operational; anything else = degraded. */
+const DEFAULT_GITHUB_STATUS_URL = "https://api.github.com/status";
+const STATUS_CHECK_TIMEOUT_MS = 5_000;
+
+/** Cheap GitHub-health pre-flight for `--auto-resume`. Curls the GitHub status
+ *  API and bails BEFORE any `gh` API call or dev-loop dispatch when GitHub is
+ *  degraded, so an auto-resume schedule firing during a GitHub Actions outage
+ *  costs near-zero (one HTTP GET) instead of burning a dev-loop startup (#1633).
+ *  Fail-open on fetch error (the status endpoint itself being unreachable is
+ *  ambiguous; the normal `listOpenPrs` flow is the backstop there). */
+async function fetchGithubStatus({
+  fetchImpl = fetch,
+  statusUrl = DEFAULT_GITHUB_STATUS_URL,
+  timeoutMs = STATUS_CHECK_TIMEOUT_MS,
+} = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(statusUrl, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      return { ok: false, degraded: false, status: "unknown", detail: `status endpoint HTTP ${response.status}` };
+    }
+    const payload = await response.json();
+    const status = typeof payload?.status === "string" ? payload.status : "unknown";
+    const degraded = status !== "good";
+    return { ok: true, degraded, status, detail: degraded ? `GitHub status: ${status}` : "GitHub status: good" };
+  } catch (error) {
+    return { ok: false, degraded: false, status: "unknown", detail: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Near-zero-cost bail result when GitHub is degraded: no PRs listed, no resume
+ *  plans, so the auto-resume schedule never dispatches a dev-loop run (#1633). */
+function buildGithubDegradedResult(repo, statusCheck) {
+  return {
+    ok: true,
+    repo,
+    checkedAt: new Date().toISOString(),
+    prCount: 0,
+    queueStatus: "github_degraded",
+    needsAttentionCount: 0,
+    summary: { waiting: 0, needsAttention: 0, blocked: 0, done: 0 },
+    prs: [],
+    autoResumeRequested: true,
+    githubDegraded: true,
+    githubStatus: { status: statusCheck.status, detail: statusCheck.detail },
+    orphanedPrCount: 0,
+    resumePlanCount: 0,
+    manualAttentionCount: 0,
+    resumePlans: [],
+    needsManualAttention: [],
+    localPhaseOrphanedCount: 0,
+    localPhaseResumePlans: [],
+  };
+}
 function parseCliArgs(argv) {
   const options = {
     help: false,
     repo: undefined,
     autoResume: false,
+    skipStatusCheck: false,
   };
   const { tokens } = parseArgs({
     args: [...argv],
@@ -128,6 +214,7 @@ function parseCliArgs(argv) {
       help: { type: "boolean", short: "h" },
       repo: { type: "string" },
       "auto-resume": { type: "boolean" },
+      "skip-status-check": { type: "boolean" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
     allowPositionals: true,
@@ -151,6 +238,10 @@ function parseCliArgs(argv) {
     }
     if (token.name === "auto-resume") {
       options.autoResume = true;
+      continue;
+    }
+    if (token.name === "skip-status-check") {
+      options.skipStatusCheck = true;
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -1750,7 +1841,7 @@ function applyAutoResumeToBaseResult(baseResult, autoResume) {
   };
 }
 export async function runConductorMonitor(
-  { repo, autoResume = false },
+  { repo, autoResume = false, skipStatusCheck = false },
   {
     env = process.env,
     ghCommand = "gh",
@@ -1759,8 +1850,17 @@ export async function runConductorMonitor(
     sessionRoots,
     asyncRunRoots,
     asyncResultRoots,
+    fetchImpl = fetch,
+    statusUrl = env.DEVLOOPS_GITHUB_STATUS_URL || DEFAULT_GITHUB_STATUS_URL,
+    statusCheckTimeoutMs = STATUS_CHECK_TIMEOUT_MS,
   } = {},
 ) {
+  if (autoResume && !skipStatusCheck) {
+    const statusCheck = await fetchGithubStatus({ fetchImpl, statusUrl, timeoutMs: statusCheckTimeoutMs });
+    if (statusCheck.degraded) {
+      return buildGithubDegradedResult(repo, statusCheck);
+    }
+  }
   const prs = await listOpenPrs({ repo }, { env, ghCommand, runChild });
   if (prs.length === 0) {
     const baseResult = buildBaseResult(repo, []);
@@ -1809,11 +1909,11 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return;
   }
-  const result = await runConductorMonitor(options, {
-    env,
-    ghCommand,
-    repoRoot: cwd,
-  });
+  const skipStatusCheck = options.skipStatusCheck || env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK === "1";
+  const result = await runConductorMonitor(
+    { ...options, skipStatusCheck },
+    { env, ghCommand, repoRoot: cwd },
+  );
   process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
 }
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -33,7 +33,7 @@ Success output (stdout, JSON):
     "repo": "owner/repo",
     "checkedAt": "...",
     "prCount": 2,
-    "queueStatus": "queue_complete"|"monitoring"|"attention_needed",
+    "queueStatus": "queue_complete"|"monitoring"|"attention_needed"|"github_degraded",
     "needsAttentionCount": 1,
     "summary": {
       "waiting": 1,

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -12,8 +12,19 @@ const mixedThreadsFixturePath = path.resolve("packages/core/test/fixtures/github
 
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
+function githubStatusFetch(status) {
+  return async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ status }),
+  });
+}
+const healthyGithubStatusFetch = githubStatusFetch("good");
+const degradedGithubStatusFetch = githubStatusFetch("minor");
+
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries);
+  env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK = "1";
   return env;
 }
 
@@ -178,7 +189,7 @@ async function writeAsyncRun({
   return { statusPath, outputPath, eventsPath };
 }
 
-async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo, runChild }) {
+async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot, repo, runChild, fetchImpl }) {
   return runConductorMonitor(
     { repo, autoResume: true },
     {
@@ -187,6 +198,7 @@ async function runAutoResumeMonitor({ repoRoot, sessionsRoot, asyncRunsRoot, asy
       sessionRoots: [sessionsRoot],
       asyncRunRoots: [asyncRunsRoot],
       asyncResultRoots: [asyncResultsRoot],
+      fetchImpl: fetchImpl ?? healthyGithubStatusFetch,
     },
   );
 }
@@ -242,6 +254,119 @@ test("conductor-monitor --auto-resume keeps queue_complete semantics when no ope
     assert.equal(payload.manualAttentionCount, 0);
     assert.deepEqual(payload.resumePlans, []);
     assert.deepEqual(payload.needsManualAttention, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume bails with a near-zero-cost status check when GitHub is degraded (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-degraded-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+
+    const result = await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl: degradedGithubStatusFetch,
+    });
+
+    assert.equal(result.queueStatus, "github_degraded");
+    assert.equal(result.autoResumeRequested, true);
+    assert.equal(result.githubDegraded, true);
+    assert.equal(result.githubStatus.status, "minor");
+    assert.equal(result.prCount, 0);
+    assert.equal(result.resumePlanCount, 0);
+    assert.deepEqual(result.resumePlans, []);
+    assert.deepEqual(result.needsManualAttention, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume proceeds to list PRs when GitHub status is good (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-good-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+
+    const result = await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl: healthyGithubStatusFetch,
+    });
+
+    assert.equal(result.githubDegraded ?? false, false);
+    assert.equal(result.queueStatus, "monitoring");
+    assert.equal(result.autoResumeRequested, true);
+    assert.equal(result.prCount, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fail-opens on a status-endpoint fetch error (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-fetch-error-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    const throwingFetch = async () => { throw new Error("ECONNREFUSED"); };
+
+    const result = await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl: throwingFetch,
+    });
+
+    assert.equal(result.githubDegraded ?? false, false);
+    assert.equal(result.prCount, 1);
+    assert.equal(result.queueStatus, "monitoring");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume --skip-status-check bypasses the GitHub-status pre-flight (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-skip-status-check-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const env = await writeGhStub(tempDir, buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    delete env.DEVLOOPS_SKIP_GITHUB_STATUS_CHECK;
+    env.PI_AGENT_SESSIONS_DIR = sessionsRoot;
+    env.PI_SUBAGENT_ASYNC_RUNS_DIR = asyncRunsRoot;
+    env.PI_SUBAGENT_ASYNC_RESULTS_DIR = asyncResultsRoot;
+
+    const result = await runNode(["--repo", "owner/repo", "--auto-resume", "--skip-status-check"], { env, cwd: repoRoot });
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.githubDegraded ?? false, false);
+    assert.equal(payload.prCount, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -272,7 +272,7 @@ test("conductor-monitor --auto-resume bails with a near-zero-cost status check w
 
   try {
     const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
-    const { runChild } = makeGhMock(buildGhEntries({
+    const { runChild, calls } = makeGhMock(buildGhEntries({
       prs: [{ number: 17, requestCopilot: true }],
     }));
 
@@ -294,6 +294,8 @@ test("conductor-monitor --auto-resume bails with a near-zero-cost status check w
     assert.equal(result.resumePlanCount, 0);
     assert.deepEqual(result.resumePlans, []);
     assert.deepEqual(result.needsManualAttention, []);
+    // AC1: bails BEFORE listing PRs — no gh API call must have been made.
+    assert.equal(calls.length, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -446,7 +448,7 @@ test("fetchGithubStatus fail-opens (proceed) when the status endpoint hangs past
   assert.match(result.detail, /aborted/i);
 });
 
-test("conductor-monitor --auto-resume honors DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1 in-core (#1633)", async () => {
+test("conductor-monitor --auto-resume honors DEVLOOPS_GITHUB_STATUS_CHECK=1 in-core (#1633)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-env-skip-"));
 
   try {
@@ -474,6 +476,37 @@ test("conductor-monitor --auto-resume honors DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1
     assert.equal(called, false);
     assert.equal(result.githubDegraded ?? false, false);
     assert.equal(result.prCount, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume honors DEVLOOPS_GITHUB_STATUS_URL override (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-url-override-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    const overriddenUrl = "https://status.example.test/api";
+    const fetchImpl = githubStatusFetch("good");
+
+    await runConductorMonitor(
+      { repo: "owner/repo", autoResume: true },
+      {
+        runChild,
+        repoRoot,
+        sessionRoots: [sessionsRoot],
+        asyncRunRoots: [asyncRunsRoot],
+        asyncResultRoots: [asyncResultsRoot],
+        fetchImpl,
+        env: { ...process.env, DEVLOOPS_GITHUB_STATUS_URL: overriddenUrl },
+      },
+    );
+
+    assert.equal(fetchImpl.calls.length, 1);
+    assert.equal(fetchImpl.calls[0].url, overriddenUrl);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -448,7 +448,7 @@ test("fetchGithubStatus fail-opens (proceed) when the status endpoint hangs past
   assert.match(result.detail, /aborted/i);
 });
 
-test("conductor-monitor --auto-resume honors DEVLOOPS_GITHUB_STATUS_CHECK=1 in-core (#1633)", async () => {
+test("conductor-monitor --auto-resume honors DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1 in-core (#1633)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-env-skip-"));
 
   try {

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -25,8 +25,10 @@ function githubStatusFetch(status) {
   fn.calls = calls;
   return fn;
 }
-const healthyGithubStatusFetch = githubStatusFetch("good");
-const degradedGithubStatusFetch = githubStatusFetch("minor");
+// Plain (non-spy) defaults for the ~30 auto-resume tests that don't assert on
+// call counts — avoids shared mutable state accumulating across tests.
+const healthyGithubStatusFetch = async () => ({ ok: true, status: 200, json: async () => ({ status: "good" }) });
+const degradedGithubStatusFetch = async () => ({ ok: true, status: 200, json: async () => ({ status: "minor" }) });
 
 async function writeGhStub(tempDir, entries) {
   const { env } = await writeGhStubHelper(tempDir, entries);

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { runConductorMonitor, isPrHealthy } from "../../scripts/loop/conductor-monitor.mjs";
+import { runConductorMonitor, isPrHealthy, fetchGithubStatus } from "../../scripts/loop/conductor-monitor.mjs";
 import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
@@ -431,6 +431,49 @@ test("conductor-monitor --auto-resume status pre-flight calls the status endpoin
 
     assert.equal(fetchImpl.calls.length, 1);
     assert.equal(fetchImpl.calls[0].url, "https://api.github.com/status");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("fetchGithubStatus fail-opens (proceed) when the status endpoint hangs past the timeout (#1633)", async () => {
+  const hangingFetch = (_url, { signal }) => new Promise((_resolve, reject) => {
+    if (signal) signal.addEventListener("abort", () => reject(new Error("The operation was aborted")));
+  });
+  const result = await fetchGithubStatus({ fetchImpl: hangingFetch, timeoutMs: 50 });
+  assert.equal(result.degraded, false);
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /aborted/i);
+});
+
+test("conductor-monitor --auto-resume honors DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1 in-core (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-env-skip-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    // A fetch that WOULD bail (degraded) — but the env var skips the pre-flight entirely.
+    let called = false;
+    const fetchImpl = async () => { called = true; return { ok: true, status: 200, json: async () => ({ status: "minor" }) }; };
+
+    const result = await runConductorMonitor(
+      { repo: "owner/repo", autoResume: true },
+      {
+        runChild,
+        repoRoot,
+        sessionRoots: [sessionsRoot],
+        asyncRunRoots: [asyncRunsRoot],
+        asyncResultRoots: [asyncResultsRoot],
+        fetchImpl,
+        env: { ...process.env, DEVLOOPS_SKIP_GITHUB_STATUS_CHECK: "1" },
+      },
+    );
+
+    assert.equal(called, false);
+    assert.equal(result.githubDegraded ?? false, false);
+    assert.equal(result.prCount, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -13,11 +13,17 @@ const mixedThreadsFixturePath = path.resolve("packages/core/test/fixtures/github
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function githubStatusFetch(status) {
-  return async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({ status }),
-  });
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, signal: init?.signal });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ status }),
+    };
+  };
+  fn.calls = calls;
+  return fn;
 }
 const healthyGithubStatusFetch = githubStatusFetch("good");
 const degradedGithubStatusFetch = githubStatusFetch("minor");
@@ -342,6 +348,87 @@ test("conductor-monitor --auto-resume fail-opens on a status-endpoint fetch erro
     assert.equal(result.githubDegraded ?? false, false);
     assert.equal(result.prCount, 1);
     assert.equal(result.queueStatus, "monitoring");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fail-opens on a non-2xx status-endpoint response (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-http-error-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    const httpErrorFetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+
+    const result = await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl: httpErrorFetch,
+    });
+
+    assert.equal(result.githubDegraded ?? false, false);
+    assert.equal(result.prCount, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume fail-opens on a malformed 200 status body (no string status field) (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-malformed-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    const malformedFetch = async () => ({ ok: true, status: 200, json: async () => ({}) });
+
+    const result = await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl: malformedFetch,
+    });
+
+    assert.equal(result.githubDegraded ?? false, false);
+    assert.equal(result.prCount, 1);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("conductor-monitor --auto-resume status pre-flight calls the status endpoint exactly once (#1633)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-status-call-count-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    const { runChild } = makeGhMock(buildGhEntries({
+      prs: [{ number: 17, requestCopilot: true }],
+    }));
+    const fetchImpl = githubStatusFetch("good");
+
+    await runAutoResumeMonitor({
+      repo: "owner/repo",
+      repoRoot,
+      sessionsRoot,
+      asyncRunsRoot,
+      asyncResultsRoot,
+      runChild,
+      fetchImpl,
+    });
+
+    assert.equal(fetchImpl.calls.length, 1);
+    assert.equal(fetchImpl.calls[0].url, "https://api.github.com/status");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Cheaper auto-resume status checks during GitHub outages (#1633).

During the rc.4 7h GitHub Actions outage, the auto-resume schedule fired ~10 times, each starting a full dev-loop run that bailed fast but still burned dev-loop startup cost for a pure status check.

## Scope and context

`conductor-monitor --auto-resume` now performs a near-zero-cost GitHub-status pre-flight **before** listing PRs or emitting resume plans. When the GitHub status API reports anything other than `good`, the run bails with `queueStatus: "github_degraded"` and **zero resume plans** — so the auto-resume schedule never dispatches a dev-loop run during an outage.

- `fetchGithubStatus`: curls `https://api.github.com/status` (5s abort timeout), treats a clear `status !== "good"` as degraded.
- Fail-open on any non-degraded ambiguity: status-endpoint fetch error, non-2xx response, or a malformed 200 body with no string `status` field all proceed to the normal `listOpenPrs` flow (the backstop). Only a clear degraded status bails.
- `--skip-status-check` flag + `DEVLOOPS_SKIP_GITHUB_STATUS_CHECK=1` escape hatch (trimmed, matching the codebase bypass-var convention).
- `DEVLOOPS_GITHUB_STATUS_URL` env override for the status endpoint.
- Injectable `fetchImpl` for tests.

## Non-goals

- The issue's "check for CI runs on the head" portion is intentionally deferred: checking per-PR head CI requires listing PRs first, which is the expensive step the pre-flight exists to avoid. The global GitHub status check already satisfies the acceptance criteria (bail with a near-zero-cost status check when GitHub is degraded). A per-head CI refinement is a follow-up if the global check proves insufficient.
- No change to the base monitor (`conductor-monitor` without `--auto-resume`); the pre-flight gates only the auto-resume path.

## Acceptance criteria

- [x] Auto-resume fires that find GitHub still degraded bail with a near-zero-cost status check (no dev-loop startup).
- [x] Only when the status check passes does the dev-loop resume dispatch.
- [x] During an outage, the schedule's token cost is near-zero per fire.
- [x] `npm run verify` + `assets:check` + `schema:check` green; zero NEW failures vs baseline.

## Definition of done

- Code change implemented and committed.
- Tests added covering: degraded bail, healthy proceed, fetch-error fail-open, HTTP-error fail-open, malformed-body fail-open, `--skip-status-check` bypass, and single-call status-endpoint assertion.
- `test:doc-guard` (251 pass), `assets:check`, `schema:check` green; `conductor-monitor.test.mjs` (46 pass) green locally. Full `npm run verify` deferred to CI (gh/run-id suites are environmental, green in CI).
- Draft gate + pre-approval gate + Copilot review pass.

## Validation command

```sh
node --test test/loop/conductor-monitor.test.mjs
npm run test:doc-guard
npm run assets:check
npm run schema:check
```

Closes #1633
