### PR TITLE
feat(gate): primer-dispatch ordering evidence + fail-closed fan-in validation (#1475)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -270,7 +270,15 @@ per-gate accounting is an optional follow-up, not a precondition.)
    write-before-reads ordering. The completion fallback fully serializes the lead reviewer
    ahead of the rest — a small, bounded latency cost, and the reason the near-free
    one-reviewer form is still the default rather than a mandatory streaming dependency.
-4. **Release the fan-out over the SAME model and the SAME byte-identical prefix**, so each
+4. **Record ordering evidence** — write the primer-dispatch evidence artifact (issue
+   #1468 slice 3) to the deterministic path `<gate>-<headSha>.primer-evidence.json`
+   beside the gate-context artifacts: `@dev-loops/core/loop/primer-evidence`
+   (`primerEvidencePath` / `buildPrimerEvidence` / `writePrimerEvidence`). The artifact
+   pairs the request plan with the observed primer runs and reviewer releases, binding
+   each primer to its own model + request-prefix fingerprint and each released reviewer
+   to a primer that landed before it. This is what lets fan-in fail closed (see
+   Phase 3 — Consolidation) instead of trusting the rule in prose.
+5. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
    reviewer READS the cache the primer wrote instead of racing to write its own. A
    differing model or prefix defeats reuse and is the same failure the byte-identity rule
    already guards against.
@@ -707,6 +715,19 @@ would overcount; NOT `fanout.wavePlan.length`, which is the WAVE count, typicall
 the dispatch-unit count; groups for grouped dispatch, angle count for per-angle
 dispatch; NOT the per-angle artifact count, which would false-fail every grouped
 round).
+
+<!-- rule: GATE-EXEC-PRIMER-EVIDENCE -->
+`GATE-EXEC-PRIMER-EVIDENCE`: when the round recorded primer-dispatch ordering
+evidence (Phase 1.5 step 4, `<gate>-<headSha>.primer-evidence.json`), fan-in MUST
+validate it against the request plan via `@dev-loops/core/loop/primer-evidence`
+`validatePrimerEvidence` and fail closed — refusing to proceed to consolidation —
+when the evidence is missing, or when the ordering barrier, request-group
+coverage, model-group binding, request-prefix fingerprint, shared-prefix hash, or
+plan hash is missing or mismatched. The refusal names the failing check
+(`primer_order` / `group_coverage` / `model_group` / `request_fingerprint` /
+`shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
+barrier: the primer write-before-read ordering is no longer asserted only in
+prose, but is a mechanically-checkable fail-closed input to consolidation.
 
 Merge the parallel reviewer findings into one consolidated fix plan with the
 sanctioned fan-in CLI:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "./loop/queue-membership": "./src/loop/queue-membership.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",
     "./loop/queue-state": "./src/loop/queue-state.mjs",
+    "./loop/primer-evidence": "./src/loop/primer-evidence.mjs",
     "./loop/review-dispatch-plan": "./src/loop/review-dispatch-plan.mjs",
     "./loop/reviewer-loop-state": "./src/loop/reviewer-loop-state.mjs",
     "./loop/run-context": "./src/loop/run-context.mjs",

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -245,6 +245,28 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
 }
 
 /**
+ * Strict fail-closed enforcement surface (GATE-EXEC-PRIMER-EVIDENCE): throws
+ * when fan-in evidence is missing or invalid, naming the failing check. This is
+ * the refusal path a gate conductor calls after validatePrimerEvidence returns
+ * ok:false — it turns a reported failure into a hard stop.
+ *
+ * @param {object} input
+ * @param {object} input.plan - dispatch plan.
+ * @param {object} input.evidence - artifact from buildPrimerEvidence().
+ * @returns {true}
+ * @throws {Error} when any primer-evidence check fails.
+ */
+export function enforcePrimerEvidence({ plan, evidence } = {}) {
+  const r = validatePrimerEvidence({ plan, evidence });
+  if (!r.ok) {
+    throw new Error(
+      `GATE-EXEC-PRIMER-EVIDENCE: primer evidence failed validation; refusing to proceed (${r.failures.map((f) => `${f.check}: ${f.reason}`).join("; ")})`,
+    );
+  }
+  return true;
+}
+
+/**
  * Persist the evidence artifact to its deterministic path.
  *
  * @param {object} input

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -1,0 +1,264 @@
+/**
+ * primer-evidence.mjs — primer dispatch ordering evidence + fail-closed fan-in
+ * validation (issue #1468 slice 3).
+ *
+ * Slice 1-2 (review-dispatch-plan.mjs) produced the deterministic request-plan
+ * artifact, request-prefix fingerprints, stable/volatile separation, and
+ * per-model primer-group partitioning. This slice closes the gap between
+ * "the rules say prime before fan-out" and "we can assert it happened": it
+ * records evidence that each request group's primer actually landed before any
+ * of that group's reviewers were released, and makes fan-in fail closed when
+ * that ordering — or the model group / request fingerprint / shared-prefix hash
+ * binding — is missing or mismatched.
+ *
+ * This module is pure and offline (no GitHub, no harness, no clock). It owns:
+ *
+ *  1. primer-evidence artifact builder — one deterministic per-gate-run record
+ *     ('<gate>-<headSha>.primer-evidence.json') pairing the request plan with
+ *     the observed primer runs and reviewer releases and deriving the ordering
+ *     verdict.
+ *  2. fail-closed validator — checks, named individually, that every request
+ *     group got its own primer run, that each primer is scoped to its own
+ *     model/prefix (never credited to another group), and that every reviewer
+ *     release happened after its group's primer landed.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- API surface reserved for future harness adapters
+
+export const PRIMER_EVIDENCE_SCHEMA_VERSION = 1;
+
+/** @param {string} s */
+const isHex = (s) => /^[0-9a-f]{64}$/i.test(String(s));
+const sha = (s) => `sha256:${String(s).replace(/^sha256:/, "").trim().toLowerCase()}`;
+
+/**
+ * Deterministic artifact path for a gate run's primer evidence.
+ *
+ * @param {object} input
+ * @param {string} input.dir - directory to write under (e.g. the gate-context dir).
+ * @param {string} input.gate - gate name (pre_approval_gate, draft_gate, ...).
+ * @param {string} input.headSha - reviewed head SHA (hex, 7-64).
+ * @returns {string} absolute-style path joined under `dir`.
+ */
+export function primerEvidencePath({ dir, gate, headSha } = {}) {
+  if (typeof dir !== "string" || dir.length === 0) throw new Error("primerEvidencePath requires a dir");
+  if (typeof gate !== "string" || gate.length === 0) throw new Error("primerEvidencePath requires a gate");
+  if (typeof headSha !== "string" || !/^[0-9a-f]{7,64}$/i.test(headSha.trim())) {
+    throw new Error("primerEvidencePath requires a hex headSha");
+  }
+  return path.join(dir, `${gate}-${headSha.trim().toLowerCase()}.primer-evidence.json`);
+}
+
+/**
+ * Import a plan's request groups into a plain lookup keyed by canonical
+ * (model, requestPrefixFingerprint). Fingerprint-less groups are keyed by
+ * `model` only (they never collapse, mirroring partitionPrimerGroups).
+ *
+ * @param {object[]} requestGroups
+ * @returns {Map<string, object>}
+ */
+function planGroupIndex(requestGroups) {
+  const idx = new Map();
+  for (let i = 0; i < requestGroups.length; i++) {
+    const g = requestGroups[i];
+    const key = g.requestPrefixFingerprint ? `${g.model}::${g.requestPrefixFingerprint}` : `${g.model}::__unkeyed:${i}`;
+    if (!idx.has(key)) idx.set(key, []);
+    idx.get(key).push(g);
+  }
+  return idx;
+}
+
+/** Normalize a fingerprint to a canonical `sha256:<hex>` or null. */
+function normFp(v) {
+  if (v == null) return null;
+  return sha(v);
+}
+
+/**
+ * Build the primer-evidence artifact for a gate run.
+ *
+ * @param {object} input
+ * @param {object} input.plan - the dispatch plan from buildReviewDispatchPlan().
+ * @param {Array<object>} input.primerRuns - [{ model, requestPrefixFingerprint, primerForm, landedAt }]
+ * @param {Array<object>} input.reviewerReleases - [{ model, requestPrefixFingerprint, releasedAt }]
+ * @returns {object} canonical evidence artifact.
+ */
+export function buildPrimerEvidence({ plan, primerRuns = [], reviewerReleases = [], _now = 0 } = {}) {
+  if (!plan || typeof plan !== "object" || !Array.isArray(plan.requestGroups)) {
+    throw new Error("buildPrimerEvidence requires a plan with requestGroups");
+  }
+  if (!Array.isArray(primerRuns)) throw new Error("primerRuns must be an array");
+  if (!Array.isArray(reviewerReleases)) throw new Error("reviewerReleases must be an array");
+
+  const groups = plan.requestGroups;
+  const idx = planGroupIndex(groups);
+
+  const normRuns = primerRuns.map((r, i) => {
+    if (typeof r.model !== "string" || r.model.length === 0) {
+      throw new Error(`primerRuns[${i}].model must be a non-empty concrete model`);
+    }
+    const fp = normFp(r.requestPrefixFingerprint);
+    const key = fp ? `${r.model}::${fp}` : `${r.model}::__unkeyed:${i}`;
+    if (!idx.has(key)) {
+      throw new Error(
+        `primerRuns[${i}] references model ${JSON.stringify(r.model)} with a prefix not present in the plan's request groups`,
+      );
+    }
+    return Object.freeze({
+      model: r.model,
+      requestPrefixFingerprint: fp,
+      primerForm: r.primerForm ?? null,
+      landedAt: Number.isFinite(r.landedAt) ? r.landedAt : null,
+    });
+  });
+
+  const normReleases = reviewerReleases.map((r, i) => {
+    return Object.freeze({
+      model: r.model,
+      requestPrefixFingerprint: normFp(r.requestPrefixFingerprint),
+      releasedAt: Number.isFinite(r.releasedAt) ? r.releasedAt : null,
+    });
+  });
+
+  return Object.freeze({
+    schemaVersion: PRIMER_EVIDENCE_SCHEMA_VERSION,
+    gate: plan.gate,
+    headSha: plan.headSha,
+    planHash: plan.planHash,
+    sharedPrefixHash: plan.sharedPrefixHash ?? null,
+    primerRuns: Object.freeze(normRuns),
+    reviewerReleases: Object.freeze(normReleases),
+  });
+}
+
+/**
+ * Fail-closed validation of primer-evidence against the request plan.
+ *
+ * @param {object} input
+ * @param {object} input.plan - dispatch plan.
+ * @param {object} input.evidence - artifact from buildPrimerEvidence().
+ * @returns {{ ok: boolean, failures: Array<{check: string, reason: string}> }}
+ */
+export function validatePrimerEvidence({ plan, evidence } = {}) {
+  const failures = [];
+
+  // shared-prefix hash binding.
+  if (evidence.sharedPrefixHash == null || evidence.sharedPrefixHash !== (plan.sharedPrefixHash ?? null)) {
+    failures.push({
+      check: "shared_prefix_hash",
+      reason: `evidence sharedPrefixHash ${JSON.stringify(evidence.sharedPrefixHash)} does not match the plan's ${JSON.stringify(plan.sharedPrefixHash ?? null)}`,
+    });
+  }
+
+  // plan hash binding: evidence must reference the same search.
+  if (evidence.planHash != null && plan.planHash != null && evidence.planHash !== plan.planHash) {
+    failures.push({
+      check: "plan_hash",
+      reason: `evidence planHash ${JSON.stringify(evidence.planHash)} does not match the plan's ${JSON.stringify(plan.planHash)}`,
+    });
+  }
+
+  const groups = plan.requestGroups ?? [];
+  const idx = planGroupIndex(groups);
+
+  // group coverage: every request group must have a primer run bound to its
+  // model + request fingerprint.
+  const coveredKeys = new Set(
+    evidence.primerRuns.map((r) =>
+      r.requestPrefixFingerprint
+        ? `${r.model}::${r.requestPrefixFingerprint}`
+        : `${r.model}::__unkeyed`,
+    ),
+  );
+  for (let i = 0; i < groups.length; i++) {
+    const g = groups[i];
+    const key = g.requestPrefixFingerprint
+      ? `${g.model}::${g.requestPrefixFingerprint}`
+      : `${g.model}::__unkeyed`;
+    if (!coveredKeys.has(key)) {
+      failures.push({
+        check: "group_coverage",
+        reason: `request group ${i} (model ${JSON.stringify(g.model)}) has no primer run in the evidence`,
+      });
+    }
+  }
+
+  // model-group / request-fingerprint binding per reviewer release.
+  for (let i = 0; i < evidence.reviewerReleases.length; i++) {
+    const rel = evidence.reviewerReleases[i];
+    const key = rel.requestPrefixFingerprint
+      ? `${rel.model}::${rel.requestPrefixFingerprint}`
+      : `${rel.model}::__unkeyed`;
+    if (rel.requestPrefixFingerprint && idx.has(key)) {
+      // bound to a known group -> ok
+    } else if (rel.requestPrefixFingerprint && !idx.has(key)) {
+      failures.push({
+        check: "model_group",
+        reason: `reviewer release ${i} bound to model ${JSON.stringify(rel.model)} + fingerprint that is not a request group (heterogeneous routing must not credit one model's primer to another)`,
+      });
+    }
+    // ordering: a released reviewer must have a primer landed before it.
+    const primerForRel = evidence.primerRuns.find(
+      (r) =>
+        r.model === rel.model &&
+        (rel.requestPrefixFingerprint == null || r.requestPrefixFingerprint === rel.requestPrefixFingerprint),
+    );
+    if (!primerForRel) {
+      failures.push({
+        check: "model_group",
+        reason: `reviewer release ${i} has no primer run for model ${JSON.stringify(rel.model)}`,
+      });
+    } else if (Number.isFinite(rel.releasedAt) && Number.isFinite(primerForRel.landedAt) && rel.releasedAt < primerForRel.landedAt) {
+      failures.push({
+        check: "primer_order",
+        reason: `reviewer release ${i} released at ${rel.releasedAt} before its primer landed at ${primerForRel.landedAt} (ordering barrier violated)`,
+      });
+    }
+  }
+
+  // request-fingerprint binding for primer runs that reference a real prefix.
+  for (let i = 0; i < evidence.primerRuns.length; i++) {
+    const r = evidence.primerRuns[i];
+    if (r.requestPrefixFingerprint) {
+      const key = `${r.model}::${r.requestPrefixFingerprint}`;
+      if (!idx.has(key)) {
+        failures.push({
+          check: "request_fingerprint",
+          reason: `primer run ${i} request-prefix fingerprint not present in the plan's request groups for model ${JSON.stringify(r.model)}`,
+        });
+      }
+    }
+  }
+
+  // Drop duplicate entries (same check on the same release).
+  const seen = new Set();
+  const unique = failures.filter((f) => {
+    const key = `${f.check}|${f.reason}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return { ok: unique.length === 0, failures: unique };
+}
+
+/**
+ * Persist the evidence artifact to its deterministic path.
+ *
+ * @param {object} input
+ * @param {string} input.dir
+ * @param {object} input.evidence
+ * @returns {Promise<{ path: string }>}
+ */
+export async function writePrimerEvidence({ dir, evidence } = {}) {
+  const target = primerEvidencePath({
+    dir,
+    gate: evidence.gate,
+    headSha: evidence.headSha,
+  });
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+  return { path: target };
+}

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -237,26 +237,43 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
         reason: `reviewer release ${i} bound to model ${JSON.stringify(rel.model)} + fingerprint that is not a request group (heterogeneous routing must not credit one model's primer to another)`,
       });
     }
-    // ordering: a released reviewer must have a primer landed before it.
-    const primerForRel = evidence.primerRuns.find(
+    // ordering: a released reviewer must have ITS group's primer landed before
+    // it. Candidate primers are scoped to the release's OWN primer group — a
+    // keyed release binds to a same-model + same-fingerprint run, a
+    // fingerprint-less release binds to a same-model fingerprint-less run —
+    // NEVER the first same-model primer (which could belong to a different
+    // group sharing the model, e.g. a keyed group). This closes the fail-open
+    // where an unkeyed release was credited to a keyed group's earlier primer
+    // even though its own group's primer landed after it.
+    const candidates = evidence.primerRuns.filter(
       (r) =>
         r.model === rel.model &&
-        (rel.requestPrefixFingerprint == null || r.requestPrefixFingerprint === rel.requestPrefixFingerprint),
+        (rel.requestPrefixFingerprint == null
+          ? r.requestPrefixFingerprint == null
+          : r.requestPrefixFingerprint === rel.requestPrefixFingerprint),
     );
-    if (!primerForRel) {
+    if (candidates.length === 0) {
       failures.push({
         check: "model_group",
         reason: `reviewer release ${i} has no primer run for model ${JSON.stringify(rel.model)}`,
       });
-    } else if (!Number.isFinite(rel.releasedAt) || !Number.isFinite(primerForRel.landedAt) || rel.releasedAt < primerForRel.landedAt) {
-      // Fail CLOSED when the ordering barrier is unprovable (missing / non-finite
-      // timestamps), not only when it is provably reversed: a release without a
-      // landed primer timestamp cannot attest the primer ran before it, so the
-      // evidence must not proceed.
-      failures.push({
-        check: "primer_order",
-        reason: `reviewer release ${i} (${JSON.stringify(rel.model)}) cannot prove its primer landed before it: releasedAt=${String(rel.releasedAt)}, primer landedAt=${String(primerForRel.landedAt)} (ordering barrier missing or violated)`,
-      });
+    } else {
+      // Deterministic: the barrier must hold against the LAST-landed candidate
+      // (reduce/max is order-independent, unlike .find()'s first-match). With a
+      // single same-group primer this is exactly that group's primer; only an
+      // anomalous multiplicity of same-group primers here is stricter, and
+      // stricter is the fail-closed direction.
+      const primerForRel = candidates.reduce((a, b) => (b.landedAt > a.landedAt ? b : a));
+      if (!Number.isFinite(rel.releasedAt) || !Number.isFinite(primerForRel.landedAt) || rel.releasedAt < primerForRel.landedAt) {
+        // Fail CLOSED when the ordering barrier is unprovable (missing / non-finite
+        // timestamps), not only when it is provably reversed: a release without a
+        // landed primer timestamp cannot attest the primer ran before it, so the
+        // evidence must not proceed.
+        failures.push({
+          check: "primer_order",
+          reason: `reviewer release ${i} (${JSON.stringify(rel.model)}) cannot prove its primer landed before it: releasedAt=${String(rel.releasedAt)}, primer landedAt=${String(primerForRel.landedAt)} (ordering barrier missing or violated)`,
+        });
+      }
     }
   }
 

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -25,12 +25,8 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- API surface reserved for future harness adapters
-
 export const PRIMER_EVIDENCE_SCHEMA_VERSION = 1;
 
-/** @param {string} s */
-const isHex = (s) => /^[0-9a-f]{64}$/i.test(String(s));
 const sha = (s) => `sha256:${String(s).replace(/^sha256:/, "").trim().toLowerCase()}`;
 
 /**
@@ -101,7 +97,7 @@ function normFp(v) {
  * @param {Array<object>} input.reviewerReleases - [{ model, requestPrefixFingerprint, releasedAt }]
  * @returns {object} canonical evidence artifact.
  */
-export function buildPrimerEvidence({ plan, primerRuns = [], reviewerReleases = [], _now = 0 } = {}) {
+export function buildPrimerEvidence({ plan, primerRuns = [], reviewerReleases = [] } = {}) {
   if (!plan || typeof plan !== "object" || !Array.isArray(plan.requestGroups)) {
     throw new Error("buildPrimerEvidence requires a plan with requestGroups");
   }
@@ -168,16 +164,24 @@ export function buildPrimerEvidence({ plan, primerRuns = [], reviewerReleases = 
 export function validatePrimerEvidence({ plan, evidence } = {}) {
   const failures = [];
 
-  // shared-prefix hash binding.
-  if (evidence.sharedPrefixHash == null || evidence.sharedPrefixHash !== (plan.sharedPrefixHash ?? null)) {
+  // shared-prefix hash binding. A plan that carries no shared-prefix hash HAS
+  // no cache-access binding to enforce (both null is a pass); when the plan
+  // carrys one, the evidence must carry the SAME value. This is a real bug
+  // fix: the prior `evidence.sharedPrefixHash == null ||` clause failed even
+  // when plan and evidence were BOTH absent (a both-absent plan could never be
+  // validated).
+  if (evidence.sharedPrefixHash !== (plan.sharedPrefixHash ?? null)) {
     failures.push({
       check: "shared_prefix_hash",
       reason: `evidence sharedPrefixHash ${JSON.stringify(evidence.sharedPrefixHash)} does not match the plan's ${JSON.stringify(plan.sharedPrefixHash ?? null)}`,
     });
   }
 
-  // plan hash binding: evidence must reference the same search.
-  if (evidence.planHash != null && plan.planHash != null && evidence.planHash !== plan.planHash) {
+  // plan hash binding: evidence must reference the same search. Fails closed
+  // on a MISSING evidence planHash too (the evidence was not derived from this
+  // search, or was tampered), not only on a mismatch — matching the contract
+  // text that "plan hash is missing or mismatched" refuses consolidation.
+  if (evidence.planHash == null || plan.planHash == null || evidence.planHash !== plan.planHash) {
     failures.push({
       check: "plan_hash",
       reason: `evidence planHash ${JSON.stringify(evidence.planHash)} does not match the plan's ${JSON.stringify(plan.planHash)}`,
@@ -244,10 +248,14 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
         check: "model_group",
         reason: `reviewer release ${i} has no primer run for model ${JSON.stringify(rel.model)}`,
       });
-    } else if (Number.isFinite(rel.releasedAt) && Number.isFinite(primerForRel.landedAt) && rel.releasedAt < primerForRel.landedAt) {
+    } else if (!Number.isFinite(rel.releasedAt) || !Number.isFinite(primerForRel.landedAt) || rel.releasedAt < primerForRel.landedAt) {
+      // Fail CLOSED when the ordering barrier is unprovable (missing / non-finite
+      // timestamps), not only when it is provably reversed: a release without a
+      // landed primer timestamp cannot attest the primer ran before it, so the
+      // evidence must not proceed.
       failures.push({
         check: "primer_order",
-        reason: `reviewer release ${i} released at ${rel.releasedAt} before its primer landed at ${primerForRel.landedAt} (ordering barrier violated)`,
+        reason: `reviewer release ${i} (${JSON.stringify(rel.model)}) cannot prove its primer landed before it: releasedAt=${String(rel.releasedAt)}, primer landedAt=${String(primerForRel.landedAt)} (ordering barrier missing or violated)`,
       });
     }
   }

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -49,8 +49,9 @@ export function primerEvidencePath({ dir, gate, headSha } = {}) {
 
 /**
  * Import a plan's request groups into a plain lookup keyed by canonical
- * (model, requestPrefixFingerprint). Fingerprint-less groups are keyed by
- * `model` only (they never collapse, mirroring partitionPrimerGroups).
+ * (model, requestPrefixFingerprint). Fingerprint-less groups are keyed by a
+ * per-model ordinal (`${model}::__unkeyed:<n>`), mirroring partitionPrimerGroups'
+ * per-partition separation.
  *
  * @param {object[]} requestGroups
  * @returns {Map<string, object>}
@@ -166,7 +167,7 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
 
   // shared-prefix hash binding. A plan that carries no shared-prefix hash HAS
   // no cache-access binding to enforce (both null is a pass); when the plan
-  // carrys one, the evidence must carry the SAME value. This is a real bug
+  // carries one, the evidence must carry the SAME value. This is a real bug
   // fix: the prior `evidence.sharedPrefixHash == null ||` clause failed even
   // when plan and evidence were BOTH absent (a both-absent plan could never be
   // validated).
@@ -278,6 +279,19 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
   }
 
   // request-fingerprint binding for primer runs that reference a real prefix.
+  // (planUnkeyedKeys + the per-model run ordinal counter support the inverse
+  // fingerprint-LESS binding below.)
+  const planUnkeyedKeys = new Set();
+  {
+    const planUnkeyedOrdinals = new Map();
+    for (const g of groups) {
+      if (g.requestPrefixFingerprint) continue;
+      const n = planUnkeyedOrdinals.get(g.model) ?? 0;
+      planUnkeyedOrdinals.set(g.model, n + 1);
+      planUnkeyedKeys.add(`${g.model}::__unkeyed:${n}`);
+    }
+  }
+  const unkeyedRunOrdinals = new Map();
   for (let i = 0; i < evidence.primerRuns.length; i++) {
     const r = evidence.primerRuns[i];
     if (r.requestPrefixFingerprint) {
@@ -286,6 +300,22 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
         failures.push({
           check: "request_fingerprint",
           reason: `primer run ${i} request-prefix fingerprint not present in the plan's request groups for model ${JSON.stringify(r.model)}`,
+        });
+      }
+    } else {
+      // Inverse group binding for fingerprint-LESS runs: mirror the keyed
+      // check above. group_coverage proves every plan group has a primer run;
+      // this proves the reverse — that every unkeyed primer run maps to a
+      // fingerprint-less plan group for its model. Without it, a hand-edited /
+      // legacy evidence file could carry extra fingerprint-less runs for models
+      // or groups the plan never requested and still validate, breaking the
+      // "derived from the plan" invariant for unkeyed groups.
+      const n = unkeyedRunOrdinals.get(r.model) ?? 0;
+      unkeyedRunOrdinals.set(r.model, n + 1);
+      if (!planUnkeyedKeys.has(`${r.model}::__unkeyed:${n}`)) {
+        failures.push({
+          check: "request_group_unkeyed",
+          reason: `primer run ${i} (${JSON.stringify(r.model)}) is fingerprint-less but no fingerprint-less request group exists in the plan for that ordinal`,
         });
       }
     }

--- a/packages/core/src/loop/primer-evidence.mjs
+++ b/packages/core/src/loop/primer-evidence.mjs
@@ -61,9 +61,25 @@ export function primerEvidencePath({ dir, gate, headSha } = {}) {
  */
 function planGroupIndex(requestGroups) {
   const idx = new Map();
+  // Fingerprint-less groups are keyed by a PER-MODEL ordinal so a primer run
+  // maps to the SAME plan group regardless of array positions. The prior
+  // position-based `${model}::__unkeyed:${i}` key used the array index (the
+  // primer run's position), which was NOT the same index planGroupIndex used
+  // (the group's position in the plan) — a fingerprint-less run whose array
+  // index differed from its group's plan index threw a false "prefix not
+  // present" error, and validatePrimerEvidence keyed them without any index
+  // at all (`__unkeyed`). One ordinal scheme everywhere closes that drift.
+  const unkeyedOrdinals = new Map();
   for (let i = 0; i < requestGroups.length; i++) {
     const g = requestGroups[i];
-    const key = g.requestPrefixFingerprint ? `${g.model}::${g.requestPrefixFingerprint}` : `${g.model}::__unkeyed:${i}`;
+    let key;
+    if (g.requestPrefixFingerprint) {
+      key = `${g.model}::${g.requestPrefixFingerprint}`;
+    } else {
+      const n = unkeyedOrdinals.get(g.model) ?? 0;
+      unkeyedOrdinals.set(g.model, n + 1);
+      key = `${g.model}::__unkeyed:${n}`;
+    }
     if (!idx.has(key)) idx.set(key, []);
     idx.get(key).push(g);
   }
@@ -95,12 +111,20 @@ export function buildPrimerEvidence({ plan, primerRuns = [], reviewerReleases = 
   const groups = plan.requestGroups;
   const idx = planGroupIndex(groups);
 
+  const runUnkeyedOrdinals = new Map();
   const normRuns = primerRuns.map((r, i) => {
     if (typeof r.model !== "string" || r.model.length === 0) {
       throw new Error(`primerRuns[${i}].model must be a non-empty concrete model`);
     }
     const fp = normFp(r.requestPrefixFingerprint);
-    const key = fp ? `${r.model}::${fp}` : `${r.model}::__unkeyed:${i}`;
+    let key;
+    if (fp) {
+      key = `${r.model}::${fp}`;
+    } else {
+      const n = runUnkeyedOrdinals.get(r.model) ?? 0;
+      runUnkeyedOrdinals.set(r.model, n + 1);
+      key = `${r.model}::__unkeyed:${n}`;
+    }
     if (!idx.has(key)) {
       throw new Error(
         `primerRuns[${i}] references model ${JSON.stringify(r.model)} with a prefix not present in the plan's request groups`,
@@ -165,18 +189,28 @@ export function validatePrimerEvidence({ plan, evidence } = {}) {
 
   // group coverage: every request group must have a primer run bound to its
   // model + request fingerprint.
-  const coveredKeys = new Set(
-    evidence.primerRuns.map((r) =>
-      r.requestPrefixFingerprint
-        ? `${r.model}::${r.requestPrefixFingerprint}`
-        : `${r.model}::__unkeyed`,
-    ),
-  );
+  const coveredKeys = new Set();
+  const coveredUnkeyedOrdinals = new Map();
+  for (const r of evidence.primerRuns) {
+    if (r.requestPrefixFingerprint) {
+      coveredKeys.add(`${r.model}::${r.requestPrefixFingerprint}`);
+    } else {
+      const n = coveredUnkeyedOrdinals.get(r.model) ?? 0;
+      coveredUnkeyedOrdinals.set(r.model, n + 1);
+      coveredKeys.add(`${r.model}::__unkeyed:${n}`);
+    }
+  }
+  const groupUnkeyedOrdinals = new Map();
   for (let i = 0; i < groups.length; i++) {
     const g = groups[i];
-    const key = g.requestPrefixFingerprint
-      ? `${g.model}::${g.requestPrefixFingerprint}`
-      : `${g.model}::__unkeyed`;
+    let key;
+    if (g.requestPrefixFingerprint) {
+      key = `${g.model}::${g.requestPrefixFingerprint}`;
+    } else {
+      const n = groupUnkeyedOrdinals.get(g.model) ?? 0;
+      groupUnkeyedOrdinals.set(g.model, n + 1);
+      key = `${g.model}::__unkeyed:${n}`;
+    }
     if (!coveredKeys.has(key)) {
       failures.push({
         check: "group_coverage",

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -387,3 +387,80 @@ describe("draft-gate hardening of validatePrimerEvidence (fan-in converge findin
     assert.throws(() => enforcePrimerEvidence({ plan, evidence: ev }), /primer_order/);
   });
 });
+
+describe("primer_order — deterministic, group-scoped binding (fan-in converge medium findings)", () => {
+  test("an unkeyed release is NOT credited to a same-model keyed primer (fail-open closed)", () => {
+    // A model with BOTH a keyed and an unkeyed primer group: partitionPrimerGroups
+    // provably produces this. The unkeyed release here is released AFTER the
+    // keyed group's earlier primer but BEFORE its own unkeyed primer — the exact
+    // cross-credit that previously passed via first-match-by-model .find().
+    const plan = buildReviewDispatchPlan({
+      gate: "pre_approval_gate",
+      headSha: "abcdef1234567890",
+      sharedPrefixHash: fp,
+      requestGroups: [
+        { model: "model-a", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h", angles: ["correctness"] },
+        { model: "model-a", requestPrefixFingerprint: null, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h", angles: ["scope"] },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 1 },
+        { model: "model-a", primerForm: PRIMER_FORM_DEDICATED, landedAt: 6 },
+      ],
+      reviewerReleases: [
+        { model: "model-a", releasedAt: 4 }, // after keyed primer (1), before its own unkeyed primer (6)
+      ],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false, JSON.stringify(r.failures));
+    assert.ok(r.failures.some((f) => f.check === "primer_order" && /releasedAt=4/.test(f.reason)));
+    assert.throws(() => enforcePrimerEvidence({ plan, evidence: ev }), /primer_order/);
+  });
+
+  test("an unkeyed release with no unkeyed primer for its model fails closed on model_group", () => {
+    // A model whose plan has ONLY a keyed group: nothing an unkeyed release may
+    // bind to, so it must fail closed rather than be credited to the keyed primer.
+    const plan = makePlan(); // single keyed group, model-a, fp
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 1 }],
+      reviewerReleases: [{ model: "model-a", releasedAt: 5 }],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false, JSON.stringify(r.failures));
+    assert.ok(r.failures.some((f) => f.check === "model_group"));
+    assert.throws(() => enforcePrimerEvidence({ plan, evidence: ev }), /model_group/);
+  });
+
+  test("primer_order is order-independent (no first-match-by-array-order defect)", () => {
+    const plan = makePlan();
+    const land = [5, 20];
+    const release = { model: "model-a", requestPrefixFingerprint: fp, releasedAt: 10 }; // between the two primers
+    const a = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: land[0] },
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_DEDICATED, landedAt: land[1] },
+      ],
+      reviewerReleases: [release],
+    });
+    const b = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_DEDICATED, landedAt: land[1] },
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: land[0] },
+      ],
+      reviewerReleases: [release],
+    });
+    // The barrier must hold against the LAST-landed same-group primer (20), so a
+    // release at t=10 fails identically regardless of run array order — the old
+    // .find() first-match passed when landedAt:5 happened to come first.
+    assert.equal(validatePrimerEvidence({ plan, evidence: a }).ok, false);
+    assert.equal(validatePrimerEvidence({ plan, evidence: b }).ok, false);
+    assert.equal(validatePrimerEvidence({ plan, evidence: a }).failures.some((f) => f.check === "primer_order"),
+      validatePrimerEvidence({ plan, evidence: b }).failures.some((f) => f.check === "primer_order"));
+  });
+});

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -4,6 +4,7 @@ import test, { describe } from "node:test";
 import {
   PRIMER_EVIDENCE_SCHEMA_VERSION,
   buildPrimerEvidence,
+  enforcePrimerEvidence,
   primerEvidencePath,
   validatePrimerEvidence,
 } from "../src/loop/primer-evidence.mjs";
@@ -239,5 +240,30 @@ describe("validatePrimerEvidence — fail-closed fan-in gate (AC-3)", () => {
     const r = validatePrimerEvidence({ plan, evidence: ev });
     assert.equal(r.ok, true);
     assert.ok(ev.primerRuns.length === 2);
+  });
+});
+
+describe("enforcePrimerEvidence — strict fail-closed refusal surface (GATE-EXEC-PRIMER-EVIDENCE)", () => {
+  test("clean evidence resolves to true", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+    });
+    assert.equal(enforcePrimerEvidence({ plan, evidence: ev }), true);
+  });
+
+  test("invalid evidence throws a refusal naming the failing check", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 5 }], // before primer
+    });
+    assert.throws(
+      () => enforcePrimerEvidence({ plan, evidence: ev }),
+      /GATE-EXEC-PRIMER-EVIDENCE.*primer_order/,
+    );
   });
 });

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import {
+  PRIMER_EVIDENCE_SCHEMA_VERSION,
+  buildPrimerEvidence,
+  primerEvidencePath,
+  validatePrimerEvidence,
+} from "../src/loop/primer-evidence.mjs";
+import {
+  CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+  PRIMER_FORM_DEDICATED,
+  PRIMER_FORM_LEAD_REVIEWER,
+  buildReviewDispatchPlan,
+  partitionPrimerGroups,
+} from "../src/loop/review-dispatch-plan.mjs";
+
+const fp = "sha256:" + "a".repeat(64);
+const fp2 = "sha256:" + "b".repeat(64);
+
+function makePlan({ groups } = {}) {
+  return buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: "abcdef1234567890",
+    sharedPrefixHash: fp,
+    requestGroups: groups ?? [
+      { model: "model-a", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h", angles: ["correctness", "security"] },
+    ],
+    capabilities: { harness: "claude" },
+  });
+}
+
+describe("primerEvidencePath — deterministic artifact path (AC-1)", () => {
+  test("derives a stable, gate+head-scoped path under a given dir", () => {
+    const p = primerEvidencePath({ dir: "tmp/gate-context", gate: "pre_approval_gate", headSha: "abcdef1234567890" });
+    assert.match(p, /^tmp\/gate-context\/pre_approval_gate-abcdef1234567890\.primer-evidence\.json$/);
+    // Deterministic: same input -> same path.
+    assert.equal(
+      p,
+      primerEvidencePath({ dir: "tmp/gate-context", gate: "pre_approval_gate", headSha: "abcdef1234567890" }),
+    );
+  });
+
+  test("fails closed on missing gate/headSha", () => {
+    assert.throws(() => primerEvidencePath({ dir: "d", headSha: "abc" }));
+    assert.throws(() => primerEvidencePath({ dir: "d", gate: "g" }));
+  });
+});
+
+describe("buildPrimerEvidence — ordering evidence record (AC-1/AC-2)", () => {
+  test("records planHash, sharedPrefixHash, gate, headSha and primer runs", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 },
+      ],
+      reviewerReleases: [
+        { model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    assert.equal(ev.schemaVersion, PRIMER_EVIDENCE_SCHEMA_VERSION);
+    assert.equal(ev.gate, "pre_approval_gate");
+    assert.equal(ev.headSha, "abcdef1234567890");
+    assert.equal(ev.planHash, plan.planHash);
+    assert.equal(ev.sharedPrefixHash, fp);
+  });
+
+  test("two request groups resolving to different concrete models produce two primer runs, each scoped to its own model/prefix", () => {
+    const plan = makePlan({
+      groups: [
+        { model: "model-a", requestPrefixFingerprint: fp, angles: ["correctness"] },
+        { model: "model-b", requestPrefixFingerprint: fp2, angles: ["security"] },
+      ],
+    });
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_DEDICATED, landedAt: 5 },
+        { model: "model-b", requestPrefixFingerprint: fp2, primerForm: PRIMER_FORM_DEDICATED, landedAt: 6 },
+      ],
+      reviewerReleases: [
+        { model: "model-a", requestPrefixFingerprint: fp, releasedAt: 20 },
+        { model: "model-b", requestPrefixFingerprint: fp2, releasedAt: 21 },
+      ],
+      capabilities: { harness: "pi" },
+    });
+    assert.equal(ev.primerRuns.length, 2);
+    // Neither primer is credited to the other's group: model-a's run carries
+    // model-a's prefix, model-b's carries model-b's.
+    const a = ev.primerRuns.find((r) => r.model === "model-a");
+    const b = ev.primerRuns.find((r) => r.model === "model-b");
+    assert.equal(a.requestPrefixFingerprint, fp);
+    assert.equal(b.requestPrefixFingerprint, fp2);
+  });
+
+  test("fails closed when a run references a model not present in the plan's request groups", () => {
+    const plan = makePlan();
+    assert.throws(() =>
+      buildPrimerEvidence({
+        plan,
+        primerRuns: [{ model: "ghost", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_DEDICATED, landedAt: 5 }],
+        reviewerReleases: [],
+      }),
+    );
+  });
+});
+
+describe("validatePrimerEvidence — fail-closed fan-in gate (AC-3)", () => {
+  function validEvidence() {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+      capabilities: { harness: "claude" },
+    });
+    return { plan, ev };
+  }
+
+  test("clean evidence validates ok with no failures", () => {
+    const { plan, ev } = validEvidence();
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, true);
+    assert.equal(r.failures.length, 0);
+  });
+
+  test("fails closed (order) when a reviewer was released before its primer landed", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 5 }], // before primer landed 10
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "primer_order" && /before.*primer/.test(f.reason)));
+  });
+
+  test("fails closed (model group) when a reviewer is released under a model with no primer run", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [
+        { model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 },
+        { model: "model-a", requestPrefixFingerprint: "sha256:" + "c".repeat(64), releasedAt: 12 },
+      ],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "model_group"));
+  });
+
+  test("fails closed (request fingerprint) when a primer's prefix does not match the plan's group", () => {
+    const plan = makePlan();
+    // Validate the request_fingerprint branch with a hand-shaped evidence literal
+    // (build() already fails closed on the same condition, but the validator must
+    // also reject a hand-edited/legacy artifact that references an unknown prefix).
+    const raw = {
+      schemaVersion: 1,
+      gate: plan.gate,
+      headSha: plan.headSha,
+      planHash: plan.planHash,
+      sharedPrefixHash: plan.sharedPrefixHash,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: "sha256:" + "e".repeat(64), primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+    };
+    const r = validatePrimerEvidence({ plan, evidence: raw });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "request_fingerprint"));
+  });
+
+  test("fails closed (shared-prefix hash) when evidence sharedPrefixHash mismatches plan", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+    });
+    // Evidence built from the plan inherits the plan's hash; force a mismatch by
+    // re-deriving against a different shared prefix and overriding.
+    const mismatched = { ...ev, sharedPrefixHash: "sha256:" + "f".repeat(64) };
+    const r = validatePrimerEvidence({ plan, evidence: mismatched });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "shared_prefix_hash"));
+  });
+
+  test("fails closed when a request group from the plan has no primer run at all", () => {
+    const plan = makePlan({
+      groups: [
+        { model: "model-a", requestPrefixFingerprint: fp, angles: ["correctness"] },
+        { model: "model-b", requestPrefixFingerprint: fp2, angles: ["security"] },
+      ],
+    });
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_DEDICATED, landedAt: 5 },
+        // model-b has NO primer run -> group coverage failure
+      ],
+      reviewerReleases: [
+        { model: "model-a", requestPrefixFingerprint: fp, releasedAt: 20 },
+      ],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "group_coverage"));
+  });
+
+  test("partition-derived evidence from two models validates with two distinct primers (AC-2 end-to-end)", () => {
+    const plan = buildReviewDispatchPlan({
+      gate: "pre_approval_gate",
+      headSha: "abcdef1234567890",
+      sharedPrefixHash: fp,
+      requestGroups: [
+        { model: "model-a", requestPrefixFingerprint: fp, angles: ["correctness"] },
+        { model: "model-b", requestPrefixFingerprint: fp2, angles: ["security"] },
+      ],
+      capabilities: { harness: "pi" },
+    });
+    const partitions = partitionPrimerGroups(plan.requestGroups);
+    assert.equal(partitions.length, 2);
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: partitions.map((p, i) => ({
+        model: p.model,
+        requestPrefixFingerprint: p.requestPrefixFingerprint,
+        primerForm: p.primerForm,
+        landedAt: 10 + i,
+      })),
+      reviewerReleases: partitions.map((p, i) => ({
+        model: p.model,
+        requestPrefixFingerprint: p.requestPrefixFingerprint,
+        releasedAt: 100 + i,
+      })),
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, true);
+    assert.ok(ev.primerRuns.length === 2);
+  });
+});

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -267,3 +267,74 @@ describe("enforcePrimerEvidence — strict fail-closed refusal surface (GATE-EXE
     );
   });
 });
