### PR TITLE
test: strip ambient run-id markers from local verify test envs (#1639)

### DIFF
--- a/packages/core/test/run-context.test.mjs
+++ b/packages/core/test/run-context.test.mjs
@@ -59,7 +59,13 @@ test("resolveRunId trims and treats blank/absent as null", () => {
   assert.equal(resolveRunId({ DEVLOOPS_RUN_ID: "  spaced  " }), "spaced");
   assert.equal(resolveRunId({ DEVLOOPS_RUN_ID: "   " }), null);
   assert.equal(resolveRunId({}), null);
-  assert.equal(resolveRunId(undefined), null);
+  // The undefined default resolves from process.env. In CI no run-id marker is
+  // present, but under a Pi async-subagent session the runtime injects its
+  // run-id alias into process.env, so strip every ambient marker to keep this
+  // assertion environment-independent (mirrors the CI guarantee).
+  const ambientClean = { ...process.env };
+  for (const marker of RUN_ID_MARKERS) delete ambientClean[marker];
+  assert.equal(resolveRunId(ambientClean), null);
 });
 
 test("mintRunId returns a neutral, unique id", () => {

--- a/packages/core/test/run-context.test.mjs
+++ b/packages/core/test/run-context.test.mjs
@@ -59,10 +59,11 @@ test("resolveRunId trims and treats blank/absent as null", () => {
   assert.equal(resolveRunId({ DEVLOOPS_RUN_ID: "  spaced  " }), "spaced");
   assert.equal(resolveRunId({ DEVLOOPS_RUN_ID: "   " }), null);
   assert.equal(resolveRunId({}), null);
-  // The undefined default resolves from process.env. In CI no run-id marker is
-  // present, but under a Pi async-subagent session the runtime injects its
-  // run-id alias into process.env, so strip every ambient marker to keep this
-  // assertion environment-independent (mirrors the CI guarantee).
+  // We deliberately do NOT call resolveRunId() with no argument here: the
+  // default resolves from process.env, which carries the Pi-runtime-injected
+  // run-id alias under an async-subagent session (and no marker in CI). Pass an
+  // explicitly marker-stripped env so this assertion is environment-independent
+  // (mirrors the CI guarantee).
   const ambientClean = { ...process.env };
   for (const marker of RUN_ID_MARKERS) delete ambientClean[marker];
   assert.equal(resolveRunId(ambientClean), null);

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -24,7 +24,15 @@ import { RUN_ID_MARKERS } from "@dev-loops/core/loop/run-context";
 export function runIdFreeEnv(overrides = {}) {
   const base = { ...process.env };
   for (const marker of RUN_ID_MARKERS) delete base[marker];
-  return { ...base, ...overrides };
+  const env = { ...base, ...overrides };
+  // The adapter boundary owns the marker literals; overrides may also unset a
+  // key by passing `undefined` (matching resolverTestEnv's established
+  // behavior). Drop undefined values so the env never carries a non-string
+  // entry that child_process.spawn would reject.
+  for (const key of Object.keys(env)) {
+    if (env[key] === undefined) delete env[key];
+  }
+  return env;
 }
 
 // In-process replacement for the PATH-installed gh stub (buildGhStubScript /

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -1,6 +1,31 @@
 import { spawn } from "node:child_process";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { RUN_ID_MARKERS } from "@dev-loops/core/loop/run-context";
+
+// Build a test env that strips the ambient async run-id markers from process.env.
+//
+// The dev-loop async path resolves an active run id from RUN_ID_MARKERS
+// (DEVLOOPS_RUN_ID, then the Pi-runtime-injected alias) in precedence order (see
+// packages/core/src/loop/run-context.mjs). Under a Pi async-subagent session the
+// runtime injects its run-id alias into the child env, so a test env built via
+// `{ ...process.env, DEVLOOPS_RUN_ID: "" }` still resolves the Pi marker and the
+// suite behaves as if in a production async context — green in CI (no Pi marker),
+// failing in a local worktree under Pi. Route gh/run-id test env construction
+// through this helper so all ambient run-id markers (any DEVLOOPS marker and the
+// Pi-injected alias) are stripped, then apply explicit overrides on top. CI is
+// unaffected because it carries neither marker; overriding suites that intend an
+// active run id pass `DEVLOOPS_RUN_ID` explicitly in overrides and it wins. Marker
+// names come from the shared RUN_ID_MARKERS contract (the adapter boundary owns the
+// Pi marker literal), keeping this helper harness-agnostic.
+//
+// @param {Record<string, string|undefined>} [overrides]
+// @returns {Record<string, string|undefined>}
+export function runIdFreeEnv(overrides = {}) {
+  const base = { ...process.env };
+  for (const marker of RUN_ID_MARKERS) delete base[marker];
+  return { ...base, ...overrides };
+}
 
 // In-process replacement for the PATH-installed gh stub (buildGhStubScript /
 // writeGhStub). Returns `{ runChild, calls }` where `runChild(command, args, env,
@@ -291,7 +316,7 @@ export async function writeGhStub(tempDir, entries = [], {
   await chmod(ghPath, 0o755);
 
   const env = {
-    ...process.env,
+    ...runIdFreeEnv(),
     PATH: [tempDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter),
     GH_SEQUENCE_PATH: sequencePath,
     GH_STUB_MODE: matchMode,

--- a/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
+++ b/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
@@ -128,3 +128,20 @@ test("#1585: an unreadable thread-fetch state (-1) folds draftGateSatisfied to f
   assert.equal(parsed.preMergeGateCheck.ok, false);
   assert.match(parsed.preMergeGateCheck.failures.join("; "), /could not fetch review thread state/i);
 });
+
+test("runIdFreeEnv strips ambient markers, drops undefined overrides, and lets explicit overrides win", () => {
+  const prevDev = process.env.DEVLOOPS_RUN_ID;
+  const prevPi = process.env.PI_SUBAGENT_RUN_ID;
+  try {
+    process.env.DEVLOOPS_RUN_ID = "ambient-dev";
+    process.env.PI_SUBAGENT_RUN_ID = "ambient-pi";
+    const forced = runIdFreeEnv({ EXPLICIT: "kept", UNSET: undefined });
+    assert.equal(forced.DEVLOOPS_RUN_ID, undefined, "ambient DEVLOOPS_RUN_ID must be stripped");
+    assert.equal(forced.PI_SUBAGENT_RUN_ID, undefined, "ambient PI_SUBAGENT_RUN_ID must be stripped");
+    assert.equal(forced.EXPLICIT, "kept");
+    assert.ok(!Object.prototype.hasOwnProperty.call(forced, "UNSET"), "undefined overrides must be removed, not kept as undefined (child_process.spawn rejects non-string env values)");
+  } finally {
+    if (prevDev === undefined) delete process.env.DEVLOOPS_RUN_ID; else process.env.DEVLOOPS_RUN_ID = prevDev;
+    if (prevPi === undefined) delete process.env.PI_SUBAGENT_RUN_ID; else process.env.PI_SUBAGENT_RUN_ID = prevPi;
+  }
+});

--- a/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
+++ b/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
@@ -3,13 +3,13 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { buildFindingMarker } from "../../scripts/github/_gate-finding-surface.mjs";
 
 const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
   ...options,
-  env: { ...process.env, ...(options.env ?? {}), DEVLOOPS_RUN_ID: "" },
+  env: runIdFreeEnv({ ...(options.env ?? {}), DEVLOOPS_RUN_ID: "" }),
 });
 
 function cleanGateBody(gate, headSha) {

--- a/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
+++ b/test/github/detect-checkpoint-evidence-gate-threads.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { buildFindingMarker } from "../../scripts/github/_gate-finding-surface.mjs";
+import { RUN_ID_MARKERS } from "@dev-loops/core/loop/run-context";
 
 const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
@@ -130,18 +131,25 @@ test("#1585: an unreadable thread-fetch state (-1) folds draftGateSatisfied to f
 });
 
 test("runIdFreeEnv strips ambient markers, drops undefined overrides, and lets explicit overrides win", () => {
-  const prevDev = process.env.DEVLOOPS_RUN_ID;
-  const prevPi = process.env.PI_SUBAGENT_RUN_ID;
+  // Drive the markers from the shared RUN_ID_MARKERS adapter contract rather than
+  // any harness-runtime literal, so this test stays harness-agnostic (the
+  // harness-runtime var name is owned by the adapter boundary, not test code).
+  const prev = new Map();
   try {
-    process.env.DEVLOOPS_RUN_ID = "ambient-dev";
-    process.env.PI_SUBAGENT_RUN_ID = "ambient-pi";
+    for (const marker of RUN_ID_MARKERS) {
+      prev.set(marker, process.env[marker]);
+      process.env[marker] = "ambient-" + marker;
+    }
     const forced = runIdFreeEnv({ EXPLICIT: "kept", UNSET: undefined });
-    assert.equal(forced.DEVLOOPS_RUN_ID, undefined, "ambient DEVLOOPS_RUN_ID must be stripped");
-    assert.equal(forced.PI_SUBAGENT_RUN_ID, undefined, "ambient PI_SUBAGENT_RUN_ID must be stripped");
+    for (const marker of RUN_ID_MARKERS) {
+      assert.equal(forced[marker], undefined, `${marker} must be stripped from the built env`);
+    }
     assert.equal(forced.EXPLICIT, "kept");
     assert.ok(!Object.prototype.hasOwnProperty.call(forced, "UNSET"), "undefined overrides must be removed, not kept as undefined (child_process.spawn rejects non-string env values)");
   } finally {
-    if (prevDev === undefined) delete process.env.DEVLOOPS_RUN_ID; else process.env.DEVLOOPS_RUN_ID = prevDev;
-    if (prevPi === undefined) delete process.env.PI_SUBAGENT_RUN_ID; else process.env.PI_SUBAGENT_RUN_ID = prevPi;
+    for (const [key, value] of prev) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 });

--- a/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
+++ b/test/github/detect-checkpoint-evidence-stale-runner.test.mjs
@@ -8,17 +8,16 @@ import {
   claimRunnerOwnership,
   recordExitSignalForRunner,
 } from "../../scripts/loop/_pr-runner-coordination.mjs";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs");
 
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
   ...options,
-  env: {
-    ...process.env,
+  env: runIdFreeEnv({
     ...(options.env ?? {}),
     DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-  },
+  }),
 });
 
 async function writeGhStub(tempDir) {

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -23,7 +23,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
+import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseGateReviewCommentMarkerBody,
@@ -49,11 +49,10 @@ const scriptPath = path.resolve("scripts/github/detect-checkpoint-evidence.mjs")
 
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
   ...options,
-  env: {
-    ...process.env,
+  env: runIdFreeEnv({
     ...(options.env ?? {}),
     DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-  },
+  }),
 });
 
 async function writeGhStub(tempDir, entries) {

--- a/test/github/reconcile-draft-gate.test.mjs
+++ b/test/github/reconcile-draft-gate.test.mjs
@@ -22,7 +22,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import test from "node:test";
-import { DEFAULT_TEST_PR_BODY, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
+import { DEFAULT_TEST_PR_BODY, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   parseReconcileDraftGateCliArgs,
@@ -32,11 +32,10 @@ const scriptPath = path.resolve("scripts/github/reconcile-draft-gate.mjs");
 
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, {
   ...options,
-  env: {
-    ...process.env,
+  env: runIdFreeEnv({
     ...(options.env ?? {}),
     DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-  },
+  }),
 });
 
 async function writeGhStub(tempDir, entries) {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test, { after, before } from "node:test";
-import { DEFAULT_TEST_PR_BODY, makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
+import { DEFAULT_TEST_PR_BODY, makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
   buildCoordinationEvaluatorInput,
@@ -106,11 +106,10 @@ const runNode = async (args = [], options = {}) => {
     return runNodeHelper(scriptPath, augmented, {
       ...options,
       cwd: options.cwd ?? fanoutDisabledRepoRoot,
-      env: {
-        ...process.env,
+      env: runIdFreeEnv({
         ...(options.env ?? {}),
         DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-      },
+      }),
     });
   }
   const { runChild, calls } = makeGhMock(entries, { repeatLastOnOverflow: true });
@@ -123,7 +122,7 @@ const runNode = async (args = [], options = {}) => {
   } catch (error) {
     return { code: 1, stdout: "", stderr: `${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`, ghCallCount };
   }
-  const env = { ...process.env, ...options.env, DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "" };
+  const env = runIdFreeEnv({ ...options.env, DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "" });
   delete env[GH_MOCK_ENTRIES];
   // Mirror the subprocess cwd: tests that stage a per-test .devloops pass
   // { cwd: tempDir }, so config (gate angle contract, rejectForeignAngles) must
@@ -447,7 +446,7 @@ test("upsertCheckpointVerdict ignores force/forceReason in programmatic API", as
       nextAction: "next",
       force: true,
       forceReason: "test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
     assert.equal(result.ok, true);
     assert.equal(result.action, "created");
     // force metadata no longer included
@@ -1043,7 +1042,7 @@ test("upsert-checkpoint-verdict blockquotes an injected 'Next action:'/'Executio
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
 
     assert.equal(result.ok, true);
     assert.equal(result.action, "created");
@@ -1536,7 +1535,7 @@ test("upsert-checkpoint-verdict renders an idempotent body: the same inputs re-p
         stdout: '{"id":103,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-103"}\n',
       },
     ], { repeatLastOnOverflow: true });
-    const created = await upsertCheckpointVerdict(inputs, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild: runChild1, repoRoot: fanoutDisabledRepoRoot });
+    const created = await upsertCheckpointVerdict(inputs, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild: runChild1, repoRoot: fanoutDisabledRepoRoot });
     assert.equal(created.action, "created");
 
     const postCall = calls1.find((c) => c.args.includes("repos/owner/repo/pulls/17/reviews"));
@@ -1560,7 +1559,7 @@ test("upsert-checkpoint-verdict renders an idempotent body: the same inputs re-p
         issueComments: [{ id: 103, body: postedBody, html_url: "https://github.com/owner/repo/pull/17#issuecomment-103", updated_at: "2026-08-03T00:00:00Z" }],
       }),
     ], { repeatLastOnOverflow: true });
-    const second = await upsertCheckpointVerdict(inputs, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild: runChild2, repoRoot: fanoutDisabledRepoRoot });
+    const second = await upsertCheckpointVerdict(inputs, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild: runChild2, repoRoot: fanoutDisabledRepoRoot });
     assert.equal(second.action, "noop");
     assert.equal(second.commentId, 103);
     // Same-head noop means no create/update comment call fires.
@@ -4663,7 +4662,7 @@ test("upsert-checkpoint-verdict posts a withheld fanout_fanin verdict whose --fi
       findingsLedger: ledgerPath,
       nextAction: "fix then re-gate",
       executionMode: "fanout_fanin",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
     assert.equal(result.action, "created");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
@@ -5434,7 +5433,7 @@ test("upsert-checkpoint-verdict CLI fails closed for inline mode without --inlin
     "--findings-summary", "no issues found", "--next-action", "mark ready for review",
   ];
   const result = await runNodeHelper(scriptPath, args, {
-    env: { ...process.env, DEVLOOPS_RUN_ID: "" },
+    env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }),
   });
   assert.equal(result.code, 1);
   const payload = JSON.parse(result.stderr);
