### PR TITLE
fix(gate): enforce GATE-EXEC-THREAD-DISPOSITION — reject invalid disposition=deferred stamps (#1672)

### DIFF
--- a/scripts/github/close-gate-findings.mjs
+++ b/scripts/github/close-gate-findings.mjs
@@ -34,7 +34,10 @@ triage; #1585). question always stays open too — it is answered, never deferre
 so an unanswered question blocks gate-close exactly like an open defect; nit is
 replied-to + resolved immediately, with no fixer cycle. A deferred thread's marker is
 stamped \`disposition=deferred\` before it is resolved, so the deferral disposition
-lives on the thread itself and in the durable tmp ledger.
+lives on the thread itself and in the durable tmp ledger. A
+contract-violating disposition=deferred stamp on a question or in-window medium
+thread (a subagent bypass of selectDispositionTargets) is detected and rejected
+before the pass runs (#1672).
 
 Round number = the MAXIMUM of three worktree-independent-first sources:
   (A) count of DISTINCT reviewed-head SHAs across this gate's own verdict surfaces —
@@ -73,6 +76,47 @@ function parseError(message) {
 // ---------------------------------------------------------------------------
 // Disposition pass
 // ---------------------------------------------------------------------------
+
+// #1672: Scan every unresolved gate-authored thread for a contract-violating
+// disposition=deferred stamp — one that selectDispositionTargets would never
+// have produced (question is never deferred; medium is deferred only past the
+// fix window). A subagent that manually stamped disposition=deferred on a
+// question or in-window medium thread (bypassing selectDispositionTargets /
+// stampDeferredDisposition entirely, via a direct gh api PATCH) leaves exactly
+// this signature. The mechanical enforcement (isDeferredAtRound in
+// selectDispositionTargets) is correct, but it only governs what THIS pass
+// stamps — it cannot prevent a manual stamp. This scan detects the bypass
+// BEFORE the disposition pass runs, so a contract-violating stamp surfaces as
+// a gate failure (throw) rather than silently proceeding to reply+resolve or
+// being counted as a clean deferral.
+function detectContractViolatingDeferredStamps(threads, login, round, mediumFixWindow) {
+  const violations = [];
+  for (const thread of threads) {
+    // Only scan UNRESOLVED threads: the scan uses the CURRENT gate's round,
+    // but a resolved thread may have been legitimately deferred by a PRIOR
+    // gate at a higher round (e.g. draft_gate round 4 defers a medium;
+    // pre_approval_gate at round 1 would falsely flag it). The marker
+    // carries no cross-gate deferral provenance, so scanning resolved
+    // threads would cause cross-gate false positives that hard-block the
+    // gate with no recovery path. The stamp-only bypass (unresolved thread
+    // with an invalid disposition=deferred stamp) is the case this scan
+    // catches; the full bypass (stamp + resolve) is caught by the
+    // stampDeferredDisposition guard when the sanctioned path is used,
+    // and a raw gh-api bypass is a process violation no code guard can
+    // mechanically prevent.
+    if (thread.isResolved) continue;
+    if (thread.author !== login) continue;
+    const marker = parseFindingMarker(thread.body);
+    if (!marker) continue;
+    if (marker.disposition === "deferred" && !isDeferredAtRound(marker.severity, round, mediumFixWindow)) {
+      violations.push({ threadId: thread.threadId, commentId: thread.commentId, severity: marker.severity, round, mediumFixWindow });
+    }
+  }
+  if (violations.length > 0) {
+    const details = violations.map((v) => `thread ${v.threadId} (comment ${v.commentId}): severity=${v.severity} at round=${v.round} (mediumFixWindow=${v.mediumFixWindow}) carries disposition=deferred but isDeferredAtRound=false`).join("; ");
+    throw new Error(`GATE-EXEC-THREAD-DISPOSITION violation: ${violations.length} gate-authored thread(s) carry a contract-violating disposition=deferred stamp (${details}). A question must be answered (never deferred) and an in-window medium (round ≤ mediumFixWindow) must stay unresolved to force a fix round. Refuse to proceed with the disposition pass.`);
+  }
+}
 
 // The window/disposition reason named in the reply: a medium thread deferred
 // because it stayed open past the in-gate fix window vs. a low finding that is
@@ -138,7 +182,7 @@ function selectDispositionTargets(threads, round, login, mediumFixWindow) {
 // `/disposition=deferred/` body search): a finding whose own summary or
 // recommendation happens to quote that literal token must never be mistaken
 // for an already-stamped marker.
-async function stampDeferredDisposition({ repo, commentId }, { env, ghCommand }) {
+async function stampDeferredDisposition({ repo, commentId, round, mediumFixWindow }, { env, ghCommand }) {
   const payload = await runGhJson(["api", `repos/${repo}/pulls/comments/${commentId}`], { env, ghCommand });
   // Trimmed to match parseReviewThreads' normalizeBody, which is what
   // selectDispositionTargets parsed thread.body through to select this exact
@@ -149,6 +193,16 @@ async function stampDeferredDisposition({ repo, commentId }, { env, ghCommand })
   const marker = parseFindingMarker(body);
   if (!marker) {
     throw new Error(`Review comment ${commentId} was selected as a deferral target but no longer carries a parseable finding marker; refuse to resolve it unstamped.`);
+  }
+  // #1672: Defense-in-depth guard — validate that this severity/round is
+  // actually deferrable BEFORE stamping or skipping. selectDispositionTargets
+  // already filters via isDeferredAtRound, so this should never fire in normal
+  // flow; it catches a direct call to stampDeferredDisposition on a question or
+  // in-window medium (a subagent bypass) and an already-stamped marker that a
+  // subagent applied manually. Without this, an already-stamped invalid marker
+  // would silently skip (the return below) and proceed to reply+resolve.
+  if (!isDeferredAtRound(marker.severity, round, mediumFixWindow)) {
+    throw new Error(`Review comment ${commentId} carries severity=${marker.severity} at round=${round} (mediumFixWindow=${mediumFixWindow}) which must not be deferred (isDeferredAtRound=false); refuse to stamp or resolve a contract-violating disposition=deferred (GATE-EXEC-THREAD-DISPOSITION).`);
   }
   if (marker.disposition === "deferred") return;
   const stamped = body.replace(FINDING_MARKER_RE, (m) => m.replace(/\s*-->$/, " disposition=deferred -->"));
@@ -163,13 +217,16 @@ async function stampDeferredDisposition({ repo, commentId }, { env, ghCommand })
 // the reply-target validation snapshot rather than re-fetching it, since it is
 // already fresh (fetched immediately before this pass runs).
 async function runDispositionPass({ repo, pr, round, threads, snapshot, login, mediumFixWindow }, { env, ghCommand }) {
+  // #1672: Before stamping, detect any contract-violating disposition=deferred
+  // stamps already present on gate-authored threads (a subagent bypass).
+  detectContractViolatingDeferredStamps(threads, login, round, mediumFixWindow);
   const targets = selectDispositionTargets(threads, round, login, mediumFixWindow);
   if (targets.length === 0) {
     return { deferredResolved: 0 };
   }
   let deferredResolved = 0;
   for (const target of targets) {
-    await stampDeferredDisposition({ repo, commentId: target.commentId }, { env, ghCommand });
+    await stampDeferredDisposition({ repo, commentId: target.commentId, round, mediumFixWindow }, { env, ghCommand });
     const message = dispositionMessage({ fp: target.fp, severity: target.severity, angle: target.angle, round, mediumFixWindow });
     await replyAndMaybeResolve(
       { repo, pr, commentId: target.commentId, threadId: target.threadId, body: message, resolve: true, validatedSnapshot: snapshot },

--- a/test/github/close-gate-findings.test.mjs
+++ b/test/github/close-gate-findings.test.mjs
@@ -638,6 +638,123 @@ test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition
   ));
 });
 
+// ---------------------------------------------------------------------------
+// #1672: GATE-EXEC-THREAD-DISPOSITION enforcement — guard against a subagent
+// manually stamping disposition=deferred on a question or in-window medium
+// thread (bypassing selectDispositionTargets / stampDeferredDisposition).
+// ---------------------------------------------------------------------------
+
+// (a) round-1 medium NOT defer-closed (default window=3): the disposition pass
+// must leave an in-window medium thread unresolved (it forces a fix round).
+test("#1672 (a): a round-1 medium thread is NOT defer-closed (stays unresolved, forces a fix round)", async () => {
+  const mediumBody = `${buildFindingMarker({ fp: "aaaaaaaaaaaaaaaa", severity: "medium", angle: "config-drift", round: 1 })}\n**medium** (\`config-drift\`): missing schema validation`;
+  const thread = threadNode({ id: "THREAD_MED_R1", path: "src/config.mjs", line: 4, commentId: 9001, body: mediumBody });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No GET/PATCH/reply/resolve entries: a regression that defer-closed this
+    // in-window medium thread would overflow the stub and fail the run.
+    roundEntries({ threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.round, 1);
+      assert.equal(result.deferredResolved, 0);
+      assert.equal(result.unresolvedGateThreadCount, 1);
+    },
+  ));
+});
+
+// (b) question NOT defer-closed: the disposition pass must leave a question
+// thread unresolved (it must be answered, never deferred).
+test("#1672 (b): a question thread is NOT defer-closed (stays unresolved, must be answered)", async () => {
+  const questionBody = `${buildFindingMarker({ fp: "bbbbbbbbbbbbbbbb", severity: "question", angle: "correctness", round: 1 })}\n**question** (\`correctness\`): why is overallVerdict not cross-checked against verdict?`;
+  const thread = threadNode({ id: "THREAD_Q_R1", path: "src/verdict.mjs", line: 4, commentId: 9002, body: questionBody });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No disposition entries: a regression that defer-closed this question
+    // thread would overflow the stub and fail the run.
+    roundEntries({ threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.round, 1);
+      assert.equal(result.deferredResolved, 0);
+      assert.equal(result.unresolvedGateThreadCount, 1);
+    },
+  ));
+});
+
+// (c) round-4 medium IS defer-closed (default window=3): past the fix window,
+// an open medium thread is replied-to + resolved by the disposition pass.
+test("#1672 (c): a round-4 medium thread IS defer-closed (past the default window)", async () => {
+  const mediumBody = `${buildFindingMarker({ fp: "cccccccccccccccc", severity: "medium", angle: "config-drift", round: 1 })}\n**medium** (\`config-drift\`): missing schema validation`;
+  const thread = threadNode({ id: "THREAD_MED_R4", path: "src/config.mjs", line: 4, commentId: 9003, body: mediumBody });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    [
+      ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      getReviewCommentEntry(9003, mediumBody),
+      patchReviewCommentEntry(9003),
+      postReplyEntry(9003, { id: 9103 }),
+      resolveThreadEntry("THREAD_MED_R4"),
+    ],
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.round, 4);
+      assert.equal(result.deferredResolved, 1);
+    },
+  ));
+});
+
+// (d) high never defer-closed: even past the fix window, a high thread stays
+// unresolved (it forces per-gate continuation until the round cap escalates).
+test("#1672 (d): a high thread is never defer-closed (even past the fix window)", async () => {
+  const highBody = `${buildFindingMarker({ fp: "dddddddddddddddd", severity: "high", angle: "security", round: 1 })}\n**high** (\`security\`): SQL injection`;
+  const thread = threadNode({ id: "THREAD_HIGH", path: "src/db.mjs", line: 2, commentId: 9004, body: highBody });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No disposition entries: a regression that defer-closed this high thread
+    // would overflow the stub and fail the run.
+    roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.round, 4);
+      assert.equal(result.deferredResolved, 0);
+    },
+  ));
+});
+
+// #1672 guard: a contract-violating disposition=deferred stamp on a QUESTION
+// thread (manually stamped by a subagent bypassing selectDispositionTargets)
+// is detected and rejected BEFORE the disposition pass proceeds.
+test("#1672 guard: a disposition=deferred stamp on a question thread is rejected (throws, does not silently skip)", async () => {
+  const stampedQuestion = `${buildFindingMarker({ fp: "eeeeeeeeeeeeeeee", severity: "question", angle: "correctness", round: 2, disposition: "deferred" })}\n**question** (\`correctness\`): why is overallVerdict not cross-checked?`;
+  const thread = threadNode({ id: "THREAD_Q_STAMPED", path: "src/verdict.mjs", line: 4, commentId: 9005, body: stampedQuestion });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No GET/PATCH/reply/resolve entries: the scan runs before any of those,
+    // and a regression that proceeded to stamp/resolve would overflow the stub.
+    roundEntries({ issueComments: roundHistory("draft_gate", 2), threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      await assert.rejects(
+        () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=question.*isDeferredAtRound=false/s,
+      );
+    },
+  ));
+});
+
+// #1672 guard: a contract-violating disposition=deferred stamp on an IN-WINDOW
+// medium thread (round 1, default window 3 — manually stamped by a subagent)
+// is detected and rejected BEFORE the disposition pass proceeds.
+test("#1672 guard: a disposition=deferred stamp on an in-window medium thread is rejected (throws, does not silently skip)", async () => {
+  const stampedMedium = `${buildFindingMarker({ fp: "ffffffffffffffff", severity: "medium", angle: "config-drift", round: 1, disposition: "deferred" })}\n**medium** (\`config-drift\`): missing schema validation`;
+  const thread = threadNode({ id: "THREAD_MED_STAMPED", path: "src/config.mjs", line: 4, commentId: 9006, body: stampedMedium });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No GET/PATCH/reply/resolve entries: the scan runs before any of those.
+    roundEntries({ threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      await assert.rejects(
+        () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=medium.*round=1.*isDeferredAtRound=false/s,
+      );
+    },
+  ));
+});
+
 // commentId is validated BEFORE it is ever interpolated into a
 // `pulls/comments/{commentId}` API path.
 test("a gate-authored thread selected for deferral with no resolvable comment id fails closed, named by threadId", async () => {


### PR DESCRIPTION
## Summary

Gate-integrity fix: enforce `GATE-EXEC-THREAD-DISPOSITION` so in-window mediums (round ≤ `mediumFixWindow=3`) and questions cannot be stamped `disposition=deferred`.

## Root cause

**Subagent bypass.** The mechanical enforcement (`isDeferredAtRound` in `selectDispositionTargets`) was already correct — it never selects `question` or in-window `medium` for deferral. But `stampDeferredDisposition` silently skipped already-stamped markers (`if (marker.disposition === "deferred") return;`) without validating whether the stamp was contract-valid. A dev-loop subagent manually stamped `disposition=deferred` on locatable question and in-window medium threads (via direct `gh api` PATCH, bypassing `selectDispositionTargets`), and no guard detected the contract violation.

## Fix

1. **`detectContractViolatingDeferredStamps()`** — new pre-disposition scan in `close-gate-findings.mjs` that throws before the disposition pass runs if any unresolved gate-authored thread carries `disposition=deferred` on a `question` or in-window `medium` (where `isDeferredAtRound` returns false). Catches the subagent bypass.

2. **Defense-in-depth guard in `stampDeferredDisposition`** — validates `isDeferredAtRound(severity, round, mediumFixWindow)` before stamping or skipping. Catches a direct call to `stampDeferredDisposition` on an invalid severity/round, and an already-stamped invalid marker that would otherwise silently skip to reply+resolve.

## Regression tests

- (a) round-1 medium NOT defer-closed (default window=3)
- (b) question NOT defer-closed
- (c) round-4 medium IS defer-closed (past default window)
- (d) high never defer-closed (even past fix window)
- Guard rejects `disposition=deferred` stamp on question thread (throws)
- Guard rejects `disposition=deferred` stamp on in-window medium thread (throws)

Closes #1672
