### PR TITLE
fix(loop): auto-release runner claims on death + supersede confirmed-dead/stale claims (#1706)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -451,6 +451,8 @@ The pre-merge gate evidence check fails closed on the PR's runner-coordination c
 
 The auto-loop now releases its claim best-effort when a run reaches a terminal stop (clean-converged, blocked, or done — including the stop at the human approval checkpoint), so a merge-authorized re-dispatch normally inherits a cleared claim and proceeds. The release is non-fatal: it never blocks the stop, and it never clears a claim owned by a genuinely active competing run.
 
+Beyond the terminal release, #1706 removes the stall on the path here: `copilot-pr-handoff` acquires ownership with `supersedeStale: true`, so pre-flight handoff takes over a competing claim whose owning run is **confirmed dead** (recorded exit signal) or past the stale-max-age window — proceeding instead of returning a blocking stop against a leaked lock. The headless dev-loop driver also clears every claim its run still owns when the spawned run's process exits (release-on-death). A genuinely live owner still blocks (one-runner-per-PR preserved); only confirmed-dead or stale claims are superseded. The manual takeover below therefore only remains for a pre-#1706 leak or a live-but-unreleasable edge.
+
 If a stale claim still blocks the merge because the completing run could not release (crash, killed process, or a pre-#1109 run), the sanctioned recovery for a lock held by a COMPLETED run is an explicit takeover by the merge run:
 
 ```sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -533,6 +533,18 @@ Integration notes:
 - `copilot-pr-handoff.mjs` uses this surface for async run ownership checks
 - `detect-checkpoint-evidence.mjs` uses strict ownership assertion before async merge-time gate evaluation
 
+Release-on-death & dead-claim supersession (#1706):
+- A run that ends without an explicit `release` still must not leave a leaky lock that blocks the
+  next legitimately-dispatched run. `_pr-runner-coordination.mjs` exposes an exit-signal record
+  (`recordExitSignalForRunner`) plus a process-exit sweep (`releaseRunClaimsOnExit`) that the
+  headless dev-loop driver invokes after its spawned run terminates (completed/killed/timed out/
+  crashed).
+- `ensureAsyncRunnerOwnership(..., { supersedeStale: true })` — used by `copilot-pr-handoff` — takes
+  over a competing claim whose owning run is **confirmed dead** (exit signal recorded) or past the
+  stale-max-age window, so pre-flight handoff proceeds instead of returning a blocking stop against a
+  leaked lock. A genuinely live owner still stands the handoff down (one-runner-per-PR preserved);
+  only confirmed-dead or stale claims are superseded.
+
 ### `scripts/loop/run-watch-cycle.mjs`
 
 Deterministic handoff → watch helper for one Copilot wait-cycle boundary.

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -28,6 +28,7 @@ import {
   buildHeadlessClaudeInvocation,
   DEFAULT_CLAUDE_BIN,
 } from "@dev-loops/core/claude/headless-entry";
+import { releaseRunClaimsOnExit } from "../loop/_pr-runner-coordination.mjs";
 
 function parseCliArgs(argv) {
   const opts = { dryRun: false, claudeBin: DEFAULT_CLAUDE_BIN };
@@ -90,7 +91,7 @@ function parseCliArgs(argv) {
   return opts;
 }
 
-function main(argv) {
+async function main(argv) {
   let opts;
   try {
     opts = parseCliArgs(argv);
@@ -123,7 +124,22 @@ function main(argv) {
     );
     return 127;
   }
+  // #1706: the spawned run's process has now terminated (completed, killed,
+  // timed out, or crashed) — deterministically release every coordination claim
+  // this run still owns so a dead run never leaves a leaky lock. Best-effort
+  // and non-fatal; the driver's exit status is never altered by a failed sweep.
+  if (!opts.dryRun) {
+    try {
+      await releaseRunClaimsOnExit({ runId, root: repoRoot });
+    } catch {
+      // swallow; never let a failed sweep change the driver exit status
+    }
+  }
   return res.status ?? 1;
 }
 
-process.exit(main(process.argv.slice(2)));
+main(process.argv.slice(2)).then((code) => {
+  process.exit(code ?? 1);
+}).catch(() => {
+  process.exit(1);
+});

--- a/scripts/claude/headless-dev-loop.mjs
+++ b/scripts/claude/headless-dev-loop.mjs
@@ -130,9 +130,29 @@ async function main(argv) {
   // and non-fatal; the driver's exit status is never altered by a failed sweep.
   if (!opts.dryRun) {
     try {
-      await releaseRunClaimsOnExit({ runId, root: repoRoot });
-    } catch {
+      const sweep = await releaseRunClaimsOnExit({ runId, root: repoRoot });
+      // #1706/review: surface a failed or partially-failed exit-claim sweep on
+      // stderr so leaked claims stay diagnosable, while keeping the sweep
+      // non-fatal — the driver's exit status is never altered by sweep failure.
+      if (sweep?.status === "scan_failed" || (sweep?.failed?.length ?? 0) > 0) {
+        process.stderr.write(
+          JSON.stringify({
+            ok: false,
+            warning: "exit-claim sweep encountered failures",
+            status: sweep.status,
+            failed: sweep.failed,
+          }) + "\n",
+        );
+      }
+    } catch (error) {
       // swallow; never let a failed sweep change the driver exit status
+      process.stderr.write(
+        JSON.stringify({
+          ok: false,
+          warning: "exit-claim sweep failed",
+          error: error instanceof Error ? error.message : String(error),
+        }) + "\n",
+      );
     }
   }
   return res.status ?? 1;

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -9,6 +9,7 @@ import {
   saveStateFile as saveSharedStateFile,
   withStateFileLock as withSharedStateFileLock,
 } from "./_steering-state-file.mjs";
+import { detectStaleRunner } from "./_stale-runner-detection.mjs";
 export const RUNNER_COORDINATION_SCHEMA_VERSION = 2;
 export const RUNNER_COORDINATION_SUPPORTED_SCHEMA_VERSIONS = Object.freeze([1, 2]);
 export const RUNNER_COORDINATION_HISTORY_LIMIT = 50; // cap audit trail; heartbeats append per-round, keep the most recent 50 events
@@ -680,6 +681,7 @@ export async function ensureAsyncRunnerOwnership({
   cwd = process.cwd(),
   claimIfMissing = true,
   requireExisting = false,
+  supersedeStale = false,
 } = {}) {
   const runId = normalizeRunId(resolveRunId(env));
   if (runId === null) {
@@ -705,6 +707,18 @@ export async function ensureAsyncRunnerOwnership({
     return claimRunnerOwnership({ repo, pr, runId, cwd, mode: "claim" });
   }
   if (asserted.error !== RUNNER_OWNERSHIP_ERROR.OWNERSHIP_MISSING) {
+    // A competing run holds the claim. With supersedeStale (handoff), a
+    // confirmed-dead owner — its run has a recorded exit signal, or its claim
+    // has gone stale past the max-age window — is taken over so the next
+    // legitimately-dispatched run proceeds instead of standing down on a
+    // leaked lock (#1706). A genuinely live owner stays fail-closed: the
+    // one-runner-per-PR invariant for active work is preserved.
+    if (supersedeStale) {
+      const stale = await detectStaleRunner({ repo, pr, cwd });
+      if (!stale.ok && stale.status !== "no_owner_record") {
+        return claimRunnerOwnership({ repo, pr, runId, cwd, mode: "takeover" });
+      }
+    }
     return asserted;
   }
   return claimRunnerOwnership({ repo, pr, runId, cwd, mode: "claim" });
@@ -778,4 +792,83 @@ export async function releaseAsyncRunnerOwnership({
       filePath,
     };
   }
+}
+
+/**
+ * Deterministic release-on-process-exit (#1706): best-effort clear of every
+ * runner-coordination claim owned by a run across all PRs under a coordination
+ * root.
+ *
+ * The headless dev-loop driver owns the spawned run's process boundary — when
+ * the spawned run terminates (completed, killed, timed out, or crashed) this
+ * scans the coordination root and releases each PR claim that THIS run still
+ * owns, so a dead run never leaves a leaky claim that blocks the next
+ * legitimately-dispatched run. Fail-closed competitor semantics are preserved:
+ * only claims owned by {@link runId} are cleared; a genuinely live competing
+ * run's claim is left intact.
+ *
+ * Coordination files live at `.pi/runner-coordination/<owner>/<name>/pr-<n>.json`.
+ * Best-effort/non-fatal by contract (mirrors {@link releaseAsyncRunnerOwnership}):
+ * an unreadable/parsing/lock failure is swallowed and reported, never thrown.
+ */
+export async function releaseRunClaimsOnExit({
+  runId,
+  root = process.cwd(),
+  readDir = fs.promises.readdir,
+  readFile = fs.promises.readFile,
+  releaseFn = releaseRunnerOwnership,
+} = {}) {
+  const normalizedRunId = normalizeRunId(runId);
+  if (normalizedRunId === null) {
+    return { ok: true, status: "skipped_no_async_run_id", released: [], failed: [] };
+  }
+  const coordinationRoot = path.join(root, ".pi", "runner-coordination");
+  let entries;
+  try {
+    entries = await readDir(coordinationRoot, { recursive: true });
+  } catch {
+    return { ok: true, status: "no_coordination_dir", released: [], failed: [], root };
+  }
+  const released = [];
+  const failed = [];
+  const prFiles = (Array.isArray(entries) ? entries : [])
+    .filter((entry) => typeof entry === "string" && /pr-\d+\.json$/.test(path.basename(entry)))
+    .map((entry) => path.join(coordinationRoot, entry));
+  for (const filePath of prFiles) {
+    let raw;
+    try {
+      raw = await readFile(filePath, "utf8");
+    } catch {
+      failed.push({ filePath, prNumber: null, reason: "read_failed" });
+      continue;
+    }
+    let state;
+    try {
+      state = JSON.parse(raw);
+    } catch {
+      failed.push({ filePath, prNumber: null, reason: "parse_failed" });
+      continue;
+    }
+    if (state?.activeRun?.runId !== normalizedRunId) {
+      continue;
+    }
+    const relToRoot = path.relative(root, filePath);
+    const prMatch = path.basename(filePath).match(/^pr-(\d+)\.json$/);
+    const prNumber = prMatch ? Number(prMatch[1]) : null;
+    const parts = relToRoot.split(path.sep);
+    const repo = parts.length >= 4 && parts[0] === ".pi" && parts[1] === "runner-coordination"
+      ? `${parts[2]}/${parts[3]}`
+      : null;
+    if (repo === null || prNumber === null) {
+      failed.push({ filePath, prNumber, reason: "bad_path" });
+      continue;
+    }
+    try {
+      const result = await releaseFn({ repo, pr: prNumber, runId: normalizedRunId, cwd: root, filePath });
+      released.push({ filePath, prNumber, status: result?.status ?? "released" });
+    } catch {
+      failed.push({ filePath, prNumber, reason: "release_failed" });
+    }
+  }
+  return { ok: true, status: "released", released, failed, root };
 }

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -806,7 +806,19 @@ export async function releaseAsyncRunnerOwnership({
  * legitimately-dispatched run. Fail-closed competitor semantics are preserved:
  * only claims owned by {@link runId} are cleared; a genuinely live competing
  * run's claim is left intact.
- *
+ */
+/**
+ * True for the "directory just isn't there" readdir errors that mean a normal
+ * nothing-to-sweep exit (no coordination claims were ever written). Any other
+ * readdir failure is a real scan problem and must not be treated as an absent
+ * coordination dir.
+ */
+function isMissingDirError(error) {
+  const code = error?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+/**
  * Coordination files live at `.pi/runner-coordination/<owner>/<name>/pr-<n>.json`.
  * Best-effort/non-fatal by contract (mirrors {@link releaseAsyncRunnerOwnership}):
  * an unreadable/parsing/lock failure is swallowed and reported, never thrown.
@@ -833,8 +845,24 @@ export async function releaseRunClaimsOnExit({
   let entries;
   try {
     entries = await readDir(coordinationRoot, { recursive: true });
-  } catch {
-    return { ok: true, status: "no_coordination_dir", released: [], failed: [], root };
+  } catch (error) {
+    // #1706/review: a missing coordination root (ENOENT/ENOTDIR) is the normal
+    // nothing-to-sweep case; ANY other readdir failure (permissions, IO,
+    // unsupported options) must not masquerade as that or the sweep looks
+    // successful while doing nothing. Surface it as a distinct scan_failed
+    // status so the caller can log a non-fatal warning. Non-fatal by contract:
+    // never rethrow.
+    if (isMissingDirError(error)) {
+      return { ok: true, status: "no_coordination_dir", released: [], failed: [], root };
+    }
+    return {
+      ok: true,
+      status: "scan_failed",
+      released: [],
+      failed: [],
+      root,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
   const released = [];
   const failed = [];

--- a/scripts/loop/_pr-runner-coordination.mjs
+++ b/scripts/loop/_pr-runner-coordination.mjs
@@ -822,7 +822,14 @@ export async function releaseRunClaimsOnExit({
   if (normalizedRunId === null) {
     return { ok: true, status: "skipped_no_async_run_id", released: [], failed: [] };
   }
-  const coordinationRoot = path.join(root, ".pi", "runner-coordination");
+  // Anchor at the same git-common-dir root the claims are stored under
+  // (#1706): in a linked worktree the coordination dir lives in the MAIN
+  // repo's .pi (git common dir), not under the worktree cwd, so a naive
+  // path.join(root, ".pi", ...) would scan the wrong location and miss the
+  // run's own claims. resolveRepoCoordinationRoot handles the common-dir
+  // anchoring and falls back to the canonicalized cwd for non-git dirs.
+  const repoBase = resolveRepoCoordinationRoot(root);
+  const coordinationRoot = path.join(repoBase, ".pi", "runner-coordination");
   let entries;
   try {
     entries = await readDir(coordinationRoot, { recursive: true });
@@ -852,7 +859,7 @@ export async function releaseRunClaimsOnExit({
     if (state?.activeRun?.runId !== normalizedRunId) {
       continue;
     }
-    const relToRoot = path.relative(root, filePath);
+    const relToRoot = path.relative(repoBase, filePath);
     const prMatch = path.basename(filePath).match(/^pr-(\d+)\.json$/);
     const prNumber = prMatch ? Number(prMatch[1]) : null;
     const parts = relToRoot.split(path.sep);

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -347,6 +347,11 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
     env,
     cwd: resolvedRepoRoot,
     claimIfMissing: true,
+    // #1706: a confirmed-dead or stale competing claim (recorded exit signal or
+    // past the stale-max-age window) is taken over so pre-flight handoff proceeds
+    // instead of returning a blocking stop against a leaked lock. Genuinely live
+    // owners still stand this handoff down (one-runner-per-PR preserved).
+    supersedeStale: true,
   });
   if (!runnerOwnership.ok) {
     return {

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -467,6 +467,8 @@ The pre-merge gate evidence check fails closed on the PR's runner-coordination c
 
 The auto-loop now releases its claim best-effort when a run reaches a terminal stop (clean-converged, blocked, or done — including the stop at the human approval checkpoint), so a merge-authorized re-dispatch normally inherits a cleared claim and proceeds. The release is non-fatal: it never blocks the stop, and it never clears a claim owned by a genuinely active competing run.
 
+Beyond the terminal release, #1706 removes the stall on the path here: `copilot-pr-handoff` acquires ownership with `supersedeStale: true`, so pre-flight handoff takes over a competing claim whose owning run is **confirmed dead** (recorded exit signal) or past the stale-max-age window — proceeding instead of returning a blocking stop against a leaked lock. The headless dev-loop driver also clears every claim its run still owns when the spawned run's process exits (release-on-death). A genuinely live owner still blocks (one-runner-per-PR preserved); only confirmed-dead or stale claims are superseded. The manual takeover below therefore only remains for a pre-#1706 leak or a live-but-unreleasable edge.
+
 If a stale claim still blocks the merge because the completing run could not release (crash, killed process, or a pre-#1109 run), the sanctioned recovery for a lock held by a COMPLETED run is an explicit takeover by the merge run:
 
 ```sh

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -10,7 +10,7 @@ import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper,
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 import { parseHandoffCliArgs, runHandoff } from "../../scripts/loop/copilot-pr-handoff.mjs";
 import { STATE } from "../../packages/core/src/loop/copilot-loop-state.mjs";
-import { claimRunnerOwnership, loadRunnerCoordinationState } from "../../scripts/loop/_pr-runner-coordination.mjs";
+import { claimRunnerOwnership, loadRunnerCoordinationState, recordExitSignalForRunner } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY } from "../../packages/core/src/loop/timeout-policy.mjs";
 
 const scriptPath = path.resolve("scripts/loop/copilot-pr-handoff.mjs");
@@ -2023,6 +2023,53 @@ test("copilot-pr-handoff stops cleanly when another run already owns the PR", as
     assert.equal(output.runnerOwnership.ok, false);
     assert.equal(output.runnerOwnership.error, "ownership_lost");
     assert.equal(output.runnerOwnership.activeRun.runId, "run-active");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1706 AC-2/AC-1: a run that dies WITHOUT releasing (exit signal recorded) is
+// treated as immediately stale — pre-flight handoff takes its claim over and
+// proceeds instead of returning the blocking stop.
+test("copilot-pr-handoff supersedes a confirmed-dead run's claim and proceeds instead of stop (#1706)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-supersede-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-dead", cwd: tempDir, now: new Date().toISOString() });
+    // run-dead dies without releasing — record its exit signal (confirmed death)
+    const sig = await recordExitSignalForRunner({ repo: "owner/repo", pr: 17, runId: "run-dead", reason: "crashed", cwd: tempDir });
+    assert.equal(sig.ok, true);
+
+    const BOT_COMMENT = JSON.stringify({
+      id: 199,
+      body: "Gate review: draft_gate verdict=clean",
+      user: { login: "copilot-pull-request-reviewer[bot]", type: "Bot" },
+      created_at: "2026-06-07T09:00:00Z",
+    });
+
+    const { env } = await writeGhStubHelper(tempDir, [
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo"], stdout: OPEN_PR + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+      { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+      { assertArgs: ["api", "repos/owner/repo/issues/17/comments", "--paginate", "--jq", ".[]"], stdout: BOT_COMMENT + "\n" },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], {
+      cwd: tempDir,
+      env: { ...env, DEVLOOPS_RUN_ID: "run-new" },
+    });
+
+    assert.equal(result.code, 0);
+    const output = JSON.parse(result.stdout);
+    // The dead-run claim was taken over — no blocking stop.
+    assert.equal(output.runnerOwnership.ok, true);
+    assert.equal(output.runnerOwnership.status, "taken_over");
+    assert.equal(output.runnerOwnership.activeRun.runId, "run-new");
+    assert.notEqual(output.state, "blocked_needs_user_decision");
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(loaded.state.activeRun.runId, "run-new");
+    assert.equal(loaded.state.previousRun.runId, "run-dead");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -553,6 +553,77 @@ test("releaseRunClaimsOnExit no-ops when no run id is present", async () => {
   }
 });
 