@@ -5545,7 +5544,7 @@ test("upsert-checkpoint-verdict --findings-ledger posts ONE review: inline locat
       findingsLedger: ledgerPath,
       nextAction: "stay draft and fix",
       executionMode: "fanout_fanin",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
 
     assert.equal(result.action, "created");
     assert.equal(result.surface, "review");
@@ -5617,7 +5616,7 @@ test("upsert-checkpoint-verdict --findings-ledger suppresses a finding an OWN-au
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
 
     assert.equal(result.suppressed, 1);
     assert.equal(result.inlineComments, 0);
@@ -5673,7 +5672,7 @@ test("upsert-checkpoint-verdict --findings-ledger corrects an existing same-head
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
 
     assert.equal(result.action, "updated");
     assert.equal(result.surface, "review");
@@ -5721,7 +5720,7 @@ test("upsert-checkpoint-verdict --findings-ledger: an identical same-head rerun 
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent",
       inlineReason: "single-agent inline review (test)",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
 
     assert.equal(result.action, "noop");
     assert.equal(result.surface, "review");
@@ -5773,7 +5772,7 @@ test("upsert-checkpoint-verdict --findings-ledger: a same-head rerun with a SWAP
       inlineReason: "single-agent inline review (test)",
       findingsLedger: path.join(tempDir, "ledger.json"),
     };
-    const ghOptions = { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot: tempDir };
+    const ghOptions = { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot: tempDir };
 
     // Control: the SAME ledger the posted review already carries still noops.
     await writeSingleSurfaceLedger(tempDir, [postedFinding]);
@@ -5822,7 +5821,7 @@ test("upsert-checkpoint-verdict rejects a --findings-ledger written for a differ
         nextAction: "stay draft and fix",
         executionMode: "inline_single_agent",
         inlineReason: "single-agent inline review (test)",
-      }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir }),
+      }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir }),
       /refuse to post another round's findings/,
     );
   } finally {
@@ -5879,7 +5878,7 @@ test("upsert-checkpoint-verdict posts a withheld fanout_fanin verdict when --fin
       findingsLedger: ledgerPath,
       nextAction: "stay draft and fix",
       executionMode: "fanout_fanin",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, repoRoot: tempDir });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
 
     assert.equal(result.ok, true);
     assert.equal(result.action, "created");
