### PR TITLE
faster stuck-CI bail (zero-allocation stall detector) (#1631)

### DIFF
--- a/packages/core/src/loop/copilot-ci-status.mjs
+++ b/packages/core/src/loop/copilot-ci-status.mjs
@@ -144,24 +144,35 @@ export function normalizeStatusCheckRollupStatus(rollup) {
 /**
  * Summarize the GitHub check-runs API payload for one head SHA.
  *
+ * `allQueued` is the zero-allocation stall signal (#1631): true when at least one
+ * check-run is present AND every one is still in the `queued` status — i.e. no
+ * runner has been allocated to any job (no job picked up / in_progress / completed).
+ * The CI watcher uses it to bail early on a stuck GitHub Actions queue instead
+ * of burning the full watch budget.
+ *
  * @param {object} payload
- * @returns {{ status: "success"|"failure"|"pending"|"none", unsupportedCompleted: boolean, failureDetails?: Array<string> }}
+ * @returns {{ status: "success"|"failure"|"pending"|"none", unsupportedCompleted: boolean, allQueued: boolean, failureDetails?: Array<string> }}
  */
 export function summarizeHeadScopedCheckRunsSignal(payload) {
   const runs = Array.isArray(payload?.check_runs) ? payload.check_runs : [];
   if (runs.length === 0) {
-    return { status: "none", unsupportedCompleted: false };
+    return { status: "none", unsupportedCompleted: false, allQueued: false };
   }
 
   let hasPending = false;
   let hasFailure = false;
   let hasSuccess = false;
   let hasUnsupportedCompleted = false;
+  let allQueued = true; // every run is status "queued" (zero runner allocation)
   const failureDetails = [];
 
   for (const run of runs) {
     const status = typeof run?.status === "string" ? run.status.toUpperCase() : "";
     const conclusion = typeof run?.conclusion === "string" ? run.conclusion.toUpperCase() : "";
+
+    if (status !== "QUEUED") {
+      allQueued = false;
+    }
 
     if (status !== "COMPLETED") {
       hasPending = true;
@@ -183,11 +194,11 @@ export function summarizeHeadScopedCheckRunsSignal(payload) {
     hasUnsupportedCompleted = true;
   }
 
-  if (hasFailure) return { status: "failure", unsupportedCompleted: hasUnsupportedCompleted, failureDetails };
-  if (hasPending) return { status: "pending", unsupportedCompleted: hasUnsupportedCompleted, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
-  if (hasUnsupportedCompleted) return { status: "none", unsupportedCompleted: true, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
-  if (hasSuccess) return { status: "success", unsupportedCompleted: false, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
-  return { status: "none", unsupportedCompleted: false, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  if (hasFailure) return { status: "failure", unsupportedCompleted: hasUnsupportedCompleted, allQueued, failureDetails };
+  if (hasPending) return { status: "pending", unsupportedCompleted: hasUnsupportedCompleted, allQueued, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  if (hasUnsupportedCompleted) return { status: "none", unsupportedCompleted: true, allQueued, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  if (hasSuccess) return { status: "success", unsupportedCompleted: false, allQueued, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
+  return { status: "none", unsupportedCompleted: false, allQueued, failureDetails: failureDetails.length > 0 ? failureDetails : undefined };
 }
 
 /**

--- a/packages/core/test/copilot-ci-status.test.mjs
+++ b/packages/core/test/copilot-ci-status.test.mjs
@@ -63,6 +63,42 @@ test("summarizeHeadScopedCheckRunsSignal preserves unsupported completed conclus
   assert.equal(summary.unsupportedCompleted, true);
 });
 
+test("summarizeHeadScopedCheckRunsSignal flags all-queued as a zero-allocation stall (#1631)", () => {
+  // Every check-run still `queued` (no runner allocated / no job picked up) →
+  // allQueued true. This is the zero-allocation stall signal the CI watcher
+  // bails on instead of burning its full watch budget.
+  const stalled = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [
+      { status: "queued", conclusion: null, name: "build" },
+      { status: "QUEUED", conclusion: null, name: "lint" },
+    ],
+  });
+  assert.equal(stalled.allQueued, true);
+  assert.equal(stalled.status, "pending");
+});
+
+test("summarizeHeadScopedCheckRunsSignal clears allQueued when any job is progressing (#1631)", () => {
+  // A run that IS progressing (in_progress / completed) must NOT read as a
+  // zero-allocation stall.
+  const inProgress = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [
+      { status: "queued", conclusion: null, name: "build" },
+      { status: "in_progress", conclusion: null, name: "lint" },
+    ],
+  });
+  assert.equal(inProgress.allQueued, false);
+
+  const completed = summarizeHeadScopedCheckRunsSignal({
+    check_runs: [{ status: "completed", conclusion: "success", name: "build" }],
+  });
+  assert.equal(completed.allQueued, false);
+});
+
+test("summarizeHeadScopedCheckRunsSignal reports allQueued false for an empty set", () => {
+  const empty = summarizeHeadScopedCheckRunsSignal({ check_runs: [] });
+  assert.equal(empty.allQueued, false);
+});
+
 test("normalizeHeadScopedCheckRunsStatus returns failure over pending for mixed check runs", () => {
   const status = normalizeHeadScopedCheckRunsStatus({
     check_runs: [

--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -34,7 +34,7 @@ Optional:
   --timeout-ms <n>              Total watch budget (default 1800000; 0 = single check, no wait)
   --poll-interval-ms <n>        Delay between polls (default 60000)
 Output (stdout, JSON):
-  { "ok": true, "status": "success"|"failure"|"pending"|"timeout"|"changed",
+  { "ok": true, "status": "success"|"failure"|"pending"|"timeout"|"changed"|"stuck",
     "settled": bool, "ciStatus": "success"|"failure"|"pending"|"none",
     "failedChecks": [{ "name": "...", "conclusion"?: "..." }], "headSha": "...", "attempts": N,
     "excludedFailureDetails": ["gate-evidence", ...] }
@@ -44,6 +44,10 @@ Statuses:
   pending    Timed-out single check (timeout-ms 0) found CI still in flight
   timeout    Watch budget elapsed while CI was still pending
   changed    Head SHA advanced during the wait; caller must re-baseline
+  stuck      Zero-allocation stall bail (#1631): every check-run stayed QUEUED
+             with zero jobs allocated (no runner picked up) and no other provider
+             reporting activity for ~5 min; treated as a stuck GitHub Actions
+             queue and bailed early instead of burning the full watch budget
 No-checks rule (grace, race-safe):
   Zero check-runs AND zero commit-statuses is NOT settled green on the first
   poll — a provider (CircleCI/Actions) may post its first check a beat after a
@@ -240,7 +244,11 @@ async function fetchHeadCiState({ repo, headSha, prVisibleCheckNames }, { env, g
           : nonLoopDerivedRuns;
         const visibleSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: visibleRuns });
         const fullSignal = summarizeHeadScopedCheckRunsSignal({ check_runs: nonLoopDerivedRuns });
-        checkRunsSignal = { ...visibleSignal, unsupportedCompleted: fullSignal.unsupportedCompleted };
+        checkRunsSignal = {
+          ...visibleSignal,
+          unsupportedCompleted: fullSignal.unsupportedCompleted,
+          allQueued: fullSignal.allQueued,
+        };
         checkRunsCount = nonLoopDerivedRuns.length;
       } else {
         checkRunsError = true; // exit 0 but no check_runs array → malformed payload, not empty
@@ -318,7 +326,18 @@ async function fetchHeadCiState({ repo, headSha, prVisibleCheckNames }, { env, g
     checkRunsCount === 0 &&
     statusesCount === 0 &&
     !(nonLoopDerivedPrVisibleNames?.length > 0);
-  return { ciStatus, noChecks, fetchError, failedChecks, excludedFailureDetails };
+  // Zero-allocation stall (#1631): at least one real check-run, ALL of them
+  // still `queued` (no runner allocated / no job picked up), and no other
+  // provider reporting activity (commit-status none). The watcher bails after
+  // ZERO_ALLOCATION_STALL_BAIL_MS of observing this instead of burning its
+  // full budget on a stuck GitHub Actions queue. A run with any job
+  // in_progress/completed, or another provider pending, never qualifies.
+  const allCheckRunsQueued =
+    !fetchError &&
+    checkRunsCount > 0 &&
+    checkRunsSignal?.allQueued === true &&
+    commitStatus === "none";
+  return { ciStatus, noChecks, fetchError, failedChecks, excludedFailureDetails, allCheckRunsQueued };
 }
 
 function buildAttemptBudget(timeoutMs, pollIntervalMs) {
@@ -361,6 +380,14 @@ function settledResult(state, { settled, status }) {
  *  has no CI still settles after the grace instead of hanging to timeout. */
 export const NO_CHECKS_GRACE_POLLS = 2;
 
+/** Zero-allocation stall bail budget (#1631): when a CI run is QUEUED with zero
+ *  jobs allocated (no runner picked up — every check-run still `queued`, no other
+ *  provider reporting activity), the watcher bails after ~5 min instead of burning
+ *  the full 30-min watch budget on a stuck GitHub Actions queue. A run that IS
+ *  progressing (any check-run in_progress/completed, or another provider pending)
+ *  is never bailed early. */
+export const ZERO_ALLOCATION_STALL_BAIL_MS = 300_000; // ~5 minutes
+
 /**
  * Map a head CI state to a terminal watcher status, or null when still in flight.
  * - failure / success classify immediately (a check is terminal).
@@ -397,6 +424,12 @@ export async function watchCiStatus(
   // immediately (preserves single-check semantics). A real watch awaits the grace.
   const graceFloor = options.timeoutMs === 0 ? 1 : NO_CHECKS_GRACE_POLLS;
   let consecutiveNoChecks = 0;
+  // Zero-allocation stall bail (#1631): track the first poll that observed a
+  // zero-allocation stall (all check-runs queued, no provider activity). The
+  // watcher bails once the stall has persisted for stallBailMs instead of
+  // burning the full watch budget on a stuck GitHub Actions queue.
+  const stallBailMs = options.stallBailMs ?? ZERO_ALLOCATION_STALL_BAIL_MS;
+  let stallStartedAtMs = null;
   for (let attempt = 1; attempt <= attemptBudget; attempt += 1) {
     // Attempt 1 polls at t=0 (CI may already be terminal); sleep only between
     // subsequent polls so the watcher never burns a full interval before its
@@ -473,6 +506,17 @@ export async function watchCiStatus(
         settled: true,
         status: terminal,
       });
+    }
+    if (state.allCheckRunsQueued) {
+      if (stallStartedAtMs === null) stallStartedAtMs = now();
+      if (now() - stallStartedAtMs >= stallBailMs) {
+        return settledResult({ ...state, headSha: currentSha, attempts: attempt }, {
+          settled: false,
+          status: "stuck",
+        });
+      }
+    } else {
+      stallStartedAtMs = null;
     }
   }
   // Budget exhausted while still pending. Re-resolve the head before the final

--- a/scripts/github/wait-pr-checks.mjs
+++ b/scripts/github/wait-pr-checks.mjs
@@ -36,11 +36,14 @@ Not-yet-registered-check race guard:
   check-less. A repo with no CI at all still settles after that grace instead
   of hanging to timeout.
 Output (stdout, JSON, the final per-check summary):
-  { "ok": true, "status": "success"|"failure"|"pending"|"timeout"|"changed",
+  { "ok": true, "status": "success"|"failure"|"pending"|"timeout"|"changed"|"stuck",
     "settled": bool, "ciStatus": "success"|"failure"|"pending"|"none",
     "failedChecks": [{ "name": "...", "conclusion"?: "..." }], "headSha": "...", "attempts": N,
     "excludedFailureDetails": ["gate-evidence", ...] }
 "changed" means the head SHA advanced during the wait; re-baseline and re-run.
+"stuck" means a zero-allocation stall bail (#1631): every check-run stayed
+QUEUED with zero jobs allocated for ~5 min; bailed early instead of the full
+budget.
 Diagnostic output (stderr):
   { "ok": true, "type": "watch_heartbeat", "elapsedMs": N, "totalBudgetMs": N, "poll": N, "maxPolls": N }
   { "ok": false, "error": "...", "usage"?: "..." }

--- a/scripts/github/wait-pr-checks.mjs
+++ b/scripts/github/wait-pr-checks.mjs
@@ -51,7 +51,7 @@ ${JQ_OUTPUT_USAGE}
 Exit codes (default output, no --jq/--silent):
   0  Green (status "success")
   1  Red (status "failure"), or an argument/gh/runtime error
-  2  Not settled (status "timeout"/"changed"/"pending")
+  2  Not settled (status "timeout"/"changed"/"pending"/"stuck")
 With --jq/--silent, the standard jq-output contract above applies instead
 (0/1 by result truthiness; 2 reserved for an invalid --jq filter).`.trim();
 

--- a/test/github/probe-ci-status.test.mjs
+++ b/test/github/probe-ci-status.test.mjs
@@ -808,3 +808,160 @@ test("watch-ci: a head with ONLY loop-derived entries settles success after grac
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// Zero-allocation stall bail (#1631): a CI run QUEUED with zero jobs allocated
+// (every check-run still `queued`, no runner picked up) is treated as stuck
+// and bails after ~5 min instead of burning the full 30-min watch budget. A
+// run that IS progressing (in_progress/completed) or has another provider
+// pending is never bailed early.
+// ---------------------------------------------------------------------------
+
+// Advancing clock: delayImpl advances a mutable time, now() reads it. Lets a
+// real inter-poll delay elapse (so the stall window can mature) without sleeping.
+function advancingDeps(env) {
+  let clock = 0;
+  return {
+    env,
+    ghCommand: "gh",
+    delayImpl: async (ms) => { clock += ms; },
+    now: () => clock,
+  };
+}
+
+test("watch-ci bails stuck within the stall window when all check-runs are queued (#1631)", async () => {
+  // Every check-run stays `queued` (zero jobs allocated, no job picked up). The
+  // watcher bails "stuck" once the stall has persisted past stallBailMs instead
+  // of burning the full watch budget.
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build", "lint"]) },
+        { match: ["check-runs"], stdout: checkRuns([
+          { status: "queued", conclusion: null, name: "build" },
+          { status: "queued", conclusion: null, name: "lint" },
+        ]) },
+        { match: ["/status"], stdout: statuses([]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 10_000, stallBailMs: 50 },
+        advancingDeps(env),
+      );
+      assert.equal(result.status, "stuck");
+      assert.equal(result.settled, false);
+      assert.equal(result.ciStatus, "pending");
+      // attempt 1 @ t=0 (stall starts), attempt 2 @ t=30, attempt 3 @ t=60 -> bail.
+      assert.equal(result.attempts, 3);
+    },
+  );
+});
+
+test("watch-ci does NOT bail stuck when a run is progressing (in_progress, #1631)", async () => {
+  // A run that IS progressing must never be bailed early: it waits out the budget
+  // and reports timeout, never "stuck".
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build"]) },
+        { match: ["check-runs"], stdout: checkRuns([{ status: "in_progress", conclusion: null, name: "build" }]) },
+        { match: ["/status"], stdout: statuses([]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 40, stallBailMs: 10 },
+        advancingDeps(env),
+      );
+      assert.equal(result.status, "timeout");
+      assert.notEqual(result.status, "stuck");
+    },
+  );
+});
+
+test("watch-ci does NOT bail stuck when another provider is pending (commit-status, #1631)", async () => {
+  // Check-runs all queued, BUT a commit-status (e.g. CircleCI) is pending - CI IS
+  // progressing on another provider, so the watcher must not bail. It waits out
+  // the budget and reports timeout, never "stuck".
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build"]) },
+        { match: ["check-runs"], stdout: checkRuns([{ status: "queued", conclusion: null, name: "build" }]) },
+        { match: ["/status"], stdout: statuses([{ state: "pending", context: "ci/circleci: build" }]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 40, stallBailMs: 10 },
+        advancingDeps(env),
+      );
+      assert.equal(result.status, "timeout");
+      assert.notEqual(result.status, "stuck");
+    },
+  );
+});
+
+test("watch-ci resets the stall when a stuck run starts progressing and settles success (#1631)", async () => {
+  // Polls 1-2: all queued (stall accumulates but under the bail window). Poll 3:
+  // the run starts progressing and completes success. Must settle success, NOT
+  // bail stuck - the stall window resets the moment a job is picked up.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-ci-stallreset-"));
+  try {
+    const ghPath = path.join(tempDir, "gh");
+    const counterPath = path.join(tempDir, "cr-counter.txt");
+    await writeFile(counterPath, "0", "utf8");
+    const script = [
+      "#!/usr/bin/env node",
+      'const { readFileSync, writeFileSync } = require("node:fs");',
+      `const counterPath = ${JSON.stringify(counterPath)};`,
+      'const argv = process.argv.slice(2).join(" ");',
+      'const has = (n) => argv.includes(n);',
+      `if (has("pr") && has("view")) { process.stdout.write(${JSON.stringify(prView("sha-a", ["build"]))}); process.exit(0); }`,
+      'if (has("check-runs")) {',
+      '  const i = Number(readFileSync(counterPath, "utf8").trim() || "0");',
+      '  writeFileSync(counterPath, String(i + 1));',
+      '  const run = i < 2 ? { status: "queued", conclusion: null, name: "build" } : { status: "completed", conclusion: "success", name: "build" };',
+      '  process.stdout.write(JSON.stringify({ check_runs: [run] })); process.exit(0);',
+      '}',
+      `if (has("/status")) { process.stdout.write(${JSON.stringify(statuses([]))}); process.exit(0); }`,
+      'process.stderr.write(`unexpected gh args: ${argv}\\n`); process.exit(97);',
+      "",
+    ].join("\n");
+    await writeFile(ghPath, script, "utf8");
+    await chmod(ghPath, 0o755);
+    const env = { ...process.env, PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter) };
+    const result = await watchCiStatus(
+      { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 10_000, stallBailMs: 100 },
+      advancingDeps(env),
+    );
+    assert.equal(result.status, "success");
+    assert.equal(result.settled, true);
+    assert.equal(result.attempts, 3);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("watch-ci single check (timeout-ms 0) on an all-queued run reports pending, never stuck (#1631)", async () => {
+  // No waiting budget -> no stall window can mature -> a single live check of an
+  // all-queued head reports the live "pending" state, never bails "stuck".
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build"]) },
+        { match: ["check-runs"], stdout: checkRuns([{ status: "queued", conclusion: null, name: "build" }]) },
+        { match: ["/status"], stdout: statuses([]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 10, timeoutMs: 0, stallBailMs: 1 },
+        fastDeps(env),
+      );
+      assert.equal(result.status, "pending");
+      assert.equal(result.attempts, 1);
+    },
+  );
+});

--- a/test/github/wait-pr-checks.test.mjs
+++ b/test/github/wait-pr-checks.test.mjs
@@ -175,6 +175,7 @@ test("exitCodeForWaitResult maps status to the documented exit codes", () => {
   assert.equal(exitCodeForWaitResult({ status: "timeout" }), 2);
   assert.equal(exitCodeForWaitResult({ status: "changed" }), 2);
   assert.equal(exitCodeForWaitResult({ status: "pending" }), 2);
+  assert.equal(exitCodeForWaitResult({ status: "stuck" }), 2);
 });
 
 test("wait-pr-checks parses --timeout/--poll in seconds into ms, with policy-derived defaults", () => {

--- a/test/github/wait-pr-checks.test.mjs
+++ b/test/github/wait-pr-checks.test.mjs
@@ -219,5 +219,5 @@ test("wait-pr-checks --help prints usage and exits 0", async () => {
   // USAGE must match the actual exit-code behavior: argument/gh/runtime errors
   // exit 1 (repo convention, asserted above), exit 2 is not-settled only.
   assert(result.stdout.includes('1  Red (status "failure"), or an argument/gh/runtime error'));
-  assert(result.stdout.includes('2  Not settled (status "timeout"/"changed"/"pending")'));
+  assert(result.stdout.includes('2  Not settled (status "timeout"/"changed"/"pending"/"stuck")'));
 });


### PR DESCRIPTION
## Summary

Adds a zero-allocation stall detector to the loop-safe CI watcher (#1531 surface) so a stuck GitHub Actions queue bails within ~5 min instead of burning the full 30-min watch budget. From the rc.4 token-efficiency retrospective (opportunity B).

## Approach

- `summarizeHeadScopedCheckRunsSignal` (loop-safe CI derivation) now exposes `allQueued`: true when at least one check-run is present AND every one is still in the `queued` status — i.e. no runner has been allocated to any job (no job picked up / `in_progress` / `completed`).
- `watchCiStatus` (`probe-ci-status.mjs`) tracks when the stall first observed and bails with a new `stuck` status once `ZERO_ALLOCATION_STALL_BAIL_MS` (~5 min) elapses, instead of polling to the full budget.
- A run that IS progressing is never bailed early: any check-run `in_progress`/`completed`, or another provider pending via the commit-status API, disqualifies the stall.

## Behavior

- A head with all check-runs `queued` (zero jobs allocated) and no other provider activity → bails `stuck` within ~5 min (was: full 30-min budget).
- A run with any job `in_progress` or a completed/success check → not bailed (settles normally or times out).
- A head where another provider (e.g. CircleCI) reports a pending commit-status → not bailed (CI is progressing on that provider).
- `timeout-ms 0` single check → never bails (no window to mature); reports live `pending`.
- `stuck` maps to exit code 2 (not settled) for `wait-pr-checks`, consistent with `timeout`/`changed`/`pending`.

## Acceptance criteria

- [x] The CI watcher bails within ~5 min when a run is QUEUED with zero jobs allocated, instead of the full 30-min budget.
- [x] A run that IS progressing (jobs IN_PROGRESS/SUCCESS) is NOT bailed early.
- [x] `npm run verify` + `assets:check` + `schema:check` green; zero NEW failures vs baseline.

## Scope

Focused on the CI watcher's stall detection. No changes to gate-evidence exclusion, no-checks grace, or head-change detection. The new `stuck` status is additive; `run-watch-cycle` already routes any non-`timeout`/non-`success` CI status to `needs_followup` (re-detect), which is the correct disposition for a stuck-queue bail.

Closes #1631