+
+describe("fingerprint-less request groups — stable per-model ordinal keying (unkeyed edge path)", () => {
+  // Regression for the unkeyed-key drift: buildPrimerEvidence keyed
+  // fingerprint-less runs by their ARRAY index while planGroupIndex keyed
+  // plan groups by their PLAN index, so a fingerprint-less run whose array
+  // position differed from its group's plan position threw a false
+  // "prefix not present" error; validatePrimerEvidence keyed them with no
+  // index at all. Both now use the same per-model ordinal scheme.
+  test("a fingerprint-less group + run validates clean (no false prefix error)", () => {
+    const plan = makePlan({
+      groups: [
+        {
+          model: "model-a",
+          requestPrefixFingerprint: null,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: ["correctness", "security"],
+        },
+        {
+          model: "model-b",
+          requestPrefixFingerprint: fp2,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: ["scope"],
+        },
+      ],
+    });
+    // The fingerprint-less run is at array index 1, the fingerprint-keyed
+    // run at index 0 — the wrong-order case that previously false-threw.
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        { model: "model-b", requestPrefixFingerprint: fp2, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 3 },
+        { model: "model-a", primerForm: PRIMER_FORM_DEDICATED, landedAt: 1 },
+      ],
+      reviewerReleases: [
+        { model: "model-a", releasedAt: 2 },
+        { model: "model-b", requestPrefixFingerprint: fp2, releasedAt: 4 },
+      ],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, true, JSON.stringify(r.failures));
+    assert.equal(enforcePrimerEvidence({ plan, evidence: ev }), true);
+  });
+
+  test("a fingerprint-less group with no primer run fails closed on group_coverage", () => {
+    const plan = makePlan({
+      groups: [
+        {
+          model: "model-a",
+          requestPrefixFingerprint: null,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: ["correctness", "security"],
+        },
+      ],
+    });
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [],
+      reviewerReleases: [{ model: "model-a", releasedAt: 5 }],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "group_coverage"));
+    assert.throws(
+      () => enforcePrimerEvidence({ plan, evidence: ev }),
+      /group_coverage/,
+    );
+  });
+});

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -338,3 +338,52 @@ describe("fingerprint-less request groups — stable per-model ordinal keying (u
     );
   });
 });
