### PR TITLE
fix(gate): widen sentinel SHA-component regex to accept SHA-256 (64-hex) heads

### DIFF
--- a/scripts/github/retire-gate-round.mjs
+++ b/scripts/github/retire-gate-round.mjs
@@ -29,7 +29,7 @@ Required:
                          (draft-gate-<angle> / pre-approval-gate-<angle>), so
                          this bounds the sweep to ONE gate — the other gate's
                          live round at the same head is never touched.
-  --head-sha <sha>       FULL 40-char head SHA the round was keyed by (the
+  --head-sha <sha>       FULL 40- or 64-char head SHA the round was keyed by (the
                          sentinel filename suffix). A short prefix would match
                          nothing and read as a vacuous success — rejected.
   --reason <text>        Why the round is being retired (recorded verbatim in
@@ -85,7 +85,7 @@ Exit codes:
      (partial retirement is reported as above)
   2  Invalid --jq filter`.trim();
 
-const HEAD_SHA_RE = /^[0-9a-f]{40}$/i;
+const HEAD_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 const VALID_GATES = new Set(GATE_NAMES);
 const parseError = buildParseError(USAGE);
 
@@ -113,7 +113,7 @@ export function parseRetireGateRoundArgs(argv) {
   }
   const headSha = headShaRaw.trim().toLowerCase();
   if (!HEAD_SHA_RE.test(headSha)) {
-    throw parseError("--head-sha must be the FULL 40-char hex head SHA the sentinels are keyed by (a short prefix would match nothing and read as a vacuous success)");
+    throw parseError("--head-sha must be the FULL 40- or 64-char hex head SHA the sentinels are keyed by (a short prefix would match nothing and read as a vacuous success)");
   }
   const reason = resolveFlagValue(argv, "--reason");
   if (reason === null || reason.trim().length === 0) {
@@ -165,7 +165,7 @@ export async function retireGateRound({ gate, headSha, reason, findingsDir = nul
     throw new Error(`Unknown gate ${JSON.stringify(gate)} — must be draft_gate or pre_approval_gate`);
   }
   if (typeof headSha !== "string" || !HEAD_SHA_RE.test(headSha)) {
-    throw new Error(`headSha must be the FULL 40-char hex head SHA, got ${JSON.stringify(headSha)}`);
+    throw new Error(`headSha must be the FULL 40- or 64-char hex head SHA, got ${JSON.stringify(headSha)}`);
   }
   // Normalize for the sentinel filename match: sentinel names embed the
   // lowercase rev-parse output, so an uppercase programmatic value would

--- a/scripts/github/verify-briefing-prefixes.mjs
+++ b/scripts/github/verify-briefing-prefixes.mjs
@@ -18,7 +18,7 @@ and offline: reads only the sentinel and record files already on disk under tmp/
 keyed by the given head SHA.
 
 Required:
-  --head-sha <sha>  The FULL 40-char reviewed head SHA (git rev-parse HEAD); sentinels are read from
+  --head-sha <sha>  The FULL 40- or 64-char reviewed head SHA (git rev-parse HEAD); sentinels are read from
                      tmp/checkpoint-context-sentinel-<scope>-<headSha>.json.
 
 Output (stdout, JSON):
@@ -62,10 +62,10 @@ the conservative flat rule (all sentinels must share one hash).
 Never manually clear sentinels — after a legitimate context rebuild at the same
 head, retire-gate-round.mjs is the sanctioned path that moves them aside.`.trim();
 
-// Full 40-char SHA required: sentinel filenames embed the full `git rev-parse
+// Full 40- or 64-char SHA required: sentinel filenames embed the full `git rev-parse
 // HEAD` value, so a short prefix would glob zero sentinels and read as a
 // vacuous pass — fail closed on anything shorter instead.
-const HEAD_SHA_RE = /^[0-9a-f]{40}$/i;
+const HEAD_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 
 const parseError = buildParseError(USAGE);
@@ -379,7 +379,7 @@ export async function main(argv = process.argv.slice(2), { tmpRoot = path.join(p
   const headShaArg = resolveFlagValue(argv, "--head-sha");
   if (headShaArg === null || headShaArg === "" || !HEAD_SHA_RE.test(headShaArg)) {
     process.stderr.write(`${formatCliError(
-      parseError(`--head-sha is required and must be the FULL 40-character hex head SHA (short prefixes would match zero sentinels and pass vacuously)${headShaArg ? ` (got ${JSON.stringify(headShaArg)})` : ""}.`)
+      parseError(`--head-sha is required and must be the FULL 40- or 64-character hex head SHA (short prefixes would match zero sentinels and pass vacuously)${headShaArg ? ` (got ${JSON.stringify(headShaArg)})` : ""}.`)
     )}\n`);
     return 2;
   }

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -2036,7 +2036,7 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
     const liveSentinelNames = tmpDirEntries.filter((e) => {
       if (!e.isFile() || !e.name.startsWith(sentinelScopePrefix) || !e.name.endsWith(".json")) return false;
       const shaComponent = e.name.slice(0, -".json".length).split("-").at(-1) ?? "";
-      return /^[0-9a-f]{40}$/.test(shaComponent) && shaComponent.startsWith(headPrefix);
+      return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(shaComponent) && shaComponent.startsWith(headPrefix);
     }).map((e) => e.name);
     const priorPrefixHash = createHash("sha256").update(existingBytes).digest("hex");
     const newPrefixHash = createHash("sha256").update(prefixBytes).digest("hex");

--- a/test/github/retire-gate-round.test.mjs
+++ b/test/github/retire-gate-round.test.mjs
@@ -24,7 +24,7 @@ function sentinelName(scope, head) {
 
 test("parseRetireGateRoundArgs requires a full head SHA and a reason", () => {
   assert.throws(() => parseRetireGateRoundArgs(["--gate", "draft_gate", "--reason", "x"]), /--head-sha/);
-  assert.throws(() => parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", "abc1234", "--reason", "x"]), /FULL 40-char/);
+  assert.throws(() => parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", "abc1234", "--reason", "x"]), /FULL 40- or 64-char/);
   assert.throws(() => parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", HEAD_A]), /--reason/);
   assert.throws(() => parseRetireGateRoundArgs(["--head-sha", HEAD_A, "--reason", "x"]), /--gate/);
   const parsed = parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", HEAD_A.toUpperCase(), "--reason", "rebuilt", "--findings-dir", "/tmp/x", "--repo", "owner/repo", "--pr", "7", "--no-findings-artifacts", "--tmp-root", "tmp2"]);
@@ -35,6 +35,11 @@ test("parseRetireGateRoundArgs requires a full head SHA and a reason", () => {
   assert.equal(parsed.pr, 7);
   assert.equal(parsed.noFindingsArtifacts, true);
   assert.equal(parsed.tmpRoot, "tmp2");
+  // A 64-hex (SHA-256) head SHA is accepted (#1652).
+  const sha256 = "c3".repeat(32);
+  const parsed256 = parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", sha256, "--reason", "rebuilt"]);
+  assert.equal(parsed256.headSha, sha256);
+  assert.equal(parsed256.gate, "draft_gate");
   // repo/pr default to null when not supplied.
   const bare = parseRetireGateRoundArgs(["--gate", "draft_gate", "--head-sha", HEAD_A, "--reason", "rebuilt"]);
   assert.equal(bare.repo, null);
@@ -208,7 +213,7 @@ test("retireGateRound re-validates headSha and reason at the function boundary",
   await withTmpRoot(async (tmpRoot) => {
     await assert.rejects(
       () => retireGateRound({ gate: "draft_gate", headSha: "abc1234", reason: "x", tmpRoot }),
-      /FULL 40-char/,
+      /FULL 40- or 64-char/,
     );
     await assert.rejects(
       () => retireGateRound({ gate: "draft_gate", headSha: HEAD_A, reason: "   ", tmpRoot }),

--- a/test/github/verify-briefing-prefixes.test.mjs
+++ b/test/github/verify-briefing-prefixes.test.mjs
@@ -262,10 +262,18 @@ test("verify-briefing-prefixes rejects a malformed --head-sha", () => {
 test("verify-briefing-prefixes rejects a SHORT head SHA (would glob zero sentinels and pass vacuously)", () => {
   const result = runChecker(["--head-sha", "abc1234"]);
   assert.equal(result.status, 2, result.stderr);
-  assert.match(result.stderr, /FULL 40-character/);
+  assert.match(result.stderr, /FULL 40- or 64-character/);
 });
 
 const FULL_TEST_SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+const FULL_TEST_SHA_256 = "d4".repeat(32);
+
+test("verify-briefing-prefixes accepts a 64-hex (SHA-256) head SHA (#1652)", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const result = runChecker(["--head-sha", FULL_TEST_SHA_256], { cwd: tmpDir });
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
 
 test("verify-briefing-prefixes exits 0 with reviewerCount 0 when no sentinels exist for the head SHA", async () => {
   await withTmpDir(async (tmpDir) => {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -3437,6 +3437,49 @@ test("writeGateContext REFUSES, naming the retirement command and the briefed re
   }
 });
 
+test("writeGateContext detects SHA-256 (64-hex) sentinel filenames, not just SHA-1 (40-hex) (#1652)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-sha256-"));
+  // A SHA-256 head is 64 hex chars; the sentinel filename embeds the full SHA.
+  const fullSha256 = "abc1234567890def".padEnd(64, "0");
+  try {
+    const baseArgs = [
+      "--repo", "owner/repo", "--pr", "29", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890def",
+      "--angles", '["scope"]',
+      "--acceptance-criteria", "#29",
+    ];
+    const first = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Original body."]), { repoRoot });
+    assert.equal(first.warning, undefined);
+    await mkdir(path.resolve(repoRoot, "tmp"), { recursive: true });
+    // Sentinel filename carries the FULL 64-hex SHA-256 component.
+    await writeFile(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-draft-gate-scope-${fullSha256}.json`), "{}\n", "utf8");
+    // A rebuild that would CHANGE the prefix bytes must REFUSE — the 64-hex
+    // sentinel was detected (regex now accepts 40-hex AND 64-hex, #1652).
+    await assert.rejects(
+      writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Corrected body."]), { repoRoot }),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /Refusing to rebuild the briefing prefix with DIFFERENT bytes while a fan-out for head abc1234567890def is in flight/);
+        assert.match(err.message, /1 reviewer sentinel/);
+        assert.match(err.message, /tmp\/checkpoint-context-sentinel-draft-gate-scope-[0-9a-f]+\.json/);
+        return true;
+      },
+    );
+    // The refusal wrote NOTHING: the original prefix bytes are untouched.
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 29, gate: "draft_gate", headSha: "abc1234567890def" });
+    const survivingPrefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(survivingPrefix.includes("Original body."), "the refusal left the existing prefix bytes intact (SHA-256 sentinel)");
+    assert.ok(!survivingPrefix.includes("Corrected body."), "no partial write of the refused bytes (SHA-256 sentinel)");
+    // AC3: after the round retires (SHA-256 sentinel removed), a rebuild proceeds.
+    await rm(path.resolve(repoRoot, "tmp", `checkpoint-context-sentinel-draft-gate-scope-${fullSha256}.json`));
+    const rebuiltAfterRetire = await writeGateContext(parseWriteGateContextCliArgs([...baseArgs, "--pr-body", "Retired-then-rebuilt body."]), { repoRoot });
+    assert.equal(rebuiltAfterRetire.warning, undefined);
+    assert.ok((await readFile(path.resolve(repoRoot, prefixPath), "utf8")).includes("Retired-then-rebuilt body."));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test("writeGateContext REFUSES on a broken live-sentinel scan (fail-closed: cannot rule out an in-flight fan-out) (#1537)", async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-rebuild-scanerr-"));
   try {


### PR DESCRIPTION
## Summary

Widen the sentinel SHA-component regex in `write-gate-context.mjs` to accept 64-hex (SHA-256) head SHAs alongside the existing 40-hex (SHA-1). Also widen the paired `retire-gate-round.mjs` and `verify-briefing-prefixes.mjs` head-SHA validators so the full detect→retire→verify contract accepts SHA-256.

Resolves #1652.

## Context

Post-merge residual from #1537 (PR #1651). The sentinel scan that guards mid-flight prefix rebuilds matched only SHA-1 (40-hex) filename components. A host/repo moving to SHA-256 head SHAs would silently break sentinel detection, bypassing the rebuild guard. The paired retirement and verification CLIs had the same SHA-1-only limitation — widening only detection would deadlock a SHA-256 round (detected as in-flight but cannot be retired).

## Acceptance criteria
- [x] Sentinel SHA-component regex accepts 40-hex and 64-hex (write-gate-context.mjs).
- [x] retire-gate-round.mjs accepts 64-hex `--head-sha`.
- [x] verify-briefing-prefixes.mjs accepts 64-hex `--head-sha`.
- [x] Tests covering both lengths in all three tools.
- [x] `npm run verify` green (local ~48 environmental failures green in CI).

## Non-goals
- Changing the hash algorithm of recorded head SHAs (GitHub-driven).
