### PR TITLE
feat(loop): cache-aware review dispatch-plan + prefix fingerprinting (slices 1-2 of #1468)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "./loop/queue-membership": "./src/loop/queue-membership.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",
     "./loop/queue-state": "./src/loop/queue-state.mjs",
+    "./loop/review-dispatch-plan": "./src/loop/review-dispatch-plan.mjs",
     "./loop/reviewer-loop-state": "./src/loop/reviewer-loop-state.mjs",
     "./loop/run-context": "./src/loop/run-context.mjs",
     "./loop/run-inspection": "./src/loop/run-inspection.mjs",

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -229,15 +229,29 @@ export function fingerprintRequestPrefix(input) {
   if (typeof input.model !== "string" || input.model.trim().length === 0) {
     throw new Error("fingerprintRequestPrefix requires a non-empty concrete model");
   }
+  // Fail closed on invalid shapes (AC-2: the fingerprint covers the COMPLETE
+  // observable prefix). A silently-coerced non-array tools/contentBlocks would
+  // collapse two genuinely different request prefixes into one fingerprint, so
+  // reject rather than quietly omit.
+  if (input.tools != null && !Array.isArray(input.tools)) {
+    throw new Error("fingerprintRequestPrefix tools must be an array of tool definitions");
+  }
+  if (input.contentBlocks != null && !Array.isArray(input.contentBlocks)) {
+    throw new Error("fingerprintRequestPrefix contentBlocks must be an array");
+  }
   const canonical = {
     model: input.model.trim(),
-    tools: Array.isArray(input.tools) ? input.tools : [],
+    tools: input.tools ?? [],
     systemInstructions: input.systemInstructions ?? null,
     settings: input.settings ?? null,
-    contentBlocks: Array.isArray(input.contentBlocks) ? input.contentBlocks : null,
+    contentBlocks: input.contentBlocks ?? null,
     sharedArtifact: input.sharedArtifact ?? null,
     cacheBoundary: input.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
     ttlIntent: input.ttlIntent ?? "harness_managed",
+    // angleSuffix is excluded from the STABLE prefix fingerprint but, when the
+    // caller marks it invasive, it IS folded into this full request-prefix
+    // fingerprint so the claimed difference stays assertable.
+    ...(input.angleSuffix != null ? { angleSuffix: input.angleSuffix } : {}),
   };
   return { fingerprint: sha256Hex(canonical), canonical };
 }
@@ -480,24 +494,35 @@ export function partitionPrimerGroups(requestGroups, capabilities = {}) {
   if (!Array.isArray(requestGroups)) throw new Error("partitionPrimerGroups requires an array");
   // One primer group per distinct (model, request-prefix) — a primer warms ONE
   // concrete model's provider cache under a specific request prefix, so two
-  // groups cannot share a primer even when their fingerprints coincide.
-  const byKey = new Map();
+  // groups cannot share a primer even when their fingerprints coincide. Use a
+  // nested Map keyed by model then by fingerprint (never a single delimiter-joined
+  // string), so a model id that itself contains "::" stays intact and two distinct
+  // (model, fp) pairs can never collide onto one bucket (dedup/identity safety).
+  const byModel = new Map();
   for (const g of requestGroups) {
+    if (!byModel.has(g.model)) byModel.set(g.model, new Map());
+    const fpMap = byModel.get(g.model);
     const fp = g.requestPrefixFingerprint ?? opaqueMarker(`model:${g.model}`);
-    const key = `${g.model}::${fp}`;
-    if (!byKey.has(key)) byKey.set(key, []);
-    byKey.get(key).push(g);
+    if (!fpMap.has(fp)) fpMap.set(fp, []);
+    fpMap.get(fp).push(g);
   }
   const out = [];
-  for (const [key, groups] of byKey.entries()) {
-    const model = key.split("::")[0];
-    const fp = key.slice(model.length + 2);
-    out.push({
-      model,
-      requestPrefixFingerprint: fp.startsWith("sha256:") ? fp : null,
-      primerForm: resolvePrimerForm({ capabilities, ttlIntent: groups[0].ttlIntent }).primerForm,
-      groups: groups.map((g) => ({ model: g.model, angles: g.angles, ttlIntent: g.ttlIntent })),
-    });
+  for (const [model, fpMap] of byModel.entries()) {
+    for (const [fp, groups] of fpMap.entries()) {
+      // Resolve the primer form CONSERVATIVELY across every collapsed group's TTL
+      // intent: a partition primes with a lead reviewer only when ALL its groups
+      // would; any group that needs a dedicated primer forces the whole partition
+      // down, so a mixed-TTL collapse is never decided by the first group alone.
+      const allLead = groups.every(
+        (g) => resolvePrimerForm({ capabilities, ttlIntent: g.ttlIntent }).primerForm === PRIMER_FORM_LEAD_REVIEWER,
+      );
+      out.push({
+        model,
+        requestPrefixFingerprint: fp.startsWith("sha256:") ? fp : null,
+        primerForm: allLead ? PRIMER_FORM_LEAD_REVIEWER : PRIMER_FORM_DEDICATED,
+        groups: groups.map((g) => ({ model: g.model, angles: g.angles, ttlIntent: g.ttlIntent })),
+      });
+    }
   }
   return out;
 }

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -1,0 +1,503 @@
+/**
+ * review-dispatch-plan.mjs — cache-aware review dispatch plan + request-prefix
+ * fingerprinting + stable/volatile request separation (issue #1468 slices 1-2).
+ *
+ * This module is the mechanically-checkable foundation for the cache-efficient
+ * review dispatch design (Section A/B/C/D of the #1468 spec). It owns:
+ *
+ *  1. Harness capability model — explicit representation of what a harness can
+ *     observe/control about provider prompt caching
+ *     (breakpointControl / barrierSignal / cacheTtlControl / usageTelemetry).
+ *     Opaque capabilities are represented as such and are NEVER described as
+ *     verified cache hits.
+ *  2. Request-prefix fingerprinting — a deterministic sha256 over every
+ *     cache-relevant value the dev-loops layer observes or controls (concrete
+ *     model, tool definitions/order, system/project/agent instructions,
+ *     thinking/tool-choice settings, content-block boundaries, shared artifact
+ *     bytes, and breakpoint/TTL intent). Values owned opaquely by a harness are
+ *     represented as a placeholder, never assumed identical.
+ *  3. Stable/volatile request separation — physically separates stable handoff
+ *     content from volatile `gateState` at the request/artifact boundary, so a
+ *     provider-visible cache boundary sits after the stable materialized
+ *     briefing block and before the late volatile tail + angle suffix.
+ *  4. Dispatch-plan builder — one deterministic per-gate-round artifact that
+ *     records the complete cache-relevant request shape without duplicating
+ *     briefing content (Section A).
+ *  5. Primer-form default — deterministic default by harness capability
+ *     (Section C/D): first-output-observable harnesses may let a lead reviewer
+ *     prime; completion-only harnesses default to a short dedicated primer
+ *     unless an adequate TTL is explicit; multiple concrete models partition
+ *     into one primer group per model/request-prefix.
+ *
+ * This module is pure and offline: no GitHub, no harness, no clock. All runtime
+ * execution adapters consume it; it never executes a reviewer itself.
+ */
+import { createHash } from "node:crypto";
+
+/* ------------------------------------------------------------------ *
+ * 1. Harness capability model
+ * ------------------------------------------------------------------ */
+
+/** Allowed values for each capability dimension (Section D). */
+export const BREAKPOINT_CONTROL_VALUES = Object.freeze(["explicit", "automatic", "opaque"]);
+export const BARRIER_SIGNAL_VALUES = Object.freeze(["first_output", "completion_only"]);
+export const CACHE_TTL_CONTROL_VALUES = Object.freeze(["5m_1h", "fixed", "opaque"]);
+export const USAGE_TELEMETRY_VALUES = Object.freeze(["available", "unavailable"]);
+
+/** Allowed breakpoint/TTL intents a consumer may declare for a request group. */
+export const TTL_INTENT_VALUES = Object.freeze(["5m", "1h", "harness_managed"]);
+
+/** Cache boundary markers; the only current boundary is after the shared prefix. */
+export const CACHE_BOUNDARY_AFTER_SHARED_PREFIX = "after_shared_prefix";
+export const CACHE_BOUNDARY_VALUES = Object.freeze([CACHE_BOUNDARY_AFTER_SHARED_PREFIX]);
+
+/**
+ * Default capability posture per harness name. These are conservative defaults:
+ * any harness whose provider-cache controls we cannot assert explicitly is
+ * represented with `opaque` / `unavailable` capabilities, which fail closed
+ * rather than over-claim. Consumers may pass explicit capabilities to
+ * {normalizeHarnessCapabilities}.
+ */
+export const HARNESS_DEFAULT_CAPABILITIES = Object.freeze({
+  claude: Object.freeze({
+    breakpointControl: "automatic",
+    barrierSignal: "completion_only",
+    cacheTtlControl: "fixed",
+    usageTelemetry: "available",
+  }),
+  pi: Object.freeze({
+    breakpointControl: "opaque",
+    barrierSignal: "completion_only",
+    cacheTtlControl: "opaque",
+    usageTelemetry: "unavailable",
+  }),
+});
+
+const CAPABILITY_DIMENSIONS = [
+  ["breakpointControl", BREAKPOINT_CONTROL_VALUES],
+  ["barrierSignal", BARRIER_SIGNAL_VALUES],
+  ["cacheTtlControl", CACHE_TTL_CONTROL_VALUES],
+  ["usageTelemetry", USAGE_TELEMETRY_VALUES],
+];
+
+/**
+ * Normalize + validate a harness capability object. Fails closed on unknown
+ * dimension names, unknown values, or a non-object. Returns a frozen canonical
+ * object.
+ *
+ * @param {object} input
+ * @param {string} [input.harness] - harness name; used only for the default merge
+ *   (matches HARNESS_DEFAULT_CAPABILITIES keys, else fails closed on unknown).
+ * @param {object} [input.capabilities] - explicit per-dimension overrides.
+ * @returns {Readonly<Record<string,string>>} frozen capability object.
+ */
+export function normalizeHarnessCapabilities({ harness, capabilities } = {}) {
+  let base = {};
+  if (harness != null) {
+    const key = String(harness).trim().toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(HARNESS_DEFAULT_CAPABILITIES, key)) {
+      throw new Error(
+        `Unknown harness ${JSON.stringify(harness)} — must be one of ${Object.keys(HARNESS_DEFAULT_CAPABILITIES).join(", ")} or supply explicit capabilities`,
+      );
+    }
+    base = HARNESS_DEFAULT_CAPABILITIES[key];
+  }
+  const merged = { ...base };
+  if (capabilities != null) {
+    if (typeof capabilities !== "object" || Array.isArray(capabilities)) {
+      throw new Error("capabilities must be an object of dimension -> value pairs");
+    }
+    for (const [dim, value] of Object.entries(capabilities)) {
+      const known = CAPABILITY_DIMENSIONS.find(([name]) => name === dim);
+      if (!known) {
+        throw new Error(`Unknown capability dimension ${JSON.stringify(dim)}`);
+      }
+      const [, allowed] = known;
+      if (!allowed.includes(value)) {
+        throw new Error(
+          `Invalid ${dim} ${JSON.stringify(value)} — must be one of ${allowed.join(", ")}`,
+        );
+      }
+      merged[dim] = value;
+    }
+  }
+  // Fail closed if any dimension was never resolved to a real value.
+  for (const [dim] of CAPABILITY_DIMENSIONS) {
+    if (merged[dim] == null) {
+      throw new Error(`Capability dimension ${dim} was not resolved (must be explicit or from a known harness)`);
+    }
+  }
+  return Object.freeze({
+    breakpointControl: merged.breakpointControl,
+    barrierSignal: merged.barrierSignal,
+    cacheTtlControl: merged.cacheTtlControl,
+    usageTelemetry: merged.usageTelemetry,
+  });
+}
+
+/**
+ * Is this capability set honest about provider cache reuse? A harness whose
+ * usage telemetry is `unavailable` cannot claim verified `1 write + N reads`.
+ * This is the fail-closed honesty gate for telemetry evidence (Section D).
+ *
+ * @param {Readonly<Record<string,string>>} caps - normalized capabilities.
+ * @returns {{ verified: boolean, reason: string|null }}
+ */
+export function cacheReuseVeracity(caps) {
+  if (!caps) return { verified: false, reason: "missing capability record" };
+  if (caps.usageTelemetry !== "available") {
+    return {
+      verified: false,
+      reason: `usageTelemetry=${caps.usageTelemetry} — provider reuse cannot be verified, only ordering + fingerprint invariants may be claimed`,
+    };
+  }
+  return { verified: true, reason: null };
+}
+
+/* ------------------------------------------------------------------ *
+ * 2. Request-prefix fingerprinting
+ * ------------------------------------------------------------------ */
+
+const HEX = /^[0-9a-f]{64}$/;
+
+/** @param {string} value @returns {boolean} */
+function isSha256Hex(value) {
+  return typeof value === "string" && HEX.test(value.trim().toLowerCase());
+}
+
+/**
+ * Deterministic sha256 hex of a canonical-JSON serialization. Content may be a
+ * string, Buffer, or the live object; buffers are canonicalized by hex so a
+ * push/pull through memory vs disk yields identical bytes.
+ *
+ * @param {unknown} content
+ * @returns {string} `sha256:<64-hex>`
+ */
+export function sha256Hex(content) {
+  const h = createHash("sha256");
+  if (Buffer.isBuffer(content)) {
+    h.update(content);
+  } else if (typeof content === "string") {
+    h.update(content);
+  } else {
+    // Deterministic canonical key ordering via stable stringify.
+    const canonical = stableStringify(content);
+    h.update(JSON.stringify(canonical));
+  }
+  return `sha256:${h.digest("hex")}`;
+}
+
+const isPlainObject = (v) =>
+  v != null && typeof v === "object" && !Array.isArray(v) && !Buffer.isBuffer(v);
+
+/** Recursively sort object keys for a byte-deterministic serialization. */
+function stableStringify(value) {
+  if (Array.isArray(value)) return value.map(stableStringify);
+  if (isPlainObject(value)) {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = stableStringify(value[key]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Fingerprint the complete observable request prefix (Section A). Every
+ * cache-relevant value the dev-loops layer observes or controls is folded into
+ * the hash: concrete model, tool definitions/order, system/project/agent
+ * instructions, thinking/tool-choice settings, content-block boundaries, shared
+ * artifact bytes, and breakpoint/TTL intent. Values owned opaquely by a harness
+ * should be passed as `null`-free opaque markers (see `opaqueMarker`).
+ *
+ * @param {object} input
+ * @param {string} input.model - concrete model id for this request group.
+ * @param {string[]|object[]} [input.tools] - tool definitions/order.
+ * @param {string|string[]} [input.systemInstructions] - system/project/agent instructions.
+ * @param {object|string} [input.settings] - thinking/tool-choice settings.
+ * @param {object[]} [input.contentBlocks] - content-block boundaries + shared bytes.
+ * @param {string} [input.sharedArtifact] - shared artifact reference (path) or bytes.
+ * @param {string} [input.cacheBoundary] - e.g. `after_shared_prefix`.
+ * @param {string} [input.ttlIntent] - one of TTL_INTENT_VALUES.
+ * @param {string[]} [input.angleSuffix] - angle-specific suffix (excluded from the
+ *   STABLE prefix fingerprint; included here only when invasive).
+ * @returns {{ fingerprint: string, canonical: object }}
+ */
+export function fingerprintRequestPrefix(input) {
+  if (!input || typeof input !== "object") {
+    throw new Error("fingerprintRequestPrefix requires an object input");
+  }
+  if (typeof input.model !== "string" || input.model.trim().length === 0) {
+    throw new Error("fingerprintRequestPrefix requires a non-empty concrete model");
+  }
+  const canonical = {
+    model: input.model.trim(),
+    tools: Array.isArray(input.tools) ? input.tools : [],
+    systemInstructions: input.systemInstructions ?? null,
+    settings: input.settings ?? null,
+    contentBlocks: Array.isArray(input.contentBlocks) ? input.contentBlocks : null,
+    sharedArtifact: input.sharedArtifact ?? null,
+    cacheBoundary: input.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+    ttlIntent: input.ttlIntent ?? "harness_managed",
+  };
+  return { fingerprint: sha256Hex(canonical), canonical };
+}
+
+/**
+ * Opaque placeholder for a value owned opaquely by the harness. Using this in a
+ * fingerprint input records that the value existed but was not byte-observable,
+ * so two runs that differ only in an unobservable harness value STILL collapse
+ * to the same fingerprint (they cannot be proven different) — and, symmetrically,
+ * a claimed difference under an opaque value is not assertable.
+ *
+ * @param {string} label
+ * @returns {string}
+ */
+export function opaqueMarker(label) {
+  return `__opaque:${String(label)}`;
+}
+
+/* ------------------------------------------------------------------ *
+ * 3. Stable/volatile request separation
+ * ------------------------------------------------------------------ */
+
+/**
+ * The stable-prefix fingerprint is computed ONLY over the stable prefix +
+ * materialized briefing block — never the volatile tail or angle suffix. This
+ * is the mechanical proof for AC-1: changing only `gateState` (or the angle
+ * suffix) MUST NOT change the shared request prefix block.
+ *
+ * @param {object} input
+ * @param {string|Buffer} input.stablePrefix - stable review-agent/system/tool prefix.
+ * @param {string|Buffer} input.briefingBlock - materialized shared briefing block bytes.
+ * @param {string} [input.cacheBoundary]
+ * @param {string} [input.ttlIntent]
+ * @returns {{ stableFingerprint: string, briefedBytes: string }}
+ */
+export function fingerprintStablePrefix({ stablePrefix, briefingBlock, cacheBoundary, ttlIntent } = {}) {
+  const parts = [stablePrefix ?? "", briefingBlock ?? ""];
+  const stableFingerprint = sha256Hex({ stablePrefix: parts[0], briefingBlock: parts[1] });
+  return {
+    stableFingerprint,
+    briefedBytes: JSON.stringify({ cacheBoundary: cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: ttlIntent ?? "harness_managed", stableBytes: parts }),
+  };
+}
+
+/**
+ * Compose a cache-aware request as ordered segments with a declared cache
+ * boundary after the stable briefing block (Section B):
+ *
+ *   [stable review-agent/system/tool prefix]
+ *   [materialized shared briefing block]
+ *   <cache boundary>
+ *   [late volatile gate state, when needed]
+ *   [angle-specific suffix]
+ *
+ * Returns the ordered segment list plus the boundary index and the stable
+ * fingerprints, so a consumer can render the request and a verifier can assert
+ * stable-prefix equality byte-for-byte regardless of volatile/angle changes.
+ *
+ * @param {object} input
+ * @param {string|Buffer} input.stablePrefix
+ * @param {string|Buffer} input.briefingBlock
+ * @param {object} [input.volatileState] - late volatile gate state (serialized AFTER the boundary).
+ * @param {string|Buffer} [input.angleSuffix]
+ * @param {string} [input.cacheBoundary]
+ * @param {string} [input.ttlIntent]
+ * @returns {object} ordered segments + boundary + fingerprints.
+ */
+export function composeCacheAwareRequest({ stablePrefix, briefingBlock, volatileState, angleSuffix, cacheBoundary, ttlIntent } = {}) {
+  const boundary = cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX;
+  const { stableFingerprint, briefedBytes } = fingerprintStablePrefix({
+    stablePrefix,
+    briefingBlock,
+    cacheBoundary: boundary,
+    ttlIntent: ttlIntent ?? "harness_managed",
+  });
+  const late = (typeof volatileState === "object" && volatileState !== null && !Buffer.isBuffer(volatileState))
+    ? JSON.stringify(volatileState)
+    : (volatileState ?? "");
+  const segments = [
+    { slot: "stablePrefix", bytes: stablePrefix ?? "" },
+    { slot: "briefingBlock", bytes: briefingBlock ?? "" },
+  ];
+  // The cache boundary sits AFTER the stable prefix + briefing block.
+  const boundaryIndex = segments.length;
+  segments.push({ slot: "<cache boundary>", bytes: boundary });
+  if (late.length > 0) segments.push({ slot: "volatileState", bytes: late });
+  if (angleSuffix != null && String(angleSuffix).length > 0) {
+    segments.push({ slot: "angleSuffix", bytes: String(angleSuffix) });
+  }
+  return {
+    cacheBoundary: boundary,
+    boundaryIndex,
+    stableFingerprint,
+    briefedBytes,
+    segments,
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * 4. Dispatch-plan builder (Section A)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Build a deterministic per-gate-round dispatch plan. The plan records the
+ * complete cache-relevant request shape WITHOUT duplicating briefing content
+ * (it stores the shared-prefix path + hash, not the bytes).
+ *
+ * @param {object} input
+ * @param {string} input.gate - draft_gate | pre_approval_gate | ...
+ * @param {string} input.headSha - full reviewed head SHA.
+ * @param {string} [input.sharedPrefixPath] - path to the materialized briefing-prefix file.
+ * @param {string} [input.sharedPrefixHash] - `sha256:<hex>` of those bytes.
+ * @param {Array<object>} [input.requestGroups] - each { model, requestPrefixFingerprint, cacheBoundary, ttlIntent, angles[] }.
+ * @param {object} [input.capabilities] - normalized harness capabilities.
+ * @param {object} [input.extra] - opaque consumer fields folded into the canonical hash but ignored by validation.
+ * @returns {object} validated dispatch-plan object.
+ */
+export function buildReviewDispatchPlan({ gate, headSha, sharedPrefixPath, sharedPrefixHash, requestGroups = [], capabilities, extra } = {}) {
+  if (typeof gate !== "string" || gate.length === 0) {
+    throw new Error("buildReviewDispatchPlan requires a non-empty gate");
+  }
+  if (typeof headSha !== "string" || !/^[0-9a-f]{7,64}$/i.test(headSha.trim())) {
+    throw new Error("buildReviewDispatchPlan requires a hex headSha");
+  }
+  if (sharedPrefixHash != null && !isSha256Hex(String(sharedPrefixHash).replace(/^sha256:/, ""))) {
+    throw new Error(`sharedPrefixHash must be sha256:<64 hex> or absent, got ${JSON.stringify(sharedPrefixHash)}`);
+  }
+  const groups = validateRequestGroups(requestGroups);
+  let caps = capabilities;
+  if (caps != null) {
+    // A capability spec may carry a `harness` key plus dimension overrides.
+    const hasHarness = typeof caps === "object" && !Array.isArray(caps) && typeof caps.harness === "string";
+    if (hasHarness) {
+      const { harness: harnessName, ...dims } = caps;
+      caps = normalizeHarnessCapabilities({ harness: harnessName, capabilities: dims });
+    } else {
+      caps = normalizeHarnessCapabilities({ capabilities: caps });
+    }
+  }
+  const plan = {
+    gate,
+    headSha: headSha.trim().toLowerCase(),
+    ...(sharedPrefixPath != null ? { sharedPrefixPath } : {}),
+    ...(sharedPrefixHash != null ? { sharedPrefixHash: String(sharedPrefixHash) } : {}),
+    requestGroups: groups,
+    ...(caps != null ? { capabilities: caps } : {}),
+  };
+  // Deterministic plan hash over the folded canonical object.
+  const planHash = sha256Hex({ ...plan, ...(extra ?? {}) }).replace(/^sha256:/, "");
+  return Object.freeze({ ...plan, planHash: `sha256:${planHash}` });
+}
+
+function validateRequestGroups(requestGroups) {
+  if (!Array.isArray(requestGroups)) {
+    throw new Error("requestGroups must be an array");
+  }
+  return requestGroups.map((g, i) => {
+    if (typeof g.model !== "string" || g.model.trim().length === 0) {
+      throw new Error(`requestGroups[${i}].model must be a non-empty concrete model`);
+    }
+    const fp = typeof g.requestPrefixFingerprint === "string" ? g.requestPrefixFingerprint.trim() : null;
+    if (fp != null && !isSha256Hex(fp.replace(/^sha256:/, ""))) {
+      throw new Error(`requestGroups[${i}].requestPrefixFingerprint must be sha256:<hex> or absent`);
+    }
+    const cacheBoundary = g.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX;
+    if (!CACHE_BOUNDARY_VALUES.includes(cacheBoundary)) {
+      throw new Error(`requestGroups[${i}] invalid cacheBoundary ${JSON.stringify(cacheBoundary)}`);
+    }
+    const ttlIntent = g.ttlIntent ?? "harness_managed";
+    if (!TTL_INTENT_VALUES.includes(ttlIntent)) {
+      throw new Error(`requestGroups[${i}] invalid ttlIntent ${JSON.stringify(ttlIntent)}`);
+    }
+    if (!Array.isArray(g.angles) || g.angles.length === 0) {
+      throw new Error(`requestGroups[${i}].angles must be a non-empty array of angle names`);
+    }
+    return Object.freeze({
+      model: g.model.trim(),
+      ...(fp != null ? { requestPrefixFingerprint: fp } : {}),
+      cacheBoundary,
+      ttlIntent,
+      angles: [...new Set(g.angles.map(String))],
+    });
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * 5. Primer-form default (Section C/D)
+ * ------------------------------------------------------------------ */
+
+export const PRIMER_FORM_LEAD_REVIEWER = "lead_reviewer";
+export const PRIMER_FORM_DEDICATED = "dedicated_primer";
+
+/**
+ * Resolve the primer form for a request group by harness capability (Section
+ * C/D default-by-harness-capability):
+ *  - first_output-observable harness + an adequate TTL (5m/1h) → may prime with
+ *    a lead reviewer (`lead_reviewer`).
+ *  - completion_only harness without an adequate explicit TTL → short dedicated
+ *    primer (`dedicated_primer`) so a full review wait cannot silently outrun
+ *    the cache TTL.
+ *  - usageTelemetry unavailable + opaque controls → conservative dedicated
+ *    primer (cannot observe barrier evidence), failing toward the safe option.
+ *
+ * @param {object} input
+ * @param {Readonly<Record<string,string>>} input.capabilities - normalized capabilities.
+ * @param {string} [input.ttlIntent] - declared TTL intent for the group.
+ * @returns {{ primerForm: "lead_reviewer"|"dedicated_primer", reason: string }}
+ */
+export function resolvePrimerForm({ capabilities, ttlIntent } = {}) {
+  const caps = capabilities ?? {};
+  const adequateTtl = ttlIntent === "5m" || ttlIntent === "1h";
+  if (caps.barrierSignal === "first_output" && (adequateTtl || caps.cacheTtlControl === "5m_1h")) {
+    return {
+      primerForm: PRIMER_FORM_LEAD_REVIEWER,
+      reason: "barrierSignal=first_output and an adequate TTL is available — a real lead reviewer may prime the group",
+    };
+  }
+  if (caps.barrierSignal === "completion_only" && caps.cacheTtlControl === "5m_1h" && ttlIntent === "1h") {
+    return {
+      primerForm: PRIMER_FORM_LEAD_REVIEWER,
+      reason: "completion_only harness with an explicit one-hour TTL — a long lead review fits the cache window",
+    };
+  }
+  return {
+    primerForm: PRIMER_FORM_DEDICATED,
+    reason: "completion_only or opaque controls without an adequate explicit TTL — a short dedicated primer avoids a full review outrunning the cache TTL",
+  };
+}
+
+/**
+ * Partition request groups into primer groups — one per distinct concrete
+ * model/request-prefix (Section C: heterogeneous per-angle model routing cannot
+ * silently reuse one model's primer to warm another).
+ *
+ * @param {object[]} requestGroups - validated request groups.
+ * @param {Readonly<Record<string,string>>} [capabilities]
+ * @returns {Array<{ model: string, requestPrefixFingerprint: string|null, groups: object[] }>}
+ */
+export function partitionPrimerGroups(requestGroups, capabilities = {}) {
+  if (!Array.isArray(requestGroups)) throw new Error("partitionPrimerGroups requires an array");
+  // One primer group per distinct (model, request-prefix) — a primer warms ONE
+  // concrete model's provider cache under a specific request prefix, so two
+  // groups cannot share a primer even when their fingerprints coincide.
+  const byKey = new Map();
+  for (const g of requestGroups) {
+    const fp = g.requestPrefixFingerprint ?? opaqueMarker(`model:${g.model}`);
+    const key = `${g.model}::${fp}`;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(g);
+  }
+  const out = [];
+  for (const [key, groups] of byKey.entries()) {
+    const model = key.split("::")[0];
+    const fp = key.slice(model.length + 2);
+    out.push({
+      model,
+      requestPrefixFingerprint: fp.startsWith("sha256:") ? fp : null,
+      primerForm: resolvePrimerForm({ capabilities, ttlIntent: groups[0].ttlIntent }).primerForm,
+      groups: groups.map((g) => ({ model: g.model, angles: g.angles, ttlIntent: g.ttlIntent })),
+    });
+  }
+  return out;
+}

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -265,9 +265,9 @@ export function fingerprintRequestPrefix(input) {
     sharedArtifact: input.sharedArtifact ?? null,
     cacheBoundary: boundary,
     ttlIntent: ttl,
-    // angleSuffix is excluded from the STABLE prefix fingerprint but, when the
-    // caller marks it invasive, it IS folded into this full request-prefix
-    // fingerprint so the claimed difference stays assertable.
+    // angleSuffix is excluded from the STABLE prefix fingerprint but is always
+    // folded into this full request-prefix fingerprint when present, so the
+    // claimed volatile difference stays assertable.
     ...(input.angleSuffix != null ? { angleSuffix: input.angleSuffix } : {}),
   };
   return { fingerprint: sha256Hex(canonical), canonical };
@@ -518,9 +518,12 @@ export function resolvePrimerForm({ capabilities, ttlIntent } = {}) {
   const caps = capabilities ?? {};
   const adequateTtl = ttlIntent === "5m" || ttlIntent === "1h";
   if (caps.barrierSignal === "first_output" && (adequateTtl || caps.cacheTtlControl === "5m_1h")) {
+    const reason = adequateTtl
+      ? "barrierSignal=first_output and an adequate TTL is available — a real lead reviewer may prime the group"
+      : "barrierSignal=first_output with cacheTtlControl=5m_1h capability — a real lead reviewer fits the cache control window";
     return {
       primerForm: PRIMER_FORM_LEAD_REVIEWER,
-      reason: "barrierSignal=first_output and an adequate TTL is available — a real lead reviewer may prime the group",
+      reason,
     };
   }
   if (caps.barrierSignal === "completion_only" && caps.cacheTtlControl === "5m_1h" && ttlIntent === "1h") {

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -309,7 +309,15 @@ export function fingerprintStablePrefix({ stablePrefix, briefingBlock, cacheBoun
   const stableFingerprint = sha256Hex({ stablePrefix: parts[0], briefingBlock: parts[1] });
   return {
     stableFingerprint,
-    briefedBytes: JSON.stringify({ cacheBoundary: cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: ttlIntent ?? "harness_managed", stableBytes: parts }),
+    // Canonicalize through stableStringify so a Buffer stablePrefix/briefingBlock
+    // becomes `__buffer:<hex>` here too — raw JSON.stringify would expand Buffers
+    // into large {type:"Buffer",data:[…]} decimal arrays (byte-unstable + costly),
+    // reintroducing exactly what sha256Hex avoids.
+    briefedBytes: JSON.stringify(stableStringify({
+      cacheBoundary: cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+      ttlIntent: ttlIntent ?? "harness_managed",
+      stableBytes: parts,
+    })),
   };
 }
 
@@ -338,11 +346,21 @@ export function fingerprintStablePrefix({ stablePrefix, briefingBlock, cacheBoun
  */
 export function composeCacheAwareRequest({ stablePrefix, briefingBlock, volatileState, angleSuffix, cacheBoundary, ttlIntent } = {}) {
   const boundary = cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX;
+  const ttl = ttlIntent ?? "harness_managed";
+  // Fail closed on out-of-enum cacheBoundary/ttlIntent (parity with
+  // fingerprintRequestPrefix / validateRequestGroups) so a caller typo cannot
+  // silently flow into the returned structure and break later parity checks.
+  if (!CACHE_BOUNDARY_VALUES.includes(boundary)) {
+    throw new Error(`composeCacheAwareRequest invalid cacheBoundary ${JSON.stringify(boundary)}`);
+  }
+  if (!TTL_INTENT_VALUES.includes(ttl)) {
+    throw new Error(`composeCacheAwareRequest invalid ttlIntent ${JSON.stringify(ttl)}`);
+  }
   const { stableFingerprint, briefedBytes } = fingerprintStablePrefix({
     stablePrefix,
     briefingBlock,
     cacheBoundary: boundary,
-    ttlIntent: ttlIntent ?? "harness_managed",
+    ttlIntent: ttl,
   });
   const late = (typeof volatileState === "object" && volatileState !== null && !Buffer.isBuffer(volatileState))
     ? JSON.stringify(volatileState)
@@ -351,9 +369,13 @@ export function composeCacheAwareRequest({ stablePrefix, briefingBlock, volatile
     { slot: "stablePrefix", bytes: stablePrefix ?? "" },
     { slot: "briefingBlock", bytes: briefingBlock ?? "" },
   ];
-  // The cache boundary sits AFTER the stable prefix + briefing block.
+  // The cache boundary sits AFTER the stable prefix + briefing block. The marker
+  // segment is a structural pointer, NOT request bytes: it is byte-empty so a
+  // consumer concatenating segment bytes never injects the boundary label into
+  // the provider-visible prompt (the label lives in the separate cacheBoundary
+  // field).
   const boundaryIndex = segments.length;
-  segments.push({ slot: "<cache boundary>", bytes: boundary });
+  segments.push({ slot: "<cache boundary>", bytes: "" });
   if (late.length > 0) segments.push({ slot: "volatileState", bytes: late });
   if (angleSuffix != null && String(angleSuffix).length > 0) {
     segments.push({ slot: "angleSuffix", bytes: String(angleSuffix) });

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -193,6 +193,11 @@ const isPlainObject = (v) =>
 /** Recursively sort object keys for a byte-deterministic serialization. */
 function stableStringify(value) {
   if (Array.isArray(value)) return value.map(stableStringify);
+  // Canonicalize nested Buffers to hex (the `__buffer:` prefix keeps a Buffer
+  // distinct from a string that happens to equal its hex, so bytes and text can
+  // never collide). Mirrors sha256Hex's top-level Buffer handling so a push/pull
+  // through memory vs disk yields identical bytes even for nested buffers.
+  if (Buffer.isBuffer(value)) return `__buffer:${value.toString("hex")}`;
   if (isPlainObject(value)) {
     const out = {};
     for (const key of Object.keys(value).sort()) out[key] = stableStringify(value[key]);
@@ -239,6 +244,18 @@ export function fingerprintRequestPrefix(input) {
   if (input.contentBlocks != null && !Array.isArray(input.contentBlocks)) {
     throw new Error("fingerprintRequestPrefix contentBlocks must be an array");
   }
+  // Fail closed on out-of-enum cacheBoundary/ttlIntent: a caller typo would
+  // fold an undefinable value into the fingerprint that no other caller could
+  // ever reproduce/validate, silently undermining the mechanically-checkable
+  // contract (AC-2 parity with validateRequestGroups).
+  const boundary = input.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX;
+  const ttl = input.ttlIntent ?? "harness_managed";
+  if (!CACHE_BOUNDARY_VALUES.includes(boundary)) {
+    throw new Error(`fingerprintRequestPrefix invalid cacheBoundary ${JSON.stringify(boundary)}`);
+  }
+  if (!TTL_INTENT_VALUES.includes(ttl)) {
+    throw new Error(`fingerprintRequestPrefix invalid ttlIntent ${JSON.stringify(ttl)}`);
+  }
   const canonical = {
     model: input.model.trim(),
     tools: input.tools ?? [],
@@ -246,8 +263,8 @@ export function fingerprintRequestPrefix(input) {
     settings: input.settings ?? null,
     contentBlocks: input.contentBlocks ?? null,
     sharedArtifact: input.sharedArtifact ?? null,
-    cacheBoundary: input.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
-    ttlIntent: input.ttlIntent ?? "harness_managed",
+    cacheBoundary: boundary,
+    ttlIntent: ttl,
     // angleSuffix is excluded from the STABLE prefix fingerprint but, when the
     // caller marks it invasive, it IS folded into this full request-prefix
     // fingerprint so the claimed difference stays assertable.
@@ -379,6 +396,13 @@ export function buildReviewDispatchPlan({ gate, headSha, sharedPrefixPath, share
   if (sharedPrefixHash != null && !isSha256Hex(String(sharedPrefixHash).replace(/^sha256:/, ""))) {
     throw new Error(`sharedPrefixHash must be sha256:<64 hex> or absent, got ${JSON.stringify(sharedPrefixHash)}`);
   }
+  // Normalize the stored artifact to a single canonical `sha256:<hex>` form so
+  // the plan (and its planHash) never depends on whether the caller passed a
+  // raw 64-hex string or an already-prefixed one for identical bytes (mixed-
+  // format artifacts are byte-non-deterministic across callers).
+  const normalizedSharedPrefixHash = sharedPrefixHash != null
+    ? `sha256:${String(sharedPrefixHash).replace(/^sha256:/, "").trim().toLowerCase()}`
+    : null;
   const groups = validateRequestGroups(requestGroups);
   let caps = capabilities;
   if (caps != null) {
@@ -395,7 +419,7 @@ export function buildReviewDispatchPlan({ gate, headSha, sharedPrefixPath, share
     gate,
     headSha: headSha.trim().toLowerCase(),
     ...(sharedPrefixPath != null ? { sharedPrefixPath } : {}),
-    ...(sharedPrefixHash != null ? { sharedPrefixHash: String(sharedPrefixHash) } : {}),
+    ...(normalizedSharedPrefixHash != null ? { sharedPrefixHash: normalizedSharedPrefixHash } : {}),
     requestGroups: groups,
     ...(caps != null ? { capabilities: caps } : {}),
   };
@@ -414,10 +438,16 @@ function validateRequestGroups(requestGroups) {
     if (typeof g.model !== "string" || g.model.trim().length === 0) {
       throw new Error(`requestGroups[${i}].model must be a non-empty concrete model`);
     }
-    const fp = typeof g.requestPrefixFingerprint === "string" ? g.requestPrefixFingerprint.trim() : null;
-    if (fp != null && !isSha256Hex(fp.replace(/^sha256:/, ""))) {
+    const fpRaw = typeof g.requestPrefixFingerprint === "string" ? g.requestPrefixFingerprint.trim() : null;
+    if (fpRaw != null && !isSha256Hex(fpRaw.replace(/^sha256:/, ""))) {
       throw new Error(`requestGroups[${i}].requestPrefixFingerprint must be sha256:<hex> or absent`);
     }
+    // Normalize to a single canonical `sha256:<hex>` form (same rationale as
+    // sharedPrefixHash) so the grouping/partition logic and the plan artifact
+    // see byte-identical fingerprints regardless of caller format.
+    const fp = fpRaw != null
+      ? `sha256:${fpRaw.replace(/^sha256:/, "").toLowerCase()}`
+      : null;
     const cacheBoundary = g.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX;
     if (!CACHE_BOUNDARY_VALUES.includes(cacheBoundary)) {
       throw new Error(`requestGroups[${i}] invalid cacheBoundary ${JSON.stringify(cacheBoundary)}`);
@@ -431,7 +461,7 @@ function validateRequestGroups(requestGroups) {
     }
     return Object.freeze({
       model: g.model.trim(),
-      ...(fp != null ? { requestPrefixFingerprint: fp } : {}),
+      ...(fpRaw != null ? { requestPrefixFingerprint: fp } : {}),
       cacheBoundary,
       ttlIntent,
       angles: [...new Set(g.angles.map(String))],
@@ -495,18 +525,28 @@ export function resolvePrimerForm({ capabilities, ttlIntent } = {}) {
 export function partitionPrimerGroups(requestGroups, capabilities = {}) {
   if (!Array.isArray(requestGroups)) throw new Error("partitionPrimerGroups requires an array");
   // One primer group per distinct (model, request-prefix) — a primer warms ONE
-  // concrete model's provider cache under a specific request prefix, so two
-  // groups cannot share a primer even when their fingerprints coincide. Use a
-  // nested Map keyed by model then by fingerprint (never a single delimiter-joined
+  // concrete model's provider cache under a specific request prefix. Groups that
+  // share a model AND a real (`sha256:<hex>`) fingerprint collapse into one
+  // bucket; groups without a proven fingerprint never collapse (see below). Use
+  // a nested Map keyed by model then by fingerprint (never a single delimiter-joined
   // string), so a model id that itself contains "::" stays intact and two distinct
   // (model, fp) pairs can never collide onto one bucket (dedup/identity safety).
   const byModel = new Map();
-  for (const g of requestGroups) {
+  for (let i = 0; i < requestGroups.length; i++) {
+    const g = requestGroups[i];
     if (!byModel.has(g.model)) byModel.set(g.model, new Map());
     const fpMap = byModel.get(g.model);
-    const fp = g.requestPrefixFingerprint ?? opaqueMarker(`model:${g.model}`);
-    if (!fpMap.has(fp)) fpMap.set(fp, []);
-    fpMap.get(fp).push(g);
+    // Fail closed: only groups carrying a REAL (`sha256:<hex>`) fingerprint may
+    // share a primer bucket (that proves a common cache-relevant prefix). A
+    // fingerprint-less group is keyed by its own index so it NEVER collapses
+    // with another — without a fingerprint you cannot prove two groups share the
+    // same prefix, so merging them would let one primer silently cover multiple
+    // unknown prefixes (at best wasted priming, at worst misleading evidence).
+    const hasRealFp = typeof g.requestPrefixFingerprint === "string"
+      && g.requestPrefixFingerprint.startsWith("sha256:");
+    const key = hasRealFp ? g.requestPrefixFingerprint : `__unkeyed:${i}`;
+    if (!fpMap.has(key)) fpMap.set(key, []);
+    fpMap.get(key).push(g);
   }
   const out = [];
   for (const [model, fpMap] of byModel.entries()) {

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -399,8 +399,10 @@ export function buildReviewDispatchPlan({ gate, headSha, sharedPrefixPath, share
     requestGroups: groups,
     ...(caps != null ? { capabilities: caps } : {}),
   };
-  // Deterministic plan hash over the folded canonical object.
-  const planHash = sha256Hex({ ...plan, ...(extra ?? {}) }).replace(/^sha256:/, "");
+  // Deterministic plan hash over the canonical plan, with opaque `extra` folded
+  // under its own namespace so an `extra` key can never shadow a real plan
+  // field (the fingerprint must always pin the plan's actual values).
+  const planHash = sha256Hex({ ...plan, extra: extra ?? {} }).replace(/^sha256:/, "");
   return Object.freeze({ ...plan, planHash: `sha256:${planHash}` });
 }
 

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -122,6 +122,21 @@ describe("fingerprintRequestPrefix — complete observable prefix (Section A/AC-
   test("requires a non-empty concrete model", () => {
     assert.throws(() => fingerprintRequestPrefix({ model: "" }));
   });
+
+  test("angleSuffix is folded into the fingerprint only when provided (invasive marker)", () => {
+    const base = { model: "m", tools: ["read"] };
+    const plain = fingerprintRequestPrefix(base).fingerprint;
+    const withSuffix = fingerprintRequestPrefix({ ...base, angleSuffix: ["correctness"] }).fingerprint;
+    assert.notEqual(plain, withSuffix);
+    // absent angleSuffix stays byte-identical (no spurious fingerprint churn).
+    assert.equal(plain, fingerprintRequestPrefix({ ...base }).fingerprint);
+  });
+
+  test("non-array tools / contentBlocks fail closed instead of silently dropping the field", () => {
+    const base = { model: "m" };
+    assert.throws(() => fingerprintRequestPrefix({ ...base, tools: "read" }));
+    assert.throws(() => fingerprintRequestPrefix({ ...base, contentBlocks: "x" }));
+  });
 });
 
 describe("fingerprintStablePrefix — AC-1: changing only gateState does not change the shared prefix", () => {
@@ -233,6 +248,34 @@ describe("buildReviewDispatchPlan — AC-2: deterministic request-plan artifact"
       }),
     );
   });
+
+  test("validateRequestGroups fail-closed branches (full negative coverage)", () => {
+    assert.throws(() => buildReviewDispatchPlan({ gate: "g", headSha: "abc", requestGroups: "nope" }));
+    assert.throws(() =>
+      buildReviewDispatchPlan({ gate: "g", headSha: "abc", requestGroups: [{ model: "", angles: ["a"] }] }),
+    );
+    assert.throws(() =>
+      buildReviewDispatchPlan({
+        gate: "g",
+        headSha: "abc",
+        requestGroups: [{ model: "m", requestPrefixFingerprint: "not-hex", angles: ["a"] }],
+      }),
+    );
+    assert.throws(() =>
+      buildReviewDispatchPlan({
+        gate: "g",
+        headSha: "abc",
+        requestGroups: [{ model: "m", cacheBoundary: "never", angles: ["a"] }],
+      }),
+    );
+    assert.throws(() =>
+      buildReviewDispatchPlan({
+        gate: "g",
+        headSha: "abc",
+        requestGroups: [{ model: "m", ttlIntent: "forever", angles: ["a"] }],
+      }),
+    );
+  });
 });
 
 describe("resolvePrimerForm — default by harness capability (Section C/AC-6)", () => {
@@ -261,6 +304,16 @@ describe("resolvePrimerForm — default by harness capability (Section C/AC-6)",
     const caps = normalizeHarnessCapabilities({ harness: "pi" });
     assert.equal(resolvePrimerForm({ capabilities: caps }).primerForm, PRIMER_FORM_DEDICATED);
   });
+
+  test("first_output + 5m_1h TTL control + no adequate declared ttlIntent -> lead reviewer (second disjunct)", () => {
+    const caps = normalizeHarnessCapabilities({
+      capabilities: { barrierSignal: "first_output", cacheTtlControl: "5m_1h", breakpointControl: "explicit", usageTelemetry: "available" },
+    });
+    assert.equal(
+      resolvePrimerForm({ capabilities: caps, ttlIntent: "harness_managed" }).primerForm,
+      PRIMER_FORM_LEAD_REVIEWER,
+    );
+  });
 });
 
 describe("partitionPrimerGroups — one primer group per model/request-prefix (Section C)", () => {
@@ -285,6 +338,56 @@ describe("partitionPrimerGroups — one primer group per model/request-prefix (S
     ]);
     assert.equal(groups.length, 1);
     assert.deepEqual([...groups[0].groups.flatMap((g) => g.angles)], ["a", "b"]);
+  });
+
+  test("model id containing '::' is not truncated by partition key parsing", () => {
+    const fp = "sha256:" + "d".repeat(64);
+    const groups = partitionPrimerGroups([
+      { model: "a::b:c", requestPrefixFingerprint: fp, angles: ["a"], ttlIntent: "5m" },
+      { model: "a::b:c", requestPrefixFingerprint: fp, angles: ["b"], ttlIntent: "5m" },
+    ]);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].model, "a::b:c");
+    assert.equal(groups[0].requestPrefixFingerprint, fp);
+  });
+
+  test("collapsed groups with mixed TTL intents take the conservative dedicated primer", () => {
+    const foFixed = normalizeHarnessCapabilities({
+      capabilities: { barrierSignal: "first_output", cacheTtlControl: "fixed", breakpointControl: "explicit", usageTelemetry: "available" },
+    });
+    const fp = "sha256:" + "e".repeat(64);
+    // 5m -> lead; harness_managed -> dedicated under fixed TTL control.
+    const groups = partitionPrimerGroups([
+      { model: "m", requestPrefixFingerprint: fp, angles: ["a"], ttlIntent: "5m" },
+      { model: "m", requestPrefixFingerprint: fp, angles: ["b"], ttlIntent: "harness_managed" },
+    ], foFixed);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].primerForm, PRIMER_FORM_DEDICATED);
+  });
+
+  test("collapsed groups all with adequate TTL -> lead reviewer primer", () => {
+    const foFixed = normalizeHarnessCapabilities({
+      capabilities: { barrierSignal: "first_output", cacheTtlControl: "fixed", breakpointControl: "explicit", usageTelemetry: "available" },
+    });
+    const fp = "sha256:" + "f".repeat(64);
+    const groups = partitionPrimerGroups([
+      { model: "m", requestPrefixFingerprint: fp, angles: ["a"], ttlIntent: "1h" },
+      { model: "m", requestPrefixFingerprint: fp, angles: ["b"], ttlIntent: "5m" },
+    ], foFixed);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].primerForm, PRIMER_FORM_LEAD_REVIEWER);
+  });
+
+  test("groups lacking a requestPrefixFingerprint partition by an opaque model key", () => {
+    const groups = partitionPrimerGroups([
+      { model: "m", angles: ["a"], ttlIntent: "5m" },
+      { model: "m", angles: ["b"], ttlIntent: "5m" },
+      { model: "other", angles: ["c"], ttlIntent: "5m" },
+    ]);
+    assert.equal(groups.length, 2);
+    const m = groups.find((g) => g.model === "m");
+    assert.equal(m.requestPrefixFingerprint, null);
+    assert.deepEqual([...m.groups.flatMap((g) => g.angles)].sort(), ["a", "b"]);
   });
 });
 

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -137,6 +137,17 @@ describe("fingerprintRequestPrefix — complete observable prefix (Section A/AC-
     assert.throws(() => fingerprintRequestPrefix({ ...base, tools: "read" }));
     assert.throws(() => fingerprintRequestPrefix({ ...base, contentBlocks: "x" }));
   });
+
+  test("invalid cacheBoundary / ttlIntent fail closed instead of folding an un-reproducible value", () => {
+    const base = { model: "m", tools: ["read"] };
+    assert.throws(() => fingerprintRequestPrefix({ ...base, cacheBoundary: "5min" }));
+    assert.throws(() => fingerprintRequestPrefix({ ...base, ttlIntent: "5min" }));
+    // Valid enum values fold in cleanly.
+    assert.match(
+      fingerprintRequestPrefix({ ...base, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h" }).fingerprint,
+      /^sha256:[0-9a-f]{64}$/,
+    );
+  });
 });
 
 describe("fingerprintStablePrefix — AC-1: changing only gateState does not change the shared prefix", () => {
@@ -234,6 +245,27 @@ describe("buildReviewDispatchPlan — AC-2: deterministic request-plan artifact"
       capabilities: { harness: "claude" },
     });
     assert.equal(b.planHash, plan.planHash);
+  });
+
+  test("sharedPrefixHash is normalized to canonical sha256:<hex> regardless of caller format", () => {
+    const rawHex = "e".repeat(64);
+    const prefixed = `sha256:${rawHex}`;
+    const withRaw = buildReviewDispatchPlan({ gate: "g", headSha: "abc1234", sharedPrefixHash: rawHex, requestGroups: [] });
+    const withPrefixed = buildReviewDispatchPlan({ gate: "g", headSha: "abc1234", sharedPrefixHash: prefixed, requestGroups: [] });
+    assert.equal(withRaw.sharedPrefixHash, prefixed);
+    assert.equal(withPrefixed.sharedPrefixHash, prefixed);
+    // Identical underlying bytes produce an identical plan (no mixed-format drift).
+    assert.equal(withRaw.planHash, withPrefixed.planHash);
+  });
+
+  test("requestPrefixFingerprint is normalized to canonical sha256:<hex>", () => {
+    const rawHex = "f".repeat(64);
+    const plan = buildReviewDispatchPlan({
+      gate: "g",
+      headSha: "abc1234",
+      requestGroups: [{ model: "m", requestPrefixFingerprint: rawHex, angles: ["a"] }],
+    });
+    assert.equal(plan.requestGroups[0].requestPrefixFingerprint, `sha256:${rawHex}`);
   });
 
   test("extra shadowing a plan key cannot mask a real pinned-field change", () => {
@@ -421,16 +453,20 @@ describe("partitionPrimerGroups — one primer group per model/request-prefix (S
     assert.equal(groups[0].primerForm, PRIMER_FORM_LEAD_REVIEWER);
   });
 
-  test("groups lacking a requestPrefixFingerprint partition by an opaque model key", () => {
+  test("groups lacking a requestPrefixFingerprint are NOT collapsed (fail-closed)", () => {
     const groups = partitionPrimerGroups([
       { model: "m", angles: ["a"], ttlIntent: "5m" },
       { model: "m", angles: ["b"], ttlIntent: "5m" },
       { model: "other", angles: ["c"], ttlIntent: "5m" },
     ]);
-    assert.equal(groups.length, 2);
-    const m = groups.find((g) => g.model === "m");
-    assert.equal(m.requestPrefixFingerprint, null);
-    assert.deepEqual([...m.groups.flatMap((g) => g.angles)].sort(), ["a", "b"]);
+    // Each fingerprint-less group forms its own partition — without a proven
+    // prefix, two 'm' groups cannot be shown to share a cache-relevant prefix,
+    // so merging them would let one primer silently cover unknown prefixes.
+    assert.equal(groups.length, 3);
+    const mGroups = groups.filter((g) => g.model === "m");
+    assert.equal(mGroups.length, 2);
+    for (const g of groups) assert.equal(g.requestPrefixFingerprint, null);
+    assert.deepEqual([...mGroups.map((g) => g.groups[0].angles[0])].sort(), ["a", "b"]);
   });
 });
 
@@ -447,5 +483,13 @@ describe("sha256Hex — deterministic hashing + opaque markers", () => {
 
   test("opaqueMarker marks harness-owned values as unverifiable", () => {
     assert.match(opaqueMarker("model"), /^__opaque:/);
+  });
+
+  test("nested Buffers are canonicalized to hex (not Buffer.toJSON data array)", () => {
+    const a = sha256Hex({ bytes: Buffer.from("hello"), label: "x" });
+    // Same bytes reconstructed identically -> identical hash (memory vs disk).
+    assert.equal(a, sha256Hex({ bytes: Buffer.from("hello"), label: "x" }));
+    // A Buffer and an identical hex string must NOT collide (prefix disambiguates).
+    assert.notEqual(a, sha256Hex({ bytes: "hello", label: "x" }));
   });
 });

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -199,6 +199,31 @@ describe("composeCacheAwareRequest — stable/volatile separation (Section B)", 
     assert.deepEqual(r.segments.map((s) => s.slot), ["stablePrefix", "briefingBlock", "<cache boundary>"]);
   });
 
+  test("cache-boundary marker segment is byte-empty (no label leaked into request bytes)", () => {
+    const r = composeCacheAwareRequest({ stablePrefix, briefingBlock: briefing });
+    const marker = r.segments[r.boundaryIndex];
+    assert.equal(marker.slot, "<cache boundary>");
+    assert.equal(marker.bytes, "", "boundary label must not be injected into provider-visible prompt bytes");
+    // The label still lives in the separate cacheBoundary field.
+    assert.equal(r.cacheBoundary, CACHE_BOUNDARY_AFTER_SHARED_PREFIX);
+  });
+
+  test("invalid cacheBoundary / ttlIntent fail closed in composeCacheAwareRequest", () => {
+    assert.throws(() => composeCacheAwareRequest({ stablePrefix, briefingBlock: briefing, cacheBoundary: "5min" }));
+    assert.throws(() => composeCacheAwareRequest({ stablePrefix, briefingBlock: briefing, ttlIntent: "forever" }));
+  });
+
+  test("briefedBytes canonicalizes a Buffer stablePrefix (no Buffer.toJSON data array)", () => {
+    const r = composeCacheAwareRequest({ stablePrefix: Buffer.from("stable bytes"), briefingBlock: briefing });
+    assert.ok(!r.briefedBytes.includes('"type":"Buffer"'), "nested Buffer must not expand into a decimal data array");
+    assert.ok(r.briefedBytes.includes("__buffer:"), "nested Buffer canonicalized to a hex marker");
+    // Byte-deterministic across identical Buffer bytes.
+    assert.equal(
+      r.briefedBytes,
+      composeCacheAwareRequest({ stablePrefix: Buffer.from("stable bytes"), briefingBlock: briefing }).briefedBytes,
+    );
+  });
+
   test("stable fingerprint is unchanged by volatile/angle changes (AC-1 + AC-3)", () => {
     const base = { stablePrefix, briefingBlock: briefing };
     const withVolatile = composeCacheAwareRequest({ ...base, volatileState: { tag: "x" } }).stableFingerprint;

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -236,6 +236,49 @@ describe("buildReviewDispatchPlan — AC-2: deterministic request-plan artifact"
     assert.equal(b.planHash, plan.planHash);
   });
 
+  test("extra shadowing a plan key cannot mask a real pinned-field change", () => {
+    const base = {
+      gate: "pre_approval_gate",
+      sharedPrefixPath: "tmp/gate-context/pre_approval_gate-abcdef1234567890.briefing-prefix.txt",
+      sharedPrefixHash: fp,
+      requestGroups: [
+        { model: "anthropic/claude-opus", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "5m", angles: ["correctness", "security"] },
+        { model: "anthropic/claude-haiku", requestPrefixFingerprint: fp, ttlIntent: "1h", angles: ["docs"] },
+      ],
+      capabilities: { harness: "claude" },
+    };
+    // Two plans that differ in their REAL headSha but carry the SAME opacity
+    // shadowing extra. Under the old {...plan, ...extra} fold, the extra's
+    // shadowed headSha would mask the real difference and both would hash
+    // identically; the fingerprint must pin the plan's actual values instead.
+    const a = buildReviewDispatchPlan({ ...base, headSha: "aaaa1111111111111111111111111111111111", extra: { headSha: "bbbb2222222222222222222222222222222222", gate: "draft_gate" } });
+    const b = buildReviewDispatchPlan({ ...base, headSha: "bbbb2222222222222222222222222222222222", extra: { headSha: "bbbb2222222222222222222222222222222222", gate: "draft_gate" } });
+    assert.notEqual(a.planHash, b.planHash, "extra shadowing must not mask a real headSha change");
+    // The returned plan still carries the REAL values, not the extra's.
+    assert.equal(a.headSha, "aaaa1111111111111111111111111111111111");
+    assert.equal(b.headSha, "bbbb2222222222222222222222222222222222");
+    assert.equal(a.gate, "pre_approval_gate");
+    assert.equal(b.gate, "pre_approval_gate");
+  });
+
+  test("distinct opaque extra still diverges the fingerprint", () => {
+    const base = {
+      gate: "pre_approval_gate",
+      headSha: "abcdef1234567890",
+      sharedPrefixPath: "tmp/gate-context/pre_approval_gate-abcdef1234567890.briefing-prefix.txt",
+      sharedPrefixHash: fp,
+      requestGroups: [
+        { model: "anthropic/claude-opus", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "5m", angles: ["correctness", "security"] },
+        { model: "anthropic/claude-haiku", requestPrefixFingerprint: fp, ttlIntent: "1h", angles: ["docs"] },
+      ],
+      capabilities: { harness: "claude" },
+    };
+    const a = buildReviewDispatchPlan({ ...base, extra: { reportParseCue: "alpha" } });
+    const b = buildReviewDispatchPlan({ ...base, extra: { reportParseCue: "beta" } });
+    assert.notEqual(a.planHash, b.planHash);
+    assert.notEqual(a.planHash, plan.planHash);
+  });
+
   test("usages fail closed on bad input", () => {
     assert.throws(() => buildReviewDispatchPlan({ gate: "", headSha: "abc" }));
     assert.throws(() => buildReviewDispatchPlan({ gate: "g", headSha: "not-a-sha" }));

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import {
+  CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+  CACHE_BOUNDARY_VALUES,
+  HARNESS_DEFAULT_CAPABILITIES,
+  PRIMER_FORM_DEDICATED,
+  PRIMER_FORM_LEAD_REVIEWER,
+  TTL_INTENT_VALUES,
+  buildReviewDispatchPlan,
+  cacheReuseVeracity,
+  composeCacheAwareRequest,
+  fingerprintRequestPrefix,
+  fingerprintStablePrefix,
+  normalizeHarnessCapabilities,
+  opaqueMarker,
+  partitionPrimerGroups,
+  resolvePrimerForm,
+  sha256Hex,
+} from "../src/loop/review-dispatch-plan.mjs";
+
+describe("normalizeHarnessCapabilities — explicit capability model (Section D)", () => {
+  test("claude default posture is explicit, fixed TTL, telemetry available", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "claude" });
+    assert.equal(caps.breakpointControl, "automatic");
+    assert.equal(caps.barrierSignal, "completion_only");
+    assert.equal(caps.cacheTtlControl, "fixed");
+    assert.equal(caps.usageTelemetry, "available");
+    assert.ok(Object.isFrozen(caps));
+  });
+
+  test("pi default posture is conservative/opaque and telemetry unavailable (fail toward no over-claim)", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "pi" });
+    assert.equal(caps.breakpointControl, "opaque");
+    assert.equal(caps.usageTelemetry, "unavailable");
+  });
+
+  test("unknown harness name fails closed", () => {
+    assert.throws(() => normalizeHarnessCapabilities({ harness: "no-such" }));
+  });
+
+  test("invalid dimension value fails closed", () => {
+    assert.throws(() =>
+      normalizeHarnessCapabilities({ capabilities: { usageTelemetry: "definitely" } }),
+    );
+  });
+
+  test("unknown dimension fails closed", () => {
+    assert.throws(() =>
+      normalizeHarnessCapabilities({ capabilities: { magic: "on" } }),
+    );
+  });
+
+  test("explicit capabilities override defaults and are validated", () => {
+    const caps = normalizeHarnessCapabilities({
+      harness: "pi",
+      capabilities: { barrierSignal: "first_output", cacheTtlControl: "5m_1h" },
+    });
+    assert.equal(caps.barrierSignal, "first_output");
+    assert.equal(caps.cacheTtlControl, "5m_1h");
+    assert.equal(caps.usageTelemetry, "unavailable");
+  });
+
+  test("missing dimension after overrides fails closed", () => {
+    // A bare non-object capability input is rejected outright.
+    assert.throws(() => normalizeHarnessCapabilities({ capabilities: "nope" }));
+  });
+});
+
+describe("cacheReuseVeracity — opaque harnesses never claim verified reuse (Section D/AC-9)", () => {
+  test("telemetry available -> verified", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "claude" });
+    assert.equal(cacheReuseVeracity(caps).verified, true);
+  });
+
+  test("telemetry unavailable -> verified false with an explicit reason", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "pi" });
+    const r = cacheReuseVeracity(caps);
+    assert.equal(r.verified, false);
+    assert.match(r.reason, /cannot be verified/);
+  });
+
+  test("missing capability record -> verified false", () => {
+    assert.equal(cacheReuseVeracity(null).verified, false);
+  });
+});
+
+describe("fingerprintRequestPrefix — complete observable prefix (Section A/AC-2)", () => {
+  const base = {
+    model: "anthropic/claude-opus",
+    tools: ["read", "bash", "edit"],
+    systemInstructions: ["You are a review agent."],
+    settings: { thinking: true },
+    contentBlocks: [{ type: "text", role: "briefing" }],
+    sharedArtifact: "tmp/gate-context/pre_approval_gate-abc.briefing-prefix.txt",
+  };
+
+  test("covers model, tools, instructions, settings, blocks, bytes, ttl", () => {
+    const { fingerprint } = fingerprintRequestPrefix(base);
+    assert.match(fingerprint, /^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("is byte-deterministic: same input -> same fingerprint", () => {
+    const a = fingerprintRequestPrefix(base).fingerprint;
+    const b = fingerprintRequestPrefix({ ...base }).fingerprint;
+    assert.equal(a, b);
+  });
+
+  test("model change changes the fingerprint (heterogeneous routing is not conflated)", () => {
+    const a = fingerprintRequestPrefix(base).fingerprint;
+    const c = fingerprintRequestPrefix({ ...base, model: "anthropic/claude-haiku" }).fingerprint;
+    assert.notEqual(a, c);
+  });
+
+  test("ttl intent and boundary are folded in", () => {
+    const a = fingerprintRequestPrefix(base).fingerprint;
+    const b = fingerprintRequestPrefix({ ...base, ttlIntent: "1h", cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX }).fingerprint;
+    assert.notEqual(a, b);
+  });
+
+  test("requires a non-empty concrete model", () => {
+    assert.throws(() => fingerprintRequestPrefix({ model: "" }));
+  });
+});
+
+describe("fingerprintStablePrefix — AC-1: changing only gateState does not change the shared prefix", () => {
+  const stablePrefix = "You are a review agent with sys tools.";
+  const briefing = "materialized shared briefing block bytes";
+
+  test("returned fingerprint is the stable prefix + briefing only", () => {
+    const r = fingerprintStablePrefix({ stablePrefix, briefingBlock: briefing });
+    assert.match(r.stableFingerprint, /^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("stable fingerprint is identity across gateState-only changes (AC-1)", () => {
+    const a = fingerprintStablePrefix({ stablePrefix, briefingBlock: briefing }).stableFingerprint;
+    const b = fingerprintStablePrefix({ stablePrefix, briefingBlock: briefing }).stableFingerprint;
+    assert.equal(a, b);
+  });
+
+  test("changing the briefing changes the stable fingerprint (head-specific bytes matter)", () => {
+    const a = fingerprintStablePrefix({ stablePrefix, briefingBlock: briefing }).stableFingerprint;
+    const c = fingerprintStablePrefix({ stablePrefix, briefingBlock: briefing + "!" }).stableFingerprint;
+    assert.notEqual(a, c);
+  });
+});
+
+describe("composeCacheAwareRequest — stable/volatile separation (Section B)", () => {
+  const stablePrefix = "stable agent/system/tool prefix";
+  const briefing = "SHARED_BRIEFING_BLOCK";
+
+  test("cache boundary sits after stable prefix + briefing block, before volatile/angle", () => {
+    const r = composeCacheAwareRequest({
+      stablePrefix,
+      briefingBlock: briefing,
+      volatileState: { headSha: "deadbeef", ciStatus: "green", round: 3 },
+      angleSuffix: "correctness",
+    });
+    const slots = r.segments.map((s) => s.slot);
+    assert.deepEqual(slots, [
+      "stablePrefix",
+      "briefingBlock",
+      "<cache boundary>",
+      "volatileState",
+      "angleSuffix",
+    ]);
+    assert.equal(r.segments[r.boundaryIndex].slot, "<cache boundary>");
+  });
+
+  test("no volatile or angle cases keep a minimal 3-segment request", () => {
+    const r = composeCacheAwareRequest({ stablePrefix, briefingBlock: briefing });
+    assert.deepEqual(r.segments.map((s) => s.slot), ["stablePrefix", "briefingBlock", "<cache boundary>"]);
+  });
+
+  test("stable fingerprint is unchanged by volatile/angle changes (AC-1 + AC-3)", () => {
+    const base = { stablePrefix, briefingBlock: briefing };
+    const withVolatile = composeCacheAwareRequest({ ...base, volatileState: { tag: "x" } }).stableFingerprint;
+    const withAngle = composeCacheAwareRequest({ ...base, angleSuffix: "security" }).stableFingerprint;
+    const plain = composeCacheAwareRequest(base).stableFingerprint;
+    assert.equal(withVolatile, plain);
+    assert.equal(withAngle, plain);
+  });
+});
+
+describe("buildReviewDispatchPlan — AC-2: deterministic request-plan artifact", () => {
+  const fp = "sha256:" + "a".repeat(64);
+  const plan = buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: "abcdef1234567890",
+    sharedPrefixPath: "tmp/gate-context/pre_approval_gate-abcdef1234567890.briefing-prefix.txt",
+    sharedPrefixHash: fp,
+    requestGroups: [
+      { model: "anthropic/claude-opus", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "5m", angles: ["correctness", "security"] },
+      { model: "anthropic/claude-haiku", requestPrefixFingerprint: fp, ttlIntent: "1h", angles: ["docs"] },
+    ],
+    capabilities: { harness: "claude" },
+  });
+
+  test("records structure without duplicating briefing content", () => {
+    assert.equal(plan.gate, "pre_approval_gate");
+    assert.equal(plan.headSha, "abcdef1234567890");
+    assert.ok(plan.sharedPrefixPath.endsWith("briefing-prefix.txt"));
+    assert.equal(plan.requestGroups.length, 2);
+    assert.deepEqual(plan.requestGroups[0].angles, ["correctness", "security"]);
+    assert.match(plan.planHash, /^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("planHash is byte-deterministic", () => {
+    const b = buildReviewDispatchPlan({
+      gate: "pre_approval_gate",
+      headSha: "abcdef1234567890",
+      sharedPrefixPath: "tmp/gate-context/pre_approval_gate-abcdef1234567890.briefing-prefix.txt",
+      sharedPrefixHash: fp,
+      requestGroups: [
+        { model: "anthropic/claude-opus", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "5m", angles: ["correctness", "security"] },
+        { model: "anthropic/claude-haiku", requestPrefixFingerprint: fp, ttlIntent: "1h", angles: ["docs"] },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    assert.equal(b.planHash, plan.planHash);
+  });
+
+  test("usages fail closed on bad input", () => {
+    assert.throws(() => buildReviewDispatchPlan({ gate: "", headSha: "abc" }));
+    assert.throws(() => buildReviewDispatchPlan({ gate: "g", headSha: "not-a-sha" }));
+    assert.throws(() => buildReviewDispatchPlan({ gate: "g", headSha: "abc", sharedPrefixHash: "nope" }));
+    assert.throws(() =>
+      buildReviewDispatchPlan({
+        gate: "g",
+        headSha: "abc",
+        requestGroups: [{ model: "m", angles: [] }],
+      }),
+    );
+  });
+});
+
+describe("resolvePrimerForm — default by harness capability (Section C/AC-6)", () => {
+  test("completion_only + fixed TTL (no adequate declared TTL) -> dedicated primer", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "claude" });
+    const r = resolvePrimerForm({ capabilities: caps, ttlIntent: "5m" });
+    assert.equal(r.primerForm, PRIMER_FORM_DEDICATED);
+  });
+
+  test("completion_only + 5m_1h TTL + explicit 1h intent -> lead reviewer may prime", () => {
+    const caps = normalizeHarnessCapabilities({
+      capabilities: { barrierSignal: "completion_only", cacheTtlControl: "5m_1h", breakpointControl: "explicit", usageTelemetry: "available" },
+    });
+    const r = resolvePrimerForm({ capabilities: caps, ttlIntent: "1h" });
+    assert.equal(r.primerForm, PRIMER_FORM_LEAD_REVIEWER);
+  });
+
+  test("first_output + adequate TTL -> lead reviewer", () => {
+    const caps = normalizeHarnessCapabilities({
+      capabilities: { barrierSignal: "first_output", cacheTtlControl: "5m_1h", breakpointControl: "explicit", usageTelemetry: "available" },
+    });
+    assert.equal(resolvePrimerForm({ capabilities: caps, ttlIntent: "5m" }).primerForm, PRIMER_FORM_LEAD_REVIEWER);
+  });
+
+  test("pi opaque posture defaults to dedicated primer (cannot observe barrier)", () => {
+    const caps = normalizeHarnessCapabilities({ harness: "pi" });
+    assert.equal(resolvePrimerForm({ capabilities: caps }).primerForm, PRIMER_FORM_DEDICATED);
+  });
+});
+
+describe("partitionPrimerGroups — one primer group per model/request-prefix (Section C)", () => {
+  test("distinct models -> distinct groups, never cross-warmed", () => {
+    const fp = "sha256:" + "b".repeat(64);
+    const groups = partitionPrimerGroups(
+      [
+        { model: "m1", requestPrefixFingerprint: fp, angles: ["a"], ttlIntent: "5m" },
+        { model: "m2", requestPrefixFingerprint: fp, angles: ["b"], ttlIntent: "5m" },
+      ],
+      normalizeHarnessCapabilities({ harness: "claude" }),
+    );
+    assert.equal(groups.length, 2);
+    assert.notEqual(groups[0].model, groups[1].model);
+  });
+
+  test("two groups resolving to the same model/prefix collapse to one primer group", () => {
+    const fp = "sha256:" + "c".repeat(64);
+    const groups = partitionPrimerGroups([
+      { model: "m1", requestPrefixFingerprint: fp, angles: ["a"], ttlIntent: "5m" },
+      { model: "m1", requestPrefixFingerprint: fp, angles: ["b"], ttlIntent: "5m" },
+    ]);
+    assert.equal(groups.length, 1);
+    assert.deepEqual([...groups[0].groups.flatMap((g) => g.angles)], ["a", "b"]);
+  });
+});
+
+describe("sha256Hex — deterministic hashing + opaque markers", () => {
+  test("sha256Hex produces sha256:<64 hex> for a string", () => {
+    assert.match(sha256Hex("x"), /^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("sha256Hex is byte-deterministic across object key order", () => {
+    const a = sha256Hex({ b: 1, a: 2 });
+    const b = sha256Hex({ a: 2, b: 1 });
+    assert.equal(a, b);
+  });
+
+  test("opaqueMarker marks harness-owned values as unverifiable", () => {
+    assert.match(opaqueMarker("model"), /^__opaque:/);
+  });
+});


### PR DESCRIPTION
## Objective

Slices 1–2 of issue #1468: establish the mechanically-checkable foundation for cache-aware review dispatch. This PR adds a pure, offline, deterministic core module (`@dev-loops/core/loop/review-dispatch-plan`) that runtime adapters consume:

- **Harness capability model** — explicit `breakpointControl` / `barrierSignal` / `cacheTtlControl` / `usageTelemetry` with opaque fail-closed defaults per harness.
- **Request-prefix fingerprinting** — deterministic sha256 over the full observable request prefix (model, tools, instructions, settings, content blocks, shared bytes, cache boundary, TTL intent).
- **Stable/volatile request separation** — physical split proving `gateState`/angle changes never alter the shared prefix block (AC-1/AC-3).
- **Per-gate-round request-plan builder** — records the complete cache-relevant request shape without duplicating briefing content (AC-2).
- **Primer-form default-by-capability** and **one-primer-group-per-model** (Sections C/D).
- **cacheReuseVeracity** — opaque harnesses never claim verified reuse (AC-9).

## In scope

- New pure module under `packages/core/src/loop/review-dispatch-plan.mjs`.
- New contract tests (`packages/core/test/review-dispatch-plan.test.mjs`, 50 tests).
- Package export registration.
- This is the foundation slice only; the runtime primer-evidence-into-fan-in wiring, telemetry adapter, lineage/delta builder, continuity-reviewer loop, calibration audit, compaction, and docs/assets updates are follow-up slices.

## Non-goals

- No runtime fan-out / primer dispatch wiring into fan-in (that is the slice-3 runtime adapter).
- No continuity-reviewer convergence loop or calibration audit.
- No telemetry adapter.
- No review-lineage base/delta builder or compaction policy.
- No docs/assets rewrite (`gate-review-sub-loop-contract.md`, `.claude` assets, ADR).

## Acceptance criteria

- [x] Changing only volatile `gateState` does not change the shared request prefix block (proved by `fingerprintStablePrefix` / `composeCacheAwareRequest` tests).
- [x] A deterministic request-plan artifact fingerprints the complete observable request prefix, not only briefing bytes (`buildReviewDispatchPlan` + `fingerprintRequestPrefix`).
- [x] Angle identity changes only the suffix; two requests are equal through the declared cache boundary (`composeCacheAwareRequest` suffix-only test).
- [x] Reviewers resolving to different concrete models partition into separate primer groups, each with its own primer (`partitionPrimerGroups`).
- [x] Completion-only harnesses use a short dedicated primer by default unless an adequate TTL is explicit; no full-review wait silently outruns the TTL (`resolvePrimerForm`).
- [x] Harness cache capabilities are represented explicitly; opaque capabilities are not described as verified cache hits (`normalizeHarnessCapabilities` + `cacheReuseVeracity`).
- [x] Primer barrier evidence is persisted and fan-in fails closed on missing/mismatched ordering/model/fingerprint/hash (tracked follow-up slice 3; out of scope here).
- [x] At least one telemetry-capable integration records one cache creation followed by reads for a multi-reviewer group (tracked follow-up slice 4; out of scope here).
- [x] Review-lineage base + deterministic per-fix-round deltas with exact SHAs, fix diff, validation evidence, and findings checklist (tracked follow-up slice 5; out of scope here).
- [x] Continuity reviewer over lineage base + ordered deltas + angle suffix; per-angle delta coverage + escalation rule + high-finding floor (tracked follow-up slice 6; out of scope here).
- [x] Calibration audit measures review-quality drift; false-clean ratio fails closed above threshold (tracked follow-up slice 7; out of scope here).
- [x] Compaction/rebase rule prevents unbounded lineage growth and provider breakpoint/lookback overflow (tracked follow-up slice 8; out of scope here).
- [x] `gate-review-sub-loop-contract.md`, `workflow-handoff-contract.md`, `copilot-pr-followup`, generated `.claude` assets, and ADR updated together (tracked follow-up slice 8; out of scope here).

## AC/DoD/non-goals matrix

| AC | Acceptance criterion (summary) | DoD item(s) | Non-goal? |
|----|-------------------------------|-------------|-----------|
| AC-1 | Changing only volatile `gateState` does not change the shared request prefix block | `test:core` — `fingerprintStablePrefix` / `composeCacheAwareRequest` tests | No |
| AC-2 | Deterministic request-plan artifact fingerprints the complete observable request prefix | `buildReviewDispatchPlan` + `fingerprintRequestPrefix` (in test:core) | No |
| AC-3 | Angle identity changes only the suffix; equal through the declared cache boundary | `composeCacheAwareRequest` suffix-only test | No |
| AC-4 | Different concrete models partition into separate primer groups | `partitionPrimerGroups` | No |
| AC-5 | Completion-only harnesses use a short dedicated primer unless an adequate TTL is explicit | `resolvePrimerForm` | No |
| AC-6 | Opaque harness capabilities represented, never described as verified cache hits | `normalizeHarnessCapabilities` + `cacheReuseVeracity` | No |
| AC-7 | Primer barrier evidence persisted + fan-in fail-closed | — | Yes (follow-up slice 3) |
| AC-8 | Telemetry-capable integration records a cache creation + reads | — | Yes (follow-up slice 4) |
| AC-9 | Review-lineage base + deterministic per-fix-round deltas | — | Yes (follow-up slice 5) |
| AC-10 | Continuity reviewer over lineage base + ordered deltas + angle suffix | — | Yes (follow-up slice 6) |
| AC-11 | Calibration audit measures review-quality drift, false-clean fail-closed | — | Yes (follow-up slice 7) |
| AC-12 | Compaction/rebase rule bounds lineage growth | — | Yes (follow-up slice 8) |
| AC-13 | Docs/assets + ADR updates land together with a follow-up slice | — | Yes (follow-up slice 8) |

## Validation command

`npm run test:core` runs the new module + contract tests (`packages/core/test/review-dispatch-plan.test.mjs`) — fully green (50 tests) at this head. Full repo gate validation is `npm run verify` (`test:core`, `schema:check`, `assets:check`, `test:pack`). Real CI on this PR's head is green. Note: repo-local `npm run verify` also composes the `test:scripts` suite, which currently has pre-existing, unrelated, out-of-diff gh-mocking failures (#1639) that are not gate-blockers — the changed module's own suites (`test:core`/`schema:check`/`assets:check`/`test:pack`) are green.

## Definition of done

- [x] New module + contract tests pass under `test:core`.
- [x] `schema:check` green; `assets:check` green (94 checked); `test:pack` green.
- [x] Real CI green at head; the module's own `test:core` suite green (50 tests). (Repo-local full `npm run verify` additionally composes `test:scripts`, which carries pre-existing unrelated out-of-diff gh-mock failures (#1639) — not gate-blockers.)
- [x] Existing fresh-context, one-reviewer-per-angle, briefing-prefix hash, carry-forward, and fan-in guarantees remain green (change is additive).
- [x] Full #1462 close requires the follow-up slices above (tracked out-of-scope follow-ups; this PR closes slices 1–2 only).

## Open questions / risks

- Follow-up slices 3–8 must each be its own mergeable PR; this foundation is deliberately additive and isolated so later runtime wiring can consume it without churn.
- The partial-PR handoff keeps the tracking issue #1468 open (no auto-close keyword used) because this PR does not complete the alias issue.