+
+describe("draft-gate hardening of validatePrimerEvidence (fan-in converge findings)", () => {
+  test("shared_prefix_hash passes when BOTH plan and evidence omit a shared prefix (no false-positive)", () => {
+    const plan = buildReviewDispatchPlan({
+      gate: "pre_approval_gate",
+      headSha: "abcdef1234567890",
+      // deliberately NO sharedPrefixHash
+      requestGroups: [
+        { model: "model-a", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h", angles: ["scope"] },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    assert.equal(plan.sharedPrefixHash == null, true); // buildReviewDispatchPlan omits the key when absent
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, true, JSON.stringify(r.failures));
+  });
+
+  test("plan_hash fails closed when evidence planHash is missing (tampered/truncated evidence)", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: 11 }],
+    });
+    const stripped = { ...ev, planHash: null };
+    const r = validatePrimerEvidence({ plan, evidence: stripped });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "plan_hash"));
+    assert.throws(() => enforcePrimerEvidence({ plan, evidence: stripped }), /plan_hash/);
+  });
+
+  test("primer_order fails closed when release/landed timestamps are missing (barrier unprovable)", () => {
+    const plan = makePlan();
+    const ev = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", requestPrefixFingerprint: fp, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+      reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: fp, releasedAt: null }],
+    });
+    const r = validatePrimerEvidence({ plan, evidence: ev });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "primer_order"));
+    assert.throws(() => enforcePrimerEvidence({ plan, evidence: ev }), /primer_order/);
+  });
+});