+// #1706: the release-on-death sweep must anchor at the git-common-dir root
+// (resolveRepoCoordinationRoot) the claims are actually stored under, NOT a
+// naive path.join(root, ".pi", ...). In a linked worktree the run's claims
+// live in the MAIN repo's .pi (common dir), so a worktree-cwd sweep that scans
+// the worktree's own .pi would miss them and leak the lock.
+test("releaseRunClaimsOnExit anchors at the git-common-dir root (linked worktree)", async () => {
+  const { repoRoot, wtPath } = await makeRepoWithWorktree();
+
+  try {
+    // Claim under the WORKTREE cwd — claims are stored at the common-dir root.
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 31, runId: "run-wt", cwd: wtPath });
+    const claimPath = defaultRunnerCoordinationFilePathForTarget(
+      { repo: "owner/repo", pr: 31 },
+      wtPath,
+    );
+    assert.ok(
+      claimPath.startsWith(path.join(realpathSync(repoRoot), ".pi")),
+      "claim must live under the main repo's .pi (git-common-dir anchored), not the worktree's",
+    );
+
+    const result = await releaseRunClaimsOnExit({ runId: "run-wt", root: wtPath });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "released");
+    assert.equal(result.released.length, 1);
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 31, cwd: wtPath });
+    assert.equal(loaded.state.activeRun, null);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(wtPath, { recursive: true, force: true });
+  }
+});
+
+test("releaseRunClaimsOnExit reports no_coordination_dir when the root is absent", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-missing-"));
+  try {
+    const result = await releaseRunClaimsOnExit({ runId: "run-x", root: tempDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "no_coordination_dir");
+    assert.deepEqual(result.released, []);
+    assert.deepEqual(result.failed, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("releaseRunClaimsOnExit records parse_failed on a corrupt claim file and continues", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-corrupt-"));
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 41, runId: "run-a", cwd: tempDir });
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 42, runId: "run-a", cwd: tempDir });
+    // Corrupt one of the two claim files.
+    const corruptPath = defaultRunnerCoordinationFilePathForTarget(
+      { repo: "owner/repo", pr: 42 },
+      tempDir,
+    );
+    await writeFile(corruptPath, "{ not-json", "utf8");
+
+    const result = await releaseRunClaimsOnExit({ runId: "run-a", root: tempDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "released");
+    // The healthy claim is released; the corrupt one is recorded as parse_failed,
+    // never thrown, and the sweep keeps going.
+    assert.equal(result.released.length, 1);
+    assert.equal(result.failed.length, 1);
+    assert.equal(result.failed[0].reason, "parse_failed");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // End-to-end CLI proof of the shared --jq/--silent output helper (issue #981).
 // `status` needs no run-id and no gh, so it is a clean read-script vehicle.
 const cliScript = path.resolve("scripts/loop/pr-runner-coordination.mjs");

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -599,6 +599,46 @@ test("releaseRunClaimsOnExit reports no_coordination_dir when the root is absent
   }
 });
 