@@ -5982,7 +5981,7 @@ function permissiveVerdictRunChild(headSha) {
 async function runVerdictEnforcement(args, { repoRoot, headSha }) {
   const options = parseUpsertCheckpointVerdictCliArgs(args);
   try {
-    const result = await upsertCheckpointVerdict(options, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild: permissiveVerdictRunChild(headSha) });
+    const result = await upsertCheckpointVerdict(options, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild: permissiveVerdictRunChild(headSha) });
     return { code: 0, stdout: `${JSON.stringify(result)}\n`, stderr: "" };
   } catch (error) {
     return { code: 1, stdout: "", stderr: `${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n` };
@@ -6254,7 +6253,7 @@ test("#1621: a findings_present draft_gate verdict DERIVES the next action, igno
       // An ADVANCING next action the caller tried to splice in.
       nextAction: "merge",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     const postCall = calls.find((c) => c.args.some((x) => x.includes("pulls/17/reviews")) && c.args.includes("POST"));
     assert.ok(postCall, "a review was posted");
@@ -6293,7 +6292,7 @@ test("#1621: a findings_present pre_approval_gate verdict derives 'rerun gate' (
       // An ADVANCING action the caller tried to splice into a non-clean verdict.
       nextAction: "await final human approval",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     const postCall = calls.find((c) => c.args.some((x) => x.includes("pulls/17/reviews")) && c.args.includes("POST"));
     assert.ok(postCall, "a review was posted");
@@ -6327,7 +6326,7 @@ test("#1621: same-head idempotency holds after next-action derivation (a rerun i
       // the existing comment already carries.
       nextAction: "merge",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "noop");
     // No re-post occurred.
     assert.equal(calls.filter((c) => c.args.some((x) => x.includes("pulls/17/reviews")) && c.args.includes("POST")).length, 0);
@@ -6346,7 +6345,7 @@ test("#1621: an inline round that surfaces a blocking finding applies the gate:f
       findingsSeverityCounts: { high: 1, medium: 0, low: 0 },
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent", inlineReason: "inline blocking finding",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     // The post succeeded.
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, true);
@@ -6370,7 +6369,7 @@ test("#1621: an inline CLEAN round does NOT apply the gate:full label", async ()
       findingsSeverityCounts: { high: 0, medium: 0, low: 0 },
       nextAction: "mark ready for review",
       executionMode: "inline_single_agent", inlineReason: "inline clean",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, undefined);
     assert.equal(calls.some((c) => c.args[0] === "label" && c.args.includes("gate:full")), false);
@@ -6406,7 +6405,7 @@ test("#1526: an inline round that surfaces an UNPARSEABLE blocking finding appli
       findingsSeverityCounts: { high: 1, medium: 0, low: 0 },
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent", inlineReason: "inline unparseable blocking finding",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, true);
     const labelCreate = calls.find((c) => c.args[0] === "label" && c.args[1] === "create" && c.args.includes("gate:full"));
@@ -6450,7 +6449,7 @@ test("#1621: a clean pre_approval_gate verdict is REFUSED while the spec-of-reco
         findingsSeverityCounts: { high: 0, medium: 0, low: 0 },
         nextAction: "await final human approval",
         executionMode: "inline_single_agent", inlineReason: "inline #1621 pre-approval test",
-      }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild }),
+      }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild }),
       (err) => {
         assert.match(err.message, /Cannot set verdict "clean" for pre_approval_gate/);
         assert.match(err.message, /unticked Acceptance criteria/);
@@ -6492,7 +6491,7 @@ test("#1621: a clean pre_approval_gate verdict is ALLOWED when the spec-of-recor
       findingsSeverityCounts: { high: 0, medium: 0, low: 0 },
       nextAction: "await final human approval",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 pre-approval test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gate, "pre_approval_gate");
   } finally {
@@ -6527,7 +6526,7 @@ test("#1621: a clean pre_approval_gate verdict is ALLOWED when there is no linke
       findingsSeverityCounts: { high: 0, medium: 0, low: 0 },
       nextAction: "await final human approval",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 pre-approval test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
@@ -6545,7 +6544,7 @@ test("#1621: a blocked draft_gate verdict DERIVES 'stay draft and fix' (not the 
       // also derive, not accept the caller's advancing action.
       nextAction: "mark ready for review",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 blocked test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     const postCall = calls.find((c) => c.args.some((x) => x.includes("pulls/17/reviews")) && c.args.includes("POST"));
     assert.ok(postCall, "a review was posted");
@@ -6572,7 +6571,7 @@ test("#1621: an inline round whose --findings-json carries a blocking-severity f
       findingsSummary: "ignored in structured mode",
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent", inlineReason: "inline structured #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, true);
     assert.ok(calls.some((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("gate:full")), "label added");
@@ -6596,7 +6595,7 @@ test("#1621: a blocking-severity finding with a resolved disposition does NOT es
       findingsSummary: "ignored in structured mode",
       nextAction: "mark ready for review",
       executionMode: "inline_single_agent", inlineReason: "inline structured resolved #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, undefined);
     assert.equal(calls.some((c) => c.args[0] === "label" && c.args.includes("gate:full")), false);
@@ -6626,7 +6625,7 @@ test("#1621: an inline UPDATE round that surfaces a blocking finding applies gat
       findingsSeverityCounts: { high: 1, medium: 0, low: 0 },
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 update test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "updated");
     assert.equal(result.gateFullLabelApplied, true);
     assert.ok(calls.some((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("gate:full")), "label added on update");
@@ -6664,7 +6663,7 @@ test("#1621: an umbrella ready PR whose first-linked issue is ticked but a sibli
         findingsSeverityCounts: { high: 0, medium: 0, low: 0 },
         nextAction: "await final human approval",
         executionMode: "inline_single_agent", inlineReason: "inline #1621 umbrella test",
-      }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild }),
+      }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild }),
       (err) => {
         assert.match(err.message, /Cannot set verdict "clean" for pre_approval_gate/);
         assert.match(err.message, /ACCEPT-CRITERIA-VERIFY-AND-REFLECT/);
@@ -6691,7 +6690,7 @@ test("#1621: an inline free-text-only findings_present round (no structuredFindi
       // `return verdict === "findings_present"` free-text fallback branch.
       nextAction: "stay draft and fix",
       executionMode: "inline_single_agent", inlineReason: "inline free-text #1621 test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "created");
     assert.equal(result.gateFullLabelApplied, true);
     assert.ok(calls.some((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("gate:full")), "label added via free-text fallback");
@@ -6720,7 +6719,7 @@ test("#1621: gate:full label is re-applied on a noop rerun (idempotent retry aft
       findingsSeverityCounts: { high: 1, medium: 0, low: 0 },
       nextAction: "merge",
       executionMode: "inline_single_agent", inlineReason: "inline #1621 noop-retry test",
-    }, { env: { ...process.env, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", repoRoot, runChild });
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", repoRoot, runChild });
     assert.equal(result.action, "noop");
     assert.equal(result.gateFullLabelApplied, true);
     assert.ok(calls.some((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("gate:full")), "label re-applied on noop");

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import test, { after, before } from "node:test";
-import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
+import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 import { parseHandoffCliArgs, runHandoff } from "../../scripts/loop/copilot-pr-handoff.mjs";
@@ -47,11 +47,10 @@ const runNode = async (args = [], options = {}) => {
   if (!entries) {
     return runNodeHelper(scriptPath, args, {
       ...options,
-      env: {
-        ...process.env,
+      env: runIdFreeEnv({
         ...(options.env ?? {}),
         DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-      },
+      }),
     });
   }
   const { runChild } = makeGhMock(entries);
@@ -64,7 +63,7 @@ const runNode = async (args = [], options = {}) => {
   if (parsed.help) {
     return { code: 0, stdout: "", stderr: "" };
   }
-  const env = { ...process.env, ...options.env, DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "" };
+  const env = runIdFreeEnv({ ...options.env, DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "" });
   delete env[GH_MOCK_ENTRIES];
   const repoRoot = options.cwd ?? process.cwd();
   const stderrChunks = [];
@@ -899,12 +898,11 @@ process.exit(97);
     );
     await chmod(ghPath, 0o755);
 
-    const env = {
-      ...process.env,
+    const env = runIdFreeEnv({
       PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
       GH_SEQUENCE_PATH: path.join(tempDir, "gh-sequence.json"),
       GH_REREQUEST_STATE_PATH: requestedStatePath,
-    };
+    });
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 
@@ -1199,12 +1197,11 @@ process.exit(97);
     );
     await chmod(ghPath, 0o755);
 
-    const env = {
-      ...process.env,
+    const env = runIdFreeEnv({
       PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
       GH_SEQUENCE_PATH: path.join(tempDir, "gh-sequence.json"),
       GH_REREQUEST_STATE_PATH: requestedStatePath,
-    };
+    });
 
     const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
 

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test, { describe, it } from "node:test";
-import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
 import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput, resolvePostConvergenceReviewSuppressed, TERMINAL_RUNNER_RELEASE_ACTIONS } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
@@ -57,7 +57,7 @@ function buildMockRuntime(rawEnv = {}, extra = {}) {
     // (a mock throw would not distinguish "git missing" from "git present").
     return defaultRunChild(cmd, cmdArgs, childEnv, stdinText);
   };
-  return { env: { ...process.env, ...rawEnv, DEVLOOPS_RUN_ID: "" }, ghCommand: "gh", runChild, ...extra };
+  return { env: runIdFreeEnv({ ...rawEnv, DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, ...extra };
 }
 
 // Run the CLI in-process when gh entries are stashed on the env, mirroring main()'s
@@ -69,11 +69,10 @@ const runNode = async (args = [], options = {}) => {
   const entries = options.env?.[GH_MOCK_ENTRIES];
   const fallback = () => runNodeHelper(scriptPath, args, {
     ...options,
-    env: {
-      ...process.env,
+    env: runIdFreeEnv({
       ...(options.env ?? {}),
       DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
-    },
+    }),
   });
   if (!entries) return fallback();
   let opts;

--- a/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
+++ b/test/loop/resolve-dev-loop-startup-cli-contract.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import { resolverTestEnv, writeGhStub } from "../_helpers.mjs";
+import { RUN_ID_MARKERS } from "@dev-loops/core/loop/run-context";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const cliPath = path.join(repoRoot, "scripts", "loop", "resolve-dev-loop-startup.mjs");
@@ -177,7 +178,7 @@ test("resolve-dev-loop-startup rejects async-required strategy via stderr contra
       env: Object.fromEntries(
         Object.entries(process.env).filter(
           ([k]) =>
-            k !== "DEVLOOPS_RUN_ID" &&
+            !RUN_ID_MARKERS.includes(k) &&
             k !== "CLAUDECODE" &&
             k !== "DEVLOOPS_DETACHED",
         ),

--- a/test/loop/run-watch-cycle.test.mjs
+++ b/test/loop/run-watch-cycle.test.mjs
@@ -1,5 +1,5 @@
 import test from "node:test";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
+import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 import assert from "node:assert/strict";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -579,13 +579,12 @@ process.exit(97);
     );
     await chmod(ghPath, 0o755);
 
-    const env = {
-      ...process.env,
+    const env = runIdFreeEnv({
       PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
       GH_REREQUEST_STATE_PATH: path.join(tempDir, "requested-state.txt"),
       GH_SEQUENCE_PATH: path.join(tempDir, "gh-sequence.json"),
       DEVLOOPS_RUN_ID: "",
-    };
+    });
 
     const result = await runWatchCycle(
       {


### PR DESCRIPTION
Closes #1639

# Stabilize local-environmental verify suites (gh/run-id)

## Problem

~48 pre-existing test failures appear in local `npm run verify` but are green in CI. Root cause: ambient `PI_SUBAGENT_RUN_ID` (injected by the Pi runtime into async-subagent child envs) leaks into test child processes. The suites only nulled `DEVLOOPS_RUN_ID`, so under a Pi async-subagent session the leaked Pi alias still resolved an "active run id" and the suites behaved as if in a production async context — green in CI (no marker), failing locally (marker present). A flaky parallel-run hang (passing on re-run) also stemmed from this marker leakage.

## Fix

- New shared `runIdFreeEnv(overrides)` helper in `test/_helpers.mjs` that builds a test env from `process.env` with **every** `RUN_ID_MARKERS` entry stripped (`DEVLOOPS_RUN_ID` + the Pi alias `PI_SUBAGENT_RUN_ID`), then applies explicit overrides on top. Marker names come from the shared `RUN_ID_MARKERS` contract in `@dev-loops/core/loop/run-context`, keeping the helper harness-agnostic and the Pi marker literal owned by the adapter boundary.
- Routed all affected gh/run-id suites' env construction through `runIdFreeEnv`:
  - `copilot-pr-handoff`, `run-watch-cycle`
  - `detect-checkpoint-evidence`, `detect-checkpoint-evidence-stale-runner`, `detect-checkpoint-evidence-gate-threads`, `reconcile-draft-gate`, `upsert-checkpoint-verdict`
  - `detect-pr-gate-coordination-state`, `resolve-dev-loop-startup-cli-contract`
- `run-context.test.mjs` contract test updated so the undefined/blank-absent assertion strips every ambient marker instead of only `DEVLOOPS_RUN_ID` (environment-independent, mirrors the CI guarantee).

CI is unaffected — it carries neither marker. Suites that intend an active run id pass `DEVLOOPS_RUN_ID` explicitly in overrides and it wins.

## Acceptance criteria matrix

| # | AC (from #1639) | Status | Evidence |
|---|------------------|--------|----------|
| 1 | Each listed suite either passes locally or skips cleanly (with recorded reason) when gh auth / run-id context is absent | ✅ | All affected suites pass locally in a fresh worktree (counts below) |
| 2 | No false failures from these suites in a fresh local worktree `npm run verify` | ✅ | Full scripts suite: 3861 pass / 0 fail, twice |
| 3 | CI behavior unchanged (suites remain green in CI) | ✅ | Fix only strips ambient env markers; CI carries neither marker, no assertion changes |
| 4 | A documented way to run the full local verify without environmental noise | ✅ | `npm run verify` from a worktree is now clean without extra setup |

## Definition of done

- [x] All affected suites pass locally in a fresh worktree `npm run verify`
- [x] Zero false failures from these suites locally
- [x] No change to what the suites assert (only how they behave under missing run-id context)
- [x] No restructuring of the verify pipeline

## Non-goals

- Changing what these suites assert (only how they behave under missing environmental context)
- Restructuring the verify pipeline
- Touching `.pi/agents` (pre-existing env symlink artifact in the main checkout; out of scope)

## Validation

Ran from the issue-1639 worktree (head `dc57a357`):

- `npm run test:scripts` (github + loop): **3861 pass / 0 fail** (twice) — previously ~48 env failures
- `npm run test:core`: **2469 pass / 0 fail**
- `npm run test:extension`: **123 pass / 0 fail**
- `npm run test:assets`: **268 pass / 0 fail**
- `npm run test:dev-loop`: **35 pass / 0 fail**
- `npm run test:pack`: **1 pass / 0 fail**
- `npm run schema:check`: up to date
- `node scripts/docs/validate-links.mjs`, `validate-rule-ownership.mjs`, `validate-decision-records.mjs`: pass
- `node scripts/github/lint-workflows.mjs`: pass
- `npm run assets:check`: ok (94 checked)
- `git diff --check`: clean