--- a/packages/core/test/primer-evidence.test.mjs
+++ b/packages/core/test/primer-evidence.test.mjs
@@ -337,6 +337,46 @@ describe("fingerprint-less request groups — stable per-model ordinal keying (u
       /group_coverage/,
     );
   });
+
+  test("an extra fingerprint-less primer run with no matching plan group fails closed (inverse unkeyed binding)", () => {
+    // The plan has only ONE fingerprint-less group for model-a, so a second
+    // fingerprint-less run (same model, higher ordinal) is a run the plan never
+    // requested — it must fail closed via the inverse unkeyed binding, closing
+    // the gap where a hand-edited/legacy evidence file could carry extra unkeyed
+    // runs and still validate.
+    const plan = makePlan({
+      groups: [
+        {
+          model: "model-a",
+          requestPrefixFingerprint: null,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: ["correctness", "security"],
+        },
+      ],
+    });
+    // Build the evidence via buildPrimerEvidence (single run) then append a
+    // second unkeyed run directly, simulating a tampered evidence artifact.
+    const base = buildPrimerEvidence({
+      plan,
+      primerRuns: [{ model: "model-a", primerForm: PRIMER_FORM_DEDICATED, landedAt: 1 }],
+      reviewerReleases: [{ model: "model-a", releasedAt: 2 }],
+    });
+    const tampered = {
+      ...base,
+      primerRuns: [
+        ...base.primerRuns,
+        Object.freeze({ model: "model-a", requestPrefixFingerprint: null, primerForm: PRIMER_FORM_DEDICATED, landedAt: 3 }),
+      ],
+    };
+    const r = validatePrimerEvidence({ plan, evidence: tampered });
+    assert.equal(r.ok, false, JSON.stringify(r.failures));
+    assert.ok(r.failures.some((f) => f.check === "request_group_unkeyed"));
+    assert.throws(
+      () => enforcePrimerEvidence({ plan, evidence: tampered }),
+      /request_group_unkeyed/,
+    );
+  });
 });
 
 describe("draft-gate hardening of validatePrimerEvidence (fan-in converge findings)", () => {

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -63,6 +63,7 @@ import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixe
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
 import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, normalizeSeverity, severityRank, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
+import { enforcePrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 
 const USAGE = `Usage: consolidate-fanin.mjs --findings-dir <dir> [--head-sha <sha>] [--gate <draft_gate|pre_approval_gate>] [--out <path>] [--ledger-out <path>] [--pr-checklist-matrix clean] [--carried-angles <json> --carry-forward-plan <json>] [--repo-root <path>] [--expected-dispatch-units <n>] [--tmp-root <path>]
 Consolidate the per-angle *.json findings artifacts a gate-review fan-out wrote into
@@ -176,6 +177,18 @@ Optional:
                                  GROUP reviewer, so this is the dispatch-UNIT count, NOT the per-angle
                                  artifact count — comparing against the angle count would false-fail
                                  every grouped round.
+  --primer-evidence <path>       The recorded primer-dispatch ordering evidence artifact
+                                 (<gate>-<headSha>.primer-evidence.json, Phase 1.5 step 4) as JSON.
+                                 Must be paired with --primer-plan (either flag alone fails closed at
+                                 parse time). When both are given, the fan-in re-validates the
+                                 evidence against the dispatch plan via enforcePrimerEvidence
+                                 (GATE-EXEC-PRIMER-EVIDENCE) and FAILS CLOSED (exit 1) when the
+                                 ordering barrier, request-group coverage, model-group binding,
+                                 request-prefix fingerprint, shared-prefix hash, or plan hash is
+                                 missing or mismatched — the refusal names the failing check.
+  --primer-plan <path>           The dispatch plan (buildReviewDispatchPlan output, carrying its
+                                 requestGroups / planHash / sharedPrefixHash) the evidence was
+                                 derived from, as JSON. Required together with --primer-evidence.
   --tmp-root <path>              The tmp/ directory holding the reviewer sentinels and per-gate briefing-prefix
                                  records read by the briefing-prefix verification (default:
                                  process.cwd()/tmp). Sentinels are read directly from this directory
@@ -559,6 +572,8 @@ export function parseConsolidateFaninCliArgs(argv) {
     carryForwardPlan: undefined,
     repoRoot: undefined,
     expectedDispatchUnits: undefined,
+    primerEvidence: undefined,
+    primerPlan: undefined,
     tmpRoot: undefined,
   };
   const { tokens } = parseArgs({
@@ -575,6 +590,8 @@ export function parseConsolidateFaninCliArgs(argv) {
       "carry-forward-plan": { type: "string" },
       "repo-root": { type: "string" },
       "expected-dispatch-units": { type: "string" },
+      "primer-evidence": { type: "string" },
+      "primer-plan": { type: "string" },
       "tmp-root": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
@@ -687,11 +704,36 @@ export function parseConsolidateFaninCliArgs(argv) {
       options.tmpRoot = tmpRoot;
       continue;
     }
+    if (token.name === "primer-evidence") {
+      const p = requireTokenValue(token, parseError).trim();
+      if (p.length === 0) {
+        throw parseError("--primer-evidence requires a non-empty path");
+      }
+      options.primerEvidence = p;
+      continue;
+    }
+    if (token.name === "primer-plan") {
+      const p = requireTokenValue(token, parseError).trim();
+      if (p.length === 0) {
+        throw parseError("--primer-plan requires a non-empty path");
+      }
+      options.primerPlan = p;
+      continue;
+    }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
     throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (!options.findingsDir) {
     throw parseError("Missing required argument: --findings-dir <dir>");
+  }
+  // Primer-evidence enforcement only makes sense when BOTH the recorded
+  // evidence artifact (Phase 1.5 step 4) and the dispatch plan it was derived
+  // from are present — enforcePrimerEvidence needs the plan's request groups
+  // and hashes to check the evidence against. Either alone fails closed here,
+  // so a caller can never half-enable the gate (a plan with no evidence to
+  // check, or evidence with no plan to validate it against).
+  if ((options.primerEvidence === undefined) !== (options.primerPlan === undefined)) {
+    throw parseError("--primer-evidence and --primer-plan must be given together: a primer-evidence artifact cannot be enforced against no plan, and a plan without its recorded evidence would silently skip the gate");
   }
   // --carried-angles is proof-carrying, not a bare trust-me list (high-severity
   // regression: a mandatory angle or a fabricated name could otherwise mint a
@@ -955,6 +997,43 @@ export async function consolidateGateFanin(options) {
     if (options.expectedDispatchUnits !== undefined && prefixVerdict.reviewerCount > 0
         && prefixVerdict.reviewerCount < options.expectedDispatchUnits) {
       throw new Error(`GATE-EXEC-BRIEFING-PREFIX sentinel count (${prefixVerdict.reviewerCount}) is short of the expected dispatch-unit count (${options.expectedDispatchUnits}) for head ${options.headSha} — ${options.expectedDispatchUnits - prefixVerdict.reviewerCount} dispatched reviewer(s) never ran the fresh-context guard (no sentinel written). Re-run the missing reviewer(s), then re-consolidate.`);
+    }
+  }
+
+  // GATE-EXEC-PRIMER-EVIDENCE (#1475): the fan-in enforcing primer-dispatch
+  // ordering evidence as a real fail-closed input to consolidation. The
+  // primer-evidence artifact (Phase 1.5 step 4, `<gate>-<headSha>`
+  // `.primer-evidence.json`) and the dispatch plan it was derived from are
+  // passed in TOGETHER (parse-time both-or-neither); when present the fan-in
+  // re-validates them via enforcePrimerEvidence and FAILS CLOSED (this throw
+  // -> exit 1) when the ordering barrier, request-group coverage, model-group
+  // binding, request-prefix fingerprint, shared-prefix hash, or plan hash is
+  // missing or mismatched — the refusal names the failing check. Absent both
+  // flags the fan-in proceeds unchanged: recording evidence is progressive /
+  // optional, so rounds that never recorded it (all pre-slice-3 rounds) are
+  // not newly blocked. This is the wiring that gives GATE-EXEC-PRIMER-EVIDENCE
+  // a real invocation site (previously it was dead code referenced only by its
+  // own error-message string).
+  if (options.primerEvidence !== undefined && options.primerPlan !== undefined) {
+    const readJson = async (filePath, label) => {
+      let text;
+      try {
+        text = await readFile(filePath, "utf8");
+      } catch (err) {
+        throw new Error(`--primer-${label} "${filePath}" could not be read: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`--primer-${label} "${filePath}" is not valid JSON`);
+      }
+    };
+    const evidence = await readJson(options.primerEvidence, "evidence");
+    const plan = await readJson(options.primerPlan, "plan");
+    try {
+      enforcePrimerEvidence({ plan, evidence });
+    } catch (err) {
+      throw new Error(err instanceof Error ? err.message : String(err));
     }
   }
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -270,7 +270,15 @@ per-gate accounting is an optional follow-up, not a precondition.)
    write-before-reads ordering. The completion fallback fully serializes the lead reviewer
    ahead of the rest — a small, bounded latency cost, and the reason the near-free
    one-reviewer form is still the default rather than a mandatory streaming dependency.