+test("releaseRunClaimsOnExit treats a missing-dir (ENOENT) readdir error as no_coordination_dir", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-enoent-"));
+  const missingDirError = Object.assign(new Error("missing"), { code: "ENOENT" });
+  try {
+    const result = await releaseRunClaimsOnExit({
+      runId: "run-x",
+      root: tempDir,
+      readDir: async () => { throw missingDirError; },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "no_coordination_dir");
+    assert.equal(result.error, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("releaseRunClaimsOnExit does not mask a non-ENOENT readdir failure as no_coordination_dir", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-scanfail-"));
+  const permissionError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+  try {
+    const result = await releaseRunClaimsOnExit({
+      runId: "run-x",
+      root: tempDir,
+      readDir: async () => { throw permissionError; },
+    });
+    // Non-fatal by contract (ok stays true, nothing thrown) but the failure is
+    // surfaced via a distinct scan_failed status + message, not a clean-looking
+    // no_coordination_dir that would make the sweep appear successful while
+    // doing nothing.
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "scan_failed");
+    assert.match(result.error, /EACCES/);
+    assert.deepEqual(result.released, []);
+    assert.deepEqual(result.failed, []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("releaseRunClaimsOnExit records parse_failed on a corrupt claim file and continues", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-corrupt-"));
   try {

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -13,7 +13,9 @@ import {
   defaultRunnerCoordinationFilePathForTarget,
   ensureAsyncRunnerOwnership,
   loadRunnerCoordinationState,
+  recordExitSignalForRunner,
   releaseAsyncRunnerOwnership,
+  releaseRunClaimsOnExit,
   releaseRunnerOwnership,
   RUNNER_COORDINATION_HISTORY_LIMIT,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
@@ -393,6 +395,159 @@ test("ensureAsyncRunnerOwnership auto-claims after release when no active owner 
     });
     assert.equal(strict.ok, false);
     assert.equal(strict.error, "ownership_missing");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1706: a run that dies without releasing (exit signal recorded) is treated as
+// confirmed-dead immediately; ensureAsyncRunnerOwnership with supersedeStale
+// takes the claim over so the next legitimately-dispatched run proceeds.
+test("ensureAsyncRunnerOwnership supersedes a dead run's claim when supersedeStale (exit signal)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-dead", cwd: tempDir });
+    // run-dead dies without releasing — record its exit signal (confirmed death)
+    const sig = await recordExitSignalForRunner({ repo: "owner/repo", pr: 17, runId: "run-dead", reason: "crashed", cwd: tempDir });
+    assert.equal(sig.ok, true);
+    assert.equal(sig.status, "exit_signal_recorded");
+
+    // live (default) supersedeStale=false → fail closed against the dead claim
+    const strict = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      env: { DEVLOOPS_RUN_ID: "run-next" },
+      claimIfMissing: true,
+    });
+    assert.equal(strict.ok, false);
+    assert.equal(strict.error, "ownership_lost");
+
+    // supersedeStale=true → the confirmed-dead claim is taken over
+    const superseded = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 17,
+      cwd: tempDir,
+      env: { DEVLOOPS_RUN_ID: "run-next" },
+      claimIfMissing: true,
+      supersedeStale: true,
+    });
+    assert.equal(superseded.ok, true);
+    assert.equal(superseded.status, "taken_over");
+    assert.equal(superseded.activeRun.runId, "run-next");
+
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(loaded.state.activeRun.runId, "run-next");
+    assert.equal(loaded.state.previousRun.runId, "run-dead");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1706: a run whose claim has gone stale (no heartbeat past the max-age window)
+// is treated as dead; supersedeStale takes it over.
+test("ensureAsyncRunnerOwnership supersedes a stale claim when supersedeStale (staleness exceeded)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+  const prevMaxAge = process.env.DEVLOOPS_STALE_RUNNER_MAX_AGE_MS;
+  process.env.DEVLOOPS_STALE_RUNNER_MAX_AGE_MS = "60000"; // 1 minute
+
+  try {
+    await claimRunnerOwnership({
+      repo: "owner/repo",
+      pr: 21,
+      runId: "run-stale",
+      cwd: tempDir,
+      now: new Date(Date.now() - 1000 * 60 * 10).toISOString(), // claimed 10 min ago
+    });
+
+    const superseded = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 21,
+      cwd: tempDir,
+      env: { DEVLOOPS_RUN_ID: "run-fresh" },
+      claimIfMissing: true,
+      supersedeStale: true,
+    });
+    assert.equal(superseded.ok, true);
+    assert.equal(superseded.status, "taken_over");
+    assert.equal(superseded.activeRun.runId, "run-fresh");
+  } finally {
+    if (prevMaxAge === undefined) {
+      delete process.env.DEVLOOPS_STALE_RUNNER_MAX_AGE_MS;
+    } else {
+      process.env.DEVLOOPS_STALE_RUNNER_MAX_AGE_MS = prevMaxAge;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1706 AC-3: supersedeStale must NOT supersede a genuinely live owner (no exit
+// signal, fresh claim) — one-runner-per-PR preserved for active work.
+test("ensureAsyncRunnerOwnership keeps a live owner (stand down) even with supersedeStale", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 23, runId: "run-live", cwd: tempDir, now: new Date().toISOString() });
+
+    const result = await ensureAsyncRunnerOwnership({
+      repo: "owner/repo",
+      pr: 23,
+      cwd: tempDir,
+      env: { DEVLOOPS_RUN_ID: "run-wannabe" },
+      claimIfMissing: true,
+      supersedeStale: true,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "ownership_lost");
+    assert.equal(result.activeRun.runId, "run-live");
+
+    // Live owner's claim is untouched.
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 23, cwd: tempDir });
+    assert.equal(loaded.state.activeRun.runId, "run-live");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// #1706 AC-1: the release-on-process-exit sweep clears every claim owned by a
+// run (completed/killed/timed out/crashed) so no leaky lock blocks the next run.
+test("releaseRunClaimsOnExit clears all claims owned by a run on process exit", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-exit", cwd: tempDir });
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 18, runId: "run-exit", cwd: tempDir });
+    // A competing live run's claim must remain untouched.
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 19, runId: "run-other", cwd: tempDir });
+
+    const result = await releaseRunClaimsOnExit({ runId: "run-exit", root: tempDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "released");
+    assert.equal(result.released.length, 2);
+
+    const pr17 = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    const pr18 = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 18, cwd: tempDir });
+    const pr19 = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 19, cwd: tempDir });
+    assert.equal(pr17.state.activeRun, null);
+    assert.equal(pr18.state.activeRun, null);
+    // Competing live run untouched.
+    assert.equal(pr19.state.activeRun.runId, "run-other");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("releaseRunClaimsOnExit no-ops when no run id is present", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-"));
+
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 17, runId: "run-x", cwd: tempDir });
+    const result = await releaseRunClaimsOnExit({ runId: "", root: tempDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "skipped_no_async_run_id");
+    const loaded = await loadRunnerCoordinationState({ repo: "owner/repo", pr: 17, cwd: tempDir });
+    assert.equal(loaded.state.activeRun.runId, "run-x");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/pr-runner-coordination.test.mjs
+++ b/test/loop/pr-runner-coordination.test.mjs
@@ -624,6 +624,44 @@ test("releaseRunClaimsOnExit records parse_failed on a corrupt claim file and co
   }
 });
 
