### PR TITLE
refactor: route --issue/--pr validation through shared primitive

### DIFF
--- a/scripts/github/create-pr.mjs
+++ b/scripts/github/create-pr.mjs
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveSettings, applyDevloopsBoard } from "../projects/_resolve-project.mjs";
 import { main as addQueueItemMain } from "../projects/add-queue-item.mjs";
 import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
@@ -212,10 +212,9 @@ export async function main(argv = process.argv.slice(2), runtime = {}) {
     // A present-but-valueless --issue (bare trailing token, or `--issue=`)
     // MUST refuse rather than silently skip enforcement — silently dropping
     // the MUST on a malformed invocation is the exact gap this PR closes.
-    if (issueRaw === null || !/^\d+$/.test(issueRaw) || Number(issueRaw) <= 0) {
-      throw parseError(`--issue must be a positive integer (got ${JSON.stringify(issueRaw ?? "<no value>")})`);
-    }
-    issue = Number(issueRaw);
+    // #1645: route through the shared parseIssueNumber primitive so the
+    // positive-integer rule lives in one place (@dev-loops/core/cli/primitives).
+    issue = parseIssueNumber(issueRaw, parseError);
   }
   // Strip --lightweight and --issue (with its value in the space form) so
   // neither is forwarded to `gh pr create` (which rejects unknown flags).

--- a/scripts/github/retire-gate-round.mjs
+++ b/scripts/github/retire-gate-round.mjs
@@ -2,6 +2,7 @@
 import { lstat, mkdir, readdir, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { buildParseError, isDirectCliRun, formatCliError } from "../_core-helpers.mjs";
+import { parsePrNumber } from "../_cli-primitives.mjs";
 import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 import { CHECKPOINT_SENTINEL_PREFIX } from "./verify-fresh-review-context.mjs";
 import { GATE_NAMES, gateScopePrefix } from "./_gate-names.mjs";
@@ -133,11 +134,9 @@ export function parseRetireGateRoundArgs(argv) {
   }
   let pr = null;
   if (prRaw !== null) {
-    const prNum = Number(prRaw);
-    if (!/^\d+$/.test(prRaw) || !Number.isInteger(prNum) || prNum <= 0) {
-      throw parseError(`--pr must be a positive integer (got ${JSON.stringify(prRaw)})`);
-    }
-    pr = prNum;
+    // #1645: route through the shared parsePrNumber primitive so the
+    // positive-integer rule lives in one place (@dev-loops/core/cli/primitives).
+    pr = parsePrNumber(prRaw, parseError);
   }
   const noFindingsArtifacts = argv.includes("--no-findings-artifacts");
   const tmpRoot = resolveFlagValue(argv, "--tmp-root");


### PR DESCRIPTION
## Summary

Follow-up from #1626 (deferred low finding, `dry` angle).

The `--issue` validation in `create-pr.mjs` and the `--pr` validation in `retire-gate-round.mjs` hand-rolled `/^\d+$/` + `Number(...) > 0`, duplicating the repo's canonical `parseIssueNumber`/`parsePrNumber` primitive (`@dev-loops/core/cli/primitives`, re-exported from `scripts/_cli-primitives.mjs`) that sibling scripts (`detect-linked-issue-pr.mjs`, `view-issue.mjs`) already use.

## Changes

- `scripts/github/create-pr.mjs`: route `--issue` validation through `parseIssueNumber(issueRaw, parseError)` instead of the hand-rolled regex/Number check.
- `scripts/github/retire-gate-round.mjs`: route `--pr` validation through `parsePrNumber(prRaw, parseError)` instead of the hand-rolled regex/Number check.

## Non-goals

- Behavior change — the validation refusals stay identical (same inputs accepted/rejected).
- Extending the primitive to carry the `got X` diagnostic — the `(got X)` message suffix is dropped in favor of the canonical `--issue/--pr must be a positive integer` message; existing tests use regex matching that passes either way.

Closes #1645