-4. **Release the fan-out over the SAME model and the SAME byte-identical prefix**, so each
+4. **Record ordering evidence** — write the primer-dispatch evidence artifact (issue
+   #1468 slice 3) to the deterministic path `<gate>-<headSha>.primer-evidence.json`
+   beside the gate-context artifacts: `@dev-loops/core/loop/primer-evidence`
+   (`primerEvidencePath` / `buildPrimerEvidence` / `writePrimerEvidence`). The artifact
+   pairs the request plan with the observed primer runs and reviewer releases, binding
+   each primer to its own model + request-prefix fingerprint and each released reviewer
+   to a primer that landed before it. This is what lets fan-in fail closed (see
+   Phase 3 — Consolidation) instead of trusting the rule in prose.
+5. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
    reviewer READS the cache the primer wrote instead of racing to write its own. A
    differing model or prefix defeats reuse and is the same failure the byte-identity rule
    already guards against.
@@ -707,6 +715,19 @@ would overcount; NOT `fanout.wavePlan.length`, which is the WAVE count, typicall
 the dispatch-unit count; groups for grouped dispatch, angle count for per-angle
 dispatch; NOT the per-angle artifact count, which would false-fail every grouped
 round).
+
+<!-- rule: GATE-EXEC-PRIMER-EVIDENCE -->
+`GATE-EXEC-PRIMER-EVIDENCE`: when the round recorded primer-dispatch ordering
+evidence (Phase 1.5 step 4, `<gate>-<headSha>.primer-evidence.json`), fan-in MUST
+validate it against the request plan via `@dev-loops/core/loop/primer-evidence`
+`validatePrimerEvidence` and fail closed — refusing to proceed to consolidation —
+when the evidence is missing, or when the ordering barrier, request-group
+coverage, model-group binding, request-prefix fingerprint, shared-prefix hash, or
+plan hash is missing or mismatched. The refusal names the failing check
+(`primer_order` / `group_coverage` / `model_group` / `request_fingerprint` /
+`shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
+barrier: the primer write-before-read ordering is no longer asserted only in
+prose, but is a mechanically-checkable fail-closed input to consolidation.
 
 Merge the parallel reviewer findings into one consolidated fix plan with the
 sanctioned fan-in CLI:

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -275,6 +275,11 @@
       "enforcement": "runtime"
     },
     {
+      "id": "GATE-EXEC-PRIMER-EVIDENCE",
+      "enforcement": "runtime",
+      "enforcementNote": "fan-in validates the recorded primer dispatch evidence via packages/core/src/loop/primer-evidence.mjs validatePrimerEvidence"
+    },
+    {
       "id": "GATE-EXEC-REGATE-MANDATORY"
     },
     {

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -12,6 +12,8 @@ import {
 import { writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
 import { normalizeStructuredFindings, renderGateReviewCommentBody } from "../../scripts/github/upsert-checkpoint-verdict.mjs";
 import { checkFanoutAngleCoverage } from "@dev-loops/core/loop/gate-fanin";
+import { buildPrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
+import { buildReviewDispatchPlan, CACHE_BOUNDARY_AFTER_SHARED_PREFIX, PRIMER_FORM_LEAD_REVIEWER } from "@dev-loops/core/loop/review-dispatch-plan";
 import { runNode } from "../_helpers.mjs";
 
 // #1592: several fixtures below deliberately keep pre-rename severity
@@ -522,6 +524,153 @@ test("a finding's oversized file reference is truncated with a plain ellipsis su
 });
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// GATE-EXEC-PRIMER-EVIDENCE wiring (#1475): the fan-in enforces the recorded
+// primer-dispatch evidence against the dispatch plan via enforcePrimerEvidence,
+// failing closed on missing/mismatched evidence — and proceeds unchanged when
+// neither flag is given (progressive/optional recording).
+// ---------------------------------------------------------------------------
+
+const PRIMER_FP = "sha256:" + "a".repeat(64);
+const PRIMER_HEAD = "0123456789abcdef0123456789abcdef01234567";
+
+function makePrimerPlanAndEvidence() {
+  const plan = buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: PRIMER_HEAD,
+    sharedPrefixPath: "/tmp/shared.md",
+    sharedPrefixHash: PRIMER_FP,
+    requestGroups: [
+      {
+        model: "model-a",
+        requestPrefixFingerprint: PRIMER_FP,
+        cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+        ttlIntent: "1h",
+        angles: ["scope", "dry"],
+      },
+    ],
+    capabilities: { harness: "claude" },
+  });
+  const evidence = buildPrimerEvidence({
+    plan,
+    primerRuns: [{ model: "model-a", requestPrefixFingerprint: PRIMER_FP, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+    reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: PRIMER_FP, releasedAt: 11 }],
+  });
+  return { plan, evidence };
+}
+
+async function withPrimerFiles(files, fn) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "primer-evidence-"));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      await writeFile(path.join(dir, name), typeof content === "string" ? content : JSON.stringify(content), "utf8");
+    }
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("consolidateGateFanin enforces valid primer evidence and consolidates (GATE-EXEC-PRIMER-EVIDENCE)", async () => {
+  const { plan, evidence } = makePrimerPlanAndEvidence();
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withPrimerFiles(
+        { "primer-evidence.json": evidence, "primer-plan.json": plan },
+        async (pdir) => {
+          const result = await consolidateGateFanin({
+            findingsDir: dir,
+            primerEvidence: path.join(pdir, "primer-evidence.json"),
+            primerPlan: path.join(pdir, "primer-plan.json"),
+          });
+          assert.equal(result.ok, true);
+          assert.equal(result.overallVerdict, "clean");
+          assert.equal(result.angles.length, 1);
+        },
+      );
+    },
+  );
+});
+
+test("consolidateGateFanin fails closed when primer evidence violates the ordering barrier", async () => {
+  const { plan } = makePrimerPlanAndEvidence();
+  // Violation: the reviewer release at t=5 lands BEFORE its primer at t=10.
+  const violation = buildPrimerEvidence({
+    plan,
+    primerRuns: [{ model: "model-a", requestPrefixFingerprint: PRIMER_FP, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 10 }],
+    reviewerReleases: [{ model: "model-a", requestPrefixFingerprint: PRIMER_FP, releasedAt: 5 }],
+  });
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withPrimerFiles(
+        { "primer-evidence.json": violation, "primer-plan.json": plan },
+        async (pdir) => {
+          await assert.rejects(
+            consolidateGateFanin({
+              findingsDir: dir,
+              primerEvidence: path.join(pdir, "primer-evidence.json"),
+              primerPlan: path.join(pdir, "primer-plan.json"),
+            }),
+            (err) => err.message.includes("GATE-EXEC-PRIMER-EVIDENCE") && err.message.includes("primer_order"),
+          );
+        },
+      );
+    },
+  );
+});
+
+test("consolidateGateFanin fails closed when primer evidence references a plan it did not come from", async () => {
+  const { evidence } = makePrimerPlanAndEvidence();
+  // A DIFFERENT plan (different request group model) than the evidence was
+  // built from: the plan-hash / shared-prefix bindings no longer match.
+  const otherPlan = buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: PRIMER_HEAD,
+    sharedPrefixPath: "/tmp/shared.md",
+    requestGroups: [
+      {
+        model: "model-c",
+        requestPrefixFingerprint: "sha256:" + "c".repeat(64),
+        cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+        ttlIntent: "1h",
+        angles: ["scope"],
+      },
+    ],
+    capabilities: { harness: "claude" },
+  });
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withPrimerFiles(
+        { "primer-evidence.json": evidence, "primer-plan.json": otherPlan },
+        async (pdir) => {
+          await assert.rejects(
+            consolidateGateFanin({
+              findingsDir: dir,
+              primerEvidence: path.join(pdir, "primer-evidence.json"),
+              primerPlan: path.join(pdir, "primer-plan.json"),
+            }),
+            (err) => err.message.includes("GATE-EXEC-PRIMER-EVIDENCE") && err.message.includes("shared_prefix_hash"),
+          );
+        },
+      );
+    },
+  );
+});
+
+test("parseConsolidateFaninCliArgs rejects --primer-evidence without --primer-plan (and vice versa)", () => {
+  assert.throws(
+    () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--primer-evidence", "/tmp/e.json"]),
+    /--primer-evidence and --primer-plan must be given together/,
+  );
+  assert.throws(
+    () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--primer-plan", "/tmp/p.json"]),
+    /--primer-evidence and --primer-plan must be given together/,
+  );
+});
+
 // pr-checklist-matrix mandatory-angle upsert
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1475

## Summary

Slice 3 of #1468 (cache-aware review dispatch). Slice 1-2 (`review-dispatch-plan.mjs`) already produced
the deterministic request plan, request-prefix fingerprints, stable/volatile separation, and per-model
primer-group partitioning. This slice closes the gap between "the rules say prime before fan-out"
and "we can assert it happened":

- New pure module `@dev-loops/core/loop/primer-evidence`:
  - `primerEvidencePath` — deterministic `<gate>-<headSha>.primer-evidence.json` artifact path
  - `buildPrimerEvidence` — pairs the request plan with observed primer runs + reviewer releases
  - `validatePrimerEvidence` — fail-closed fan-in check naming the failing guard
  - `enforcePrimerEvidence` — strict refusal surface that throws (naming the check) on invalid evidence
  - `writePrimerEvidence` — persists to the deterministic path
- **Fan-in wiring (the slice gap, now closed):** `scripts/loop/consolidate-fanin.mjs` (the sanctioned fan-in
  CLI) now takes `--primer-evidence` + `--primer-plan` (both-or-neither) and calls `enforcePrimerEvidence`
  before consolidation, FAILING CLOSED (exit 1) when the recorded evidence violates the ordering barrier,
  request-group coverage, model-group binding, request-prefix fingerprint, shared-prefix hash, or plan
  hash. Previously the enforcement surface was dead code (zero invocation sites) referenced only by its
  own error-message string; it is now a real, test-covered fail-closed input to consolidation. Recording
  remains progressive/optional — rounds that never recorded evidence are unaffected (no regression to
  pre-slice-3 rounds).
- Consistency fix for fingerprint-less request groups: build and validate now share one per-model ordinal
  keying scheme (`__unkeyed:<n>`), closing the previous drift where a fingerprint-less primer run whose
  array position differed from its group's plan position threw a false "prefix not present" error.
- Contract docs (`skills/docs/gate-review-sub-loop-contract.md` + regenerated `.claude` mirror):
  - Phase 1.5 step 4 now records primer-dispatch ordering evidence
  - Phase 3 adds `GATE-EXEC-PRIMER-EVIDENCE`: fan-in validates the recorded evidence and fails closed
    when the ordering barrier, group coverage, model-group binding, request-prefix fingerprint,
    shared-prefix hash, or plan hash is missing/mismatched — naming the check.

## Scope

Positive scope boundary of slice 3 (what this PR delivers):
- the pure primer-evidence module (build / validate / enforce / persist),
- the fan-in enforcement wiring in `consolidate-fanin.mjs` (`--primer-evidence` + `--primer-plan`),
- the fingerprint-less group keying consistency fix,
- the contract/rule documentation (`GATE-EXEC-PRIMER-EVIDENCE`) and its mirror.

Out of scope (see Non-goals): no claim of provider cache reuse from artifact hashes alone; no
conversation sharing; no weakening of one-reviewer-per-fresh-angle provenance; no gate-verdict or
angle semantics change.

## Acceptance criteria

- AC-1 ordering evidence at deterministic artifact path — `primerEvidencePath` / `buildPrimerEvidence`
- AC-2 per-request-group primer, no cross-credit — two-model test + partition-derived end-to-end test
- AC-3 fan-in fails closed with a named reason — `enforcePrimerEvidence` wired into the fan-in CLI and
  `validatePrimerEvidence` guards (`primer_order` / `group_coverage` / `model_group` /
  `request_fingerprint` / `shared_prefix_hash` / `plan_hash`)
- AC-4 completion-only -> short dedicated primer — already shipped in `resolvePrimerForm` (slice 1-2), unchanged
- AC-5 `GATE-EXEC-PRIME` one-reviewer-as-primer default unchanged — slice adds evidence only

## Definition of Done

- [x] Slice-3 code implemented and the fan-in enforcement wired (real invocation site, not dead code)
- [x] Tests added: fingerprint-less group coverage + the fan-in wiring (valid evidence consolidates;
      ordering / plan-hash violations fail closed; both-or-neither parse guard)
- [x] Cross-harness non-regression (#1086): fan-in proceeds unchanged when no evidence is provided; all
      pre-existing fan-in and primer-evidence behaviors preserved
- [x] Local validation green (see Validation)
- [x] Review gate: clean draft_gate + pre_approval_gate verdict at the final head

## Validation

- `npm run test:core` — 2514 pass (incl. new fingerprint-less + enforcement tests)
- `npm run test:scripts` — 3896 pass, 36 skip (incl. new fan-in wiring tests)
- `npm run test:doc-guard` — 269 pass
- `npm run test:docs` — links OK; rule ownership passed (17 enforced, incl. GATE-EXEC-PRIMER-EVIDENCE with a real call site)
- `npm run test:assets` — 274 pass
- `generate-claude-assets.mjs --check` — ok (94 checked)
- `schema:check` — up to date

## Non-goals (honored)

No claim of provider cache reuse from artifact hashes alone; no conversation sharing across angles
or rounds; no weakening of one-reviewer-per-fresh-angle provenance; no gate-verdict or angle
semantics change.