+test("releaseRunClaimsOnExit records release_failed when the release fn throws and continues", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-releasefail-"));
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 51, runId: "run-x", cwd: tempDir });
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 52, runId: "run-x", cwd: tempDir });
+    const throwingReleaseFn = async () => {
+      throw new Error("release boom");
+    };
+    const result = await releaseRunClaimsOnExit({ runId: "run-x", root: tempDir, releaseFn: throwingReleaseFn });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "released");
+    assert.equal(result.released.length, 0);
+    assert.equal(result.failed.length, 2);
+    assert.ok(result.failed.every((f) => f.reason === "release_failed"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("releaseRunClaimsOnExit records read_failed when a claim file is unreadable and continues", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-runner-coordination-readfail-"));
+  try {
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 61, runId: "run-x", cwd: tempDir });
+    await claimRunnerOwnership({ repo: "owner/repo", pr: 62, runId: "run-x", cwd: tempDir });
+    const throwingReadFile = async () => {
+      throw new Error("read boom");
+    };
+    const result = await releaseRunClaimsOnExit({ runId: "run-x", root: tempDir, readFile: throwingReadFile });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, "released");
+    assert.equal(result.released.length, 0);
+    assert.equal(result.failed.length, 2);
+    assert.ok(result.failed.every((f) => f.reason === "read_failed"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 // End-to-end CLI proof of the shared --jq/--silent output helper (issue #981).
 // `status` needs no run-id and no gh, so it is a clean read-script vehicle.
 const cliScript = path.resolve("scripts/loop/pr-runner-coordination.mjs");


### PR DESCRIPTION
## Summary

Fixes the recurring zombie-lock stall where a `dev-loop` subagent reports outage/failure but keeps heartbeating and then dies without releasing its `pr-runner-coordination` claim — so the next dispatch stands down (one-runner-per-PR) and the PR stalls ~30–45 min/cycle behind a leaked lock.

This change makes a dead run's claim **auto-release or auto-supersede**, and makes pre-flight handoff **fail toward the next runner** instead of toward a stall.

Closes #1706

## Acceptance criteria matrix

| # | Acceptance criterion | Implemented | Evidence |
|---|----------------------|-------------|----------|
| AC-1 | Run completes/kills/timeouts deterministically releases (or marks expired) its claim at exit; next dispatch claims cleanly without a manual `release` | ✅ | `releaseRunClaimsOnExit` (process-exit sweep) + headless driver invokes it after the spawned run terminates; terminal handoff already releases. |
| AC-2 | Confirmed-dead run's claim treated stale immediately; `loop handoff` does not return a blocking `stop` against it and takes it over | ✅ | `ensureAsyncRunnerOwnership(..., { supersedeStale: true })` in `copilot-pr-handoff` takes over exit-signal/stale claims. |
| AC-3 | Stand-down on live owner preserved (no two-writer hazard); only confirmed-dead/stale superseded | ✅ | Live (non-stale, no exit-signal) owner still fails closed; regression test asserts claim untouched. |
| AC-4 | Regression test: run dies without explicit release → next supersedes; live run → next stands down | ✅ | `test/loop/pr-runner-coordination.test.mjs` + `test/loop/copilot-pr-handoff.test.mjs`. |
| AC-5 | Coordination/handoff docs + copilot-pr-followup skill updated | ✅ | `scripts/README.md`, `skills/copilot-pr-followup/SKILL.md`. |

## Definition of done

- [x] All ACs covered by executable tests (gh-mocked where applicable).
- [x] `npm run verify` green aside from pre-existing environmental gh-mock failures at base (identical base↔branch).
- [ ] Real multi-phase PR drive no longer stalls behind a leaked stale claim (observed impact; ongoing runtime check).

## Non-goals

- Not changing the one-runner-per-PR invariant for genuinely active runs (two writers remain forbidden for live work).
- Not removing the per-run budget; this is lock hygiene, not budget size.
- The per-run budget ceiling for gate-heavy PRs is a separate config/budget lever (operator note), out of scope here.

## Implementation

- `scripts/loop/_pr-runner-coordination.mjs`
  - `ensureAsyncRunnerOwnership` gains `supersedeStale`: on a competing claim, runs `detectStaleRunner`; if the owner is confirmed dead (exit signal) or past the stale-max-age window, performs a `takeover` instead of failing closed.
  - `releaseRunClaimsOnExit`: best-effort, fail-closed-to-competitor sweep that clears every coordination claim owned by a run across the coordination root.
- `scripts/loop/copilot-pr-handoff.mjs`: acquires ownership with `supersedeStale: true`.
- `scripts/claude/headless-dev-loop.mjs`: invokes the release-on-exit sweep after the spawned run's process terminates (completed/killed/timed out/crashed); non-fatal, never alters the driver exit status.

## Validation

- `npm run test:loop` / `test:github`: no new failures vs base (failure sets identical; all pre-existing gh-mock failures excluded). Added 13 passing tests.
- `npm run assets:check` — passed (94).
- `npm run schema:check` — passed.
- `npm run test:docs` — link + rule-ownership + decision-record validation passed.
- `npm run test:workflows` — passed.
- `npm run test:extension` — passed (123).
- `npm run test:pack` — passed (1).
- `npm run test:core` — 1 pre-existing failure (identical at base, `resolveRunId trims...`).
- `npm run test:dev-loop` — passed (35).

Pre-existing environmental failures at base (excluded per spec): `test/loop/*` 36 failing, `test/github/*` 12 failing, `test/core` 1 failing — all byte-identical between base and this branch.

