### PR TITLE
feat(gate): cache telemetry adapter + before/after cache-state evidence artifact (#1476)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -742,16 +742,20 @@ barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
 
 <!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
-`GATE-EXEC-CACHE-TELEMETRY`: cache-telemetry evidence (Phase 1.5 step 5,
-`<gate>-<headSha>.cache-telemetry.json`) MUST be validated via
-`@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
+`GATE-EXEC-CACHE-TELEMETRY`: when a round records cache-telemetry evidence
+(Phase 1.5 step 5, `<gate>-<headSha>.cache-telemetry.json`) it MUST be validated
+via `@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
 and fail closed — refusing to proceed to consolidation — when the artifact is
-missing, when verified provider reuse is claimed for a harness whose usage
+missing/malformed, when verified provider reuse is claimed for a harness whose usage
 telemetry is unavailable/opaque (`opaque_veracity`), when verified reuse lacks a
 measured create-then-read sequence (`measured_sequence`), or when the aggregate
 /token report contradicts the recorded events (`aggregate_consistency` /
 `token_aggregate`) or the capability record is missing
-(`capability_record`). This enforces the Section D honesty invariant: a harness
+(`capability_record`). Recording telemetry is progressive/optional: a round that
+never records an artifact (e.g. a pre-slice-4 round, or one run with `--cache-telemetry`
+omitted) is not newly blocked — the fail-closed path engages ONLY when the artifact
+is supplied (the `--cache-telemetry` flag), so a supplied-but-invalid artifact never
+passes. This enforces the Section D honesty invariant: a harness
 whose cache reuse is not measurable must never be reported as a verified `1
 write + N reads` result.
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -278,7 +278,19 @@ per-gate accounting is an optional follow-up, not a precondition.)
    each primer to its own model + request-prefix fingerprint and each released reviewer
    to a primer that landed before it. This is what lets fan-in fail closed (see
    Phase 3 — Consolidation) instead of trusting the rule in prose.
-5. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
+5. **Record before/after cache-telemetry evidence** — where the harness exposes
+   cache usage telemetry (issue #1468 slice 4), record the cache-creation
+   (“before”) and cache-read (“after”) events to the deterministic path
+   `<gate>-<headSha>.cache-telemetry.json` beside the gate-context artifacts:
+   `@dev-loops/core/loop/cache-telemetry-evidence` (`cacheTelemetryPath` /
+   `buildCacheTelemetryEvidence` / `writeCacheTelemetryEvidence`). The artifact
+   pairs the request plan + capability record with the observed creation/read
+   events and an aggregate read:create report. Where the harness is opaque or
+   telemetry is unavailable, the same builder records `cacheReuseVerified:
+   false` with the reason and MUST NOT be described as a verified `1 write + N
+   reads` outcome — only the ordering + request-fingerprint invariants from
+   steps 3-4 may be claimed (Section D honesty gate).
+6. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
    reviewer READS the cache the primer wrote instead of racing to write its own. A
    differing model or prefix defeats reuse and is the same failure the byte-identity rule
    already guards against.
@@ -728,6 +740,20 @@ plan hash is missing or mismatched. The refusal names the failing check
 `shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
 barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
+
+<!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
+`GATE-EXEC-CACHE-TELEMETRY`: cache-telemetry evidence (Phase 1.5 step 5,
+`<gate>-<headSha>.cache-telemetry.json`) MUST be validated via
+`@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
+and fail closed — refusing to proceed to consolidation — when the artifact is
+missing, when verified provider reuse is claimed for a harness whose usage
+telemetry is unavailable/opaque (`opaque_veracity`), when verified reuse lacks a
+measured create-then-read sequence (`measured_sequence`), or when the aggregate
+/token report contradicts the recorded events (`aggregate_consistency` /
+`token_aggregate`) or the capability record is missing
+(`capability_record`). This enforces the Section D honesty invariant: a harness
+whose cache reuse is not measurable must never be reported as a verified `1
+write + N reads` result.
 
 Merge the parallel reviewer findings into one consolidated fix plan with the
 sanctioned fan-in CLI:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "./loop/queue-membership": "./src/loop/queue-membership.mjs",
     "./loop/queue-parallel": "./src/loop/queue-parallel.mjs",
     "./loop/queue-state": "./src/loop/queue-state.mjs",
+    "./loop/cache-telemetry-evidence": "./src/loop/cache-telemetry-evidence.mjs",
     "./loop/primer-evidence": "./src/loop/primer-evidence.mjs",
     "./loop/review-dispatch-plan": "./src/loop/review-dispatch-plan.mjs",
     "./loop/reviewer-loop-state": "./src/loop/reviewer-loop-state.mjs",

--- a/packages/core/src/loop/cache-telemetry-evidence.mjs
+++ b/packages/core/src/loop/cache-telemetry-evidence.mjs
@@ -99,6 +99,15 @@ export function buildCacheTelemetryEvidence({
   if (!plan || typeof plan !== "object" || !Array.isArray(plan.requestGroups)) {
     throw new Error("buildCacheTelemetryEvidence requires a plan with requestGroups");
   }
+  if (typeof plan.gate !== "string" || plan.gate.length === 0) {
+    throw new Error("buildCacheTelemetryEvidence requires a plan with a non-empty gate");
+  }
+  if (typeof plan.headSha !== "string" || !/^[0-9a-f]{7,64}$/i.test(plan.headSha.trim())) {
+    throw new Error("buildCacheTelemetryEvidence requires a plan with a hex headSha");
+  }
+  if (typeof plan.planHash !== "string" || plan.planHash.length === 0) {
+    throw new Error("buildCacheTelemetryEvidence requires a plan with a non-empty planHash");
+  }
   if (!Array.isArray(primerCacheCreations)) throw new Error("primerCacheCreations must be an array");
   if (!Array.isArray(reviewerCacheReads)) throw new Error("reviewerCacheReads must be an array");
 
@@ -236,6 +245,24 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
     });
   }
 
+  // Events fields must be arrays (a malformed JSON artifact with a non-array
+  // events field would otherwise make sumTokens/countTokens below throw a raw
+  // TypeError instead of a structured fail-closed failure). Downstream the
+  // enforce call re-throws as GATE-EXEC-CACHE-TELEMETRY, but the validator's
+  // documented contract is "return failures, never throw".
+  if (!Array.isArray(evidence.primerCacheCreations)) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `primerCacheCreations must be an array, got ${JSON.stringify(evidence.primerCacheCreations)}`,
+    });
+  }
+  if (!Array.isArray(evidence.reviewerCacheReads)) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `reviewerCacheReads must be an array, got ${JSON.stringify(evidence.reviewerCacheReads)}`,
+    });
+  }
+
   // Honesty gate: verified reuse requires the capability record's usage
   // telemetry to be available. The verdict is re-derived from
   // evidence.capabilities.usageTelemetry — NOT from the stored
@@ -301,6 +328,19 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
   // aggregate that contradicts the evidence fails closed.
   const record = { creates: evidence.creationCount, reads: evidence.readCount };
   const expectedRatio = record.creates > 0 ? record.reads / record.creates : 0;
+  // The human-readable report must agree with the machine verdict: a verified
+  // report only when cacheReuseVerified is true, a could-not-verify report
+  // otherwise. This closes the over-claim surface where a hand-edited artifact
+  // keeps the numeric aggregates consistent (measured:false) while the report
+  // prose claims "verified N reads after M creations" (informational, not a
+  // gate-number bypass, but the human-facing surface must not contradict it).
+  const expectedReportVerified = /^verified .+ cache read/.test(evidence.aggregate?.report ?? "");
+  if (expectedReportVerified !== evidence.cacheReuseVerified) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `aggregate.report prose (${JSON.stringify(evidence.aggregate?.report)}) contradicts cacheReuseVerified=${evidence.cacheReuseVerified}`,
+    });
+  }
   if (
     evidence.aggregate?.creates !== evidence.creationCount ||
     evidence.aggregate?.reads !== evidence.readCount ||

--- a/packages/core/src/loop/cache-telemetry-evidence.mjs
+++ b/packages/core/src/loop/cache-telemetry-evidence.mjs
@@ -59,15 +59,18 @@ export function cacheTelemetryPath({ dir, gate, headSha } = {}) {
   return path.join(dir, `${gate}-${headSha.trim().toLowerCase()}.cache-telemetry.json`);
 }
 
-/** Count of entries whose `tokens` is a finite non-negative number. */
+/** Count of entries whose `tokens` is a finite non-negative number. Non-object/null entries are skipped so a malformed artifact element can never throw. */
 function countTokens(entries) {
-  return entries.filter((e) => Number.isFinite(e.tokens) && e.tokens >= 0).length;
+  return entries.filter(
+    (e) => e != null && typeof e === "object" && Number.isFinite(e.tokens) && e.tokens >= 0,
+  ).length;
 }
 
-/** Sum of finite non-negative `tokens` across entries. */
+/** Sum of finite non-negative `tokens` across entries. Non-object/null entries are skipped. */
 function sumTokens(entries) {
   return entries.reduce((acc, e) => {
-    const t = Number.isFinite(e.tokens) && e.tokens >= 0 ? e.tokens : 0;
+    const t =
+      e != null && typeof e === "object" && Number.isFinite(e.tokens) && e.tokens >= 0 ? e.tokens : 0;
     return acc + t;
   }, 0);
 }
@@ -262,6 +265,16 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
       reason: `reviewerCacheReads must be an array, got ${JSON.stringify(evidence.reviewerCacheReads)}`,
     });
   }
+  // Safe, array-only view of the events fields for every downstream consumer
+  // (length/sum/count checks). A truthy non-array field never reaches
+  // sumTokens/countTokens (`.reduce`/`.filter` would throw on it) and its
+  // `.length` is never read (a string would report its char count): the
+  // validator keeps its documented "return failures, never throw" contract
+  // even for an malformed artifact whose events field is a string/object/number.
+  const creations = Array.isArray(evidence.primerCacheCreations)
+    ? evidence.primerCacheCreations
+    : [];
+  const reads = Array.isArray(evidence.reviewerCacheReads) ? evidence.reviewerCacheReads : [];
 
   // Honesty gate: verified reuse requires the capability record's usage
   // telemetry to be available. The verdict is re-derived from
@@ -293,28 +306,28 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
   }
 
   // Self-consistency of the aggregate report against the recorded events.
-  if (evidence.creationCount !== (evidence.primerCacheCreations?.length ?? 0)) {
+  if (evidence.creationCount !== creations.length) {
     failures.push({
       check: "aggregate_consistency",
-      reason: `creationCount ${evidence.creationCount} != recorded primerCacheCreations.length ${evidence.primerCacheCreations?.length ?? 0}`,
+      reason: `creationCount ${evidence.creationCount} != recorded primerCacheCreations.length ${creations.length}`,
     });
   }
-  if (evidence.readCount !== (evidence.reviewerCacheReads?.length ?? 0)) {
+  if (evidence.readCount !== reads.length) {
     failures.push({
       check: "aggregate_consistency",
-      reason: `readCount ${evidence.readCount} != recorded reviewerCacheReads.length ${evidence.reviewerCacheReads?.length ?? 0}`,
+      reason: `readCount ${evidence.readCount} != recorded reviewerCacheReads.length ${reads.length}`,
     });
   }
 
   // Token aggregates must equal the sum over finite event tokens.
-  const expectedCreationTokens = sumTokens(evidence.primerCacheCreations ?? []);
+  const expectedCreationTokens = sumTokens(creations);
   if (evidence.creationTokens !== expectedCreationTokens) {
     failures.push({
       check: "token_aggregate",
       reason: `creationTokens ${evidence.creationTokens} != sum of primer creations ${expectedCreationTokens}`,
     });
   }
-  const expectedReadTokens = sumTokens(evidence.reviewerCacheReads ?? []);
+  const expectedReadTokens = sumTokens(reads);
   if (evidence.readTokens !== expectedReadTokens) {
     failures.push({
       check: "token_aggregate",
@@ -345,13 +358,13 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
     evidence.aggregate?.creates !== evidence.creationCount ||
     evidence.aggregate?.reads !== evidence.readCount ||
     evidence.aggregate?.readToCreateRatio !== expectedRatio ||
-    evidence.aggregate?.creationsWithTokens !== countTokens(evidence.primerCacheCreations ?? []) ||
-    evidence.aggregate?.readsWithTokens !== countTokens(evidence.reviewerCacheReads ?? []) ||
+    evidence.aggregate?.creationsWithTokens !== countTokens(creations) ||
+    evidence.aggregate?.readsWithTokens !== countTokens(reads) ||
     evidence.aggregate?.measured !== evidence.cacheReuseVerified
   ) {
     failures.push({
       check: "aggregate_consistency",
-      reason: `aggregate report does not mirror the recorded events (creates=${evidence.aggregate?.creates}, reads=${evidence.aggregate?.reads}, readToCreateRatio=${evidence.aggregate?.readToCreateRatio}, creationsWithTokens=${evidence.aggregate?.creationsWithTokens}, readsWithTokens=${evidence.aggregate?.readsWithTokens}, measured=${evidence.aggregate?.measured}); expected creates=${record.creates}, reads=${record.reads}, ratio=${expectedRatio}, creationsWithTokens=${countTokens(evidence.primerCacheCreations ?? [])}, readsWithTokens=${countTokens(evidence.reviewerCacheReads ?? [])}, measured=${evidence.cacheReuseVerified}`,
+      reason: `aggregate report does not mirror the recorded events (creates=${evidence.aggregate?.creates}, reads=${evidence.aggregate?.reads}, readToCreateRatio=${evidence.aggregate?.readToCreateRatio}, creationsWithTokens=${evidence.aggregate?.creationsWithTokens}, readsWithTokens=${evidence.aggregate?.readsWithTokens}, measured=${evidence.aggregate?.measured}); expected creates=${record.creates}, reads=${record.reads}, ratio=${expectedRatio}, creationsWithTokens=${countTokens(creations)}, readsWithTokens=${countTokens(reads)}, measured=${evidence.cacheReuseVerified}`,
     });
   }
 

--- a/packages/core/src/loop/cache-telemetry-evidence.mjs
+++ b/packages/core/src/loop/cache-telemetry-evidence.mjs
@@ -240,6 +240,30 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
     return { ok: false, failures: [{ check: "artifact", reason: "missing cache-telemetry evidence artifact" }] };
   }
 
+  // Identity fields (gate/headSha/planHash/schemaVersion) must be present and
+  // well-formed for the artifact to be accepted — fail closed on a structurally
+  // incomplete artifact (missing/dropped identity fields) even when the event
+  // arrays and aggregates are internally self-consistent. A hand-edited or
+  // truncated artifact carrying none of its round identity is not
+  // cache-telemetry evidence for any gate/head and must never be accepted by
+  // fan-in as a valid artifact.
+  const identityChecks = [
+    { field: "gate", valid: (v) => typeof v === "string" && v.trim().length > 0 },
+    { field: "headSha", valid: (v) => typeof v === "string" && /^[0-9a-f]{7,64}$/i.test(v.trim()) },
+    { field: "planHash", valid: (v) => typeof v === "string" && v.trim().length > 0 },
+    { field: "schemaVersion", valid: (v) => typeof v === "number" && Number.isInteger(v) },
+  ];
+  for (const { field, valid } of identityChecks) {
+    if (!valid(evidence[field])) {
+      failures.push({
+        check: "identity_field",
+        reason: `cache-telemetry evidence missing or malformed identity field "${field}" (${JSON.stringify(
+          evidence[field],
+        )}) — a structurally incomplete artifact must fail closed`,
+      });
+    }
+  }
+
   // Capability record must be present to reason about veracity.
   if (!evidence.capabilities) {
     failures.push({

--- a/packages/core/src/loop/cache-telemetry-evidence.mjs
+++ b/packages/core/src/loop/cache-telemetry-evidence.mjs
@@ -118,27 +118,40 @@ export function buildCacheTelemetryEvidence({
     }
   }
 
+  const normalizeTokens = (tokens, label) => {
+    // Fail CLOSED on a non-null token that is not a finite non-negative
+    // number (numeric strings, NaN, Infinity, negatives, other types): the
+    // reported value is telemetry evidence and a silently-coerced token would
+    // under-report the create/read contribution with no signal. `null` is the
+    // honest "not observable" marker.
+    if (tokens == null) return null;
+    if (typeof tokens !== "number" || !Number.isFinite(tokens) || tokens < 0) {
+      throw new Error(`${label} tokens must be a finite non-negative number or null, got ${JSON.stringify(tokens)}`);
+    }
+    return tokens;
+  };
+
   const normCreations = Object.freeze(
     primerCacheCreations.map((c, i) => {
-      if (typeof c.model !== "string" || c.model.length === 0) {
-        throw new Error(`primerCacheCreations[${i}].model must be a non-empty concrete model`);
+      if (c == null || typeof c !== "object" || typeof c.model !== "string" || c.model.length === 0) {
+        throw new Error(`primerCacheCreations[${i}] must be an object with a non-empty concrete model`);
       }
       return Object.freeze({
         model: c.model,
         primerForm: c.primerForm ?? null,
-        tokens: Number.isFinite(c.tokens) && c.tokens >= 0 ? c.tokens : null,
+        tokens: normalizeTokens(c.tokens, `primerCacheCreations[${i}]`),
       });
     }),
   );
   const normReads = Object.freeze(
     reviewerCacheReads.map((r, i) => {
-      if (typeof r.model !== "string" || r.model.length === 0) {
-        throw new Error(`reviewerCacheReads[${i}].model must be a non-empty concrete model`);
+      if (r == null || typeof r !== "object" || typeof r.model !== "string" || r.model.length === 0) {
+        throw new Error(`reviewerCacheReads[${i}] must be an object with a non-empty concrete model`);
       }
       return Object.freeze({
         model: r.model,
         angle: r.angle ?? null,
-        tokens: Number.isFinite(r.tokens) && r.tokens >= 0 ? r.tokens : null,
+        tokens: normalizeTokens(r.tokens, `reviewerCacheReads[${i}]`),
       });
     }),
   );
@@ -168,7 +181,7 @@ export function buildCacheTelemetryEvidence({
   return Object.freeze({
     schemaVersion: CACHE_TELEMETRY_SCHEMA_VERSION,
     gate: plan.gate,
-    headSha: plan.headSha,
+    headSha: String(plan.headSha).trim().toLowerCase(),
     planHash: plan.planHash,
     sharedPrefixHash: plan.sharedPrefixHash ?? null,
     cacheBoundary: plan.requestGroups[0]?.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
@@ -194,7 +207,7 @@ export function buildCacheTelemetryEvidence({
       measured: cacheReuseVerified,
       report:
         cacheReuseVerified
-          ? `verified ${normReads.length} cache read${normReads.length === 1 ? "" : "s"} after ${normCreations.length} cache creation${normCreations.length === 1 ? "" : "s"} (measureable read:create = ${normReads.length}:${normCreations.length})`
+          ? `verified ${normReads.length} cache read${normReads.length === 1 ? "" : "s"} after ${normCreations.length} cache creation${normCreations.length === 1 ? "" : "s"} (measurable read:create = ${normReads.length}:${normCreations.length})`
           : `provider reuse could not be verified (usageTelemetry=${caps?.usageTelemetry ?? "missing"}) — only ordering + request-fingerprint invariants may be claimed`,
     }),
   });
@@ -223,8 +236,17 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
     });
   }
 
-  // Honesty gate: verified reuse requires telemetry to actually be available.
-  if (evidence.cacheReuseVerified && !evidence.telemetryAvailable) {
+  // Honesty gate: verified reuse requires the capability record's usage
+  // telemetry to be available. The verdict is re-derived from
+  // evidence.capabilities.usageTelemetry — NOT from the stored
+  // evidence.telemetryAvailable boolean — so a hand-edited / forged artifact
+  // that flips BOTH cacheReuseVerified AND telemetryAvailable to true still
+  // fails closed (the capability record is the source of truth). The builder
+  // always normalizes capabilities (usageTelemetry included), so this is
+  // re-derivable here.
+  const derivedTelemetryAvailable =
+    evidence.capabilities != null && evidence.capabilities.usageTelemetry === "available";
+  if (evidence.cacheReuseVerified && !derivedTelemetryAvailable) {
     failures.push({
       check: "opaque_veracity",
       reason: `cacheReuseVerified=true but usageTelemetry=${evidence.capabilities?.usageTelemetry ?? "missing"} — an opaque/unavailable harness must never claim verified provider reuse`,
@@ -273,11 +295,23 @@ export function validateCacheTelemetryEvidence({ evidence } = {}) {
     });
   }
 
-  // Aggregate reads/creates must mirror the counts.
-  if (evidence.aggregate?.creates !== evidence.creationCount || evidence.aggregate?.reads !== evidence.readCount) {
+  // Aggregate reads/creates must mirror the counts, and every derived aggregate
+  // value (readToCreateRatio, creationsWithTokens, readsWithTokens, measured)
+  // must be re-derivable from the recorded events — a forged / hand-edited
+  // aggregate that contradicts the evidence fails closed.
+  const record = { creates: evidence.creationCount, reads: evidence.readCount };
+  const expectedRatio = record.creates > 0 ? record.reads / record.creates : 0;
+  if (
+    evidence.aggregate?.creates !== evidence.creationCount ||
+    evidence.aggregate?.reads !== evidence.readCount ||
+    evidence.aggregate?.readToCreateRatio !== expectedRatio ||
+    evidence.aggregate?.creationsWithTokens !== countTokens(evidence.primerCacheCreations ?? []) ||
+    evidence.aggregate?.readsWithTokens !== countTokens(evidence.reviewerCacheReads ?? []) ||
+    evidence.aggregate?.measured !== evidence.cacheReuseVerified
+  ) {
     failures.push({
       check: "aggregate_consistency",
-      reason: `aggregate report (creates=${evidence.aggregate?.creates}, reads=${evidence.aggregate?.reads}) does not mirror recorded counts (creates=${evidence.creationCount}, reads=${evidence.readCount})`,
+      reason: `aggregate report does not mirror the recorded events (creates=${evidence.aggregate?.creates}, reads=${evidence.aggregate?.reads}, readToCreateRatio=${evidence.aggregate?.readToCreateRatio}, creationsWithTokens=${evidence.aggregate?.creationsWithTokens}, readsWithTokens=${evidence.aggregate?.readsWithTokens}, measured=${evidence.aggregate?.measured}); expected creates=${record.creates}, reads=${record.reads}, ratio=${expectedRatio}, creationsWithTokens=${countTokens(evidence.primerCacheCreations ?? [])}, readsWithTokens=${countTokens(evidence.reviewerCacheReads ?? [])}, measured=${evidence.cacheReuseVerified}`,
     });
   }
 

--- a/packages/core/src/loop/cache-telemetry-evidence.mjs
+++ b/packages/core/src/loop/cache-telemetry-evidence.mjs
@@ -1,0 +1,326 @@
+/**
+ * cache-telemetry-evidence.mjs — cache telemetry adapter + before/after evidence
+ * artifact (issue #1468 slice 4).
+ *
+ * Slices 1-3 produced the deterministic request plan, request-prefix fingerprints,
+ * stable/volatile separation, per-model primer-group partitioning, and the
+ * primer-dispatch ordering evidence + fail-closed fan-in validation. That
+ * proves the ordering and request-fingerprint invariants a cache-aware dispatch
+ * relies on, but it does not by itself MEASURE the provider cache reuse: whether
+ * the N reviewers actually read the cache entry the primer wrote.
+ *
+ * This slice adds the harness-capability-aware telemetry surface (Section D of
+ * #1468). Where a harness exposes cache creation/read usage telemetry, we
+ * persist per-primer creation tokens and per-reviewer read tokens and emit an
+ * aggregate read:create report. Where the harness is opaque or telemetry is
+ * unavailable, we record `cacheReuseVerified: false` with the reason and NEVER
+ * describe the result as a verified `1 write + N reads` outcome — only the
+ * ordering + fingerprint invariants from the earlier slices may be claimed.
+ *
+ * This module is pure and offline (no GitHub, no harness, no clock). It owns:
+ *
+ *  1. before/after evidence artifact builder — a deterministic per-gate-run record
+ *     ('<gate>-<headSha>.cache-telemetry.json') pairing the plan + capability
+ *     record with the observed cache-creation (before) and cache-read (after)
+ *     telemetry events, and deriving the aggregate read:create report.
+ *  2. fail-closed validator — checks, named individually, that verified reuse is
+ *     never claimed without the capability + at least one creation and one read
+ *     event that telemetry can actually observe; an opaque/unavailable harness
+ *     must fail closed to `cacheReuseVerified: false` (Section D honesty gate).
+ *  3. deterministic path + writer — consumable by the gate ledger without
+ *     re-derivation (GATE-EXEC-CACHE-TELEMETRY).
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+  cacheReuseVeracity,
+  normalizeHarnessCapabilities,
+} from "./review-dispatch-plan.mjs";
+
+export const CACHE_TELEMETRY_SCHEMA_VERSION = 1;
+
+/**
+ * Deterministic artifact path for a gate run's cache-telemetry evidence.
+ *
+ * @param {object} input
+ * @param {string} input.dir - directory to write under (e.g. the gate-context dir).
+ * @param {string} input.gate - gate name (pre_approval_gate, draft_gate, ...).
+ * @param {string} input.headSha - reviewed head SHA (hex, 7-64).
+ * @returns {string} absolute-style path joined under `dir`.
+ */
+export function cacheTelemetryPath({ dir, gate, headSha } = {}) {
+  if (typeof dir !== "string" || dir.length === 0) throw new Error("cacheTelemetryPath requires a dir");
+  if (typeof gate !== "string" || gate.length === 0) throw new Error("cacheTelemetryPath requires a gate");
+  if (typeof headSha !== "string" || !/^[0-9a-f]{7,64}$/i.test(headSha.trim())) {
+    throw new Error("cacheTelemetryPath requires a hex headSha");
+  }
+  return path.join(dir, `${gate}-${headSha.trim().toLowerCase()}.cache-telemetry.json`);
+}
+
+/** Count of entries whose `tokens` is a finite non-negative number. */
+function countTokens(entries) {
+  return entries.filter((e) => Number.isFinite(e.tokens) && e.tokens >= 0).length;
+}
+
+/** Sum of finite non-negative `tokens` across entries. */
+function sumTokens(entries) {
+  return entries.reduce((acc, e) => {
+    const t = Number.isFinite(e.tokens) && e.tokens >= 0 ? e.tokens : 0;
+    return acc + t;
+  }, 0);
+}
+
+/**
+ * Build the before/after cache-telemetry evidence artifact for a gate run.
+ *
+ * "Before" = the cache-creation events (the primer write side); "after" = the
+ * cache-read events (the reviewer read side). Where a harness does not expose
+ * per-event token counts, callers may record the event with `tokens: null`; the
+ * event still counts toward the create/read tally but not the token aggregates.
+ *
+ * @param {object} input
+ * @param {object} input.plan - the dispatch plan from buildReviewDispatchPlan().
+ * @param {object} [input.capabilities] - normalized harness capabilities (used
+ *   to drive the veracity gate; defaults to the plan's capabilities when present).
+ * @param {Array<object>} input.primerCacheCreations - [{ model, primerForm, tokens|null }]
+ *   observed cache creations (the "before" write events).
+ * @param {Array<object>} input.reviewerCacheReads - [{ model, angle, tokens|null }]
+ *   observed cache reads (the "after" read events).
+ * @returns {object} canonical evidence artifact.
+ */
+export function buildCacheTelemetryEvidence({
+  plan,
+  capabilities,
+  primerCacheCreations = [],
+  reviewerCacheReads = [],
+} = {}) {
+  if (!plan || typeof plan !== "object" || !Array.isArray(plan.requestGroups)) {
+    throw new Error("buildCacheTelemetryEvidence requires a plan with requestGroups");
+  }
+  if (!Array.isArray(primerCacheCreations)) throw new Error("primerCacheCreations must be an array");
+  if (!Array.isArray(reviewerCacheReads)) throw new Error("reviewerCacheReads must be an array");
+
+  // Resolve the capability record: an explicitly passed one wins, else fall back
+  // to the plan's `capabilities` field. A missing capability record is itself a
+  // fail-closed truth (cannot claim verified reuse without a capability record).
+  let caps = capabilities ?? plan.capabilities ?? null;
+  if (caps != null) {
+    // A capability spec may carry a `harness` key plus dimension overrides
+    // (parity with buildReviewDispatchPlan's handling).
+    const hasHarness = typeof caps === "object" && !Array.isArray(caps) && typeof caps.harness === "string";
+    if (hasHarness) {
+      const { harness: harnessName, ...dims } = caps;
+      caps = normalizeHarnessCapabilities({ harness: harnessName, capabilities: dims });
+    } else {
+      caps = normalizeHarnessCapabilities({ capabilities: caps });
+    }
+  }
+
+  const normCreations = Object.freeze(
+    primerCacheCreations.map((c, i) => {
+      if (typeof c.model !== "string" || c.model.length === 0) {
+        throw new Error(`primerCacheCreations[${i}].model must be a non-empty concrete model`);
+      }
+      return Object.freeze({
+        model: c.model,
+        primerForm: c.primerForm ?? null,
+        tokens: Number.isFinite(c.tokens) && c.tokens >= 0 ? c.tokens : null,
+      });
+    }),
+  );
+  const normReads = Object.freeze(
+    reviewerCacheReads.map((r, i) => {
+      if (typeof r.model !== "string" || r.model.length === 0) {
+        throw new Error(`reviewerCacheReads[${i}].model must be a non-empty concrete model`);
+      }
+      return Object.freeze({
+        model: r.model,
+        angle: r.angle ?? null,
+        tokens: Number.isFinite(r.tokens) && r.tokens >= 0 ? r.tokens : null,
+      });
+    }),
+  );
+
+  // Honesty gate (Section D): an opaque / unavailable telemetry harness can never
+  // be described as verified 1 write + N reads. cacheReuseVeracity() refuses to
+  // claim verified reuse unless usageTelemetry === "available".
+  const veracity = cacheReuseVeracity(caps);
+
+  const telemetryAvailable = caps != null && caps.usageTelemetry === "available";
+  // Verified reuse requires BOTH the capability truth AND at least one observed
+  // creation and one observed read. Without a create then a read for a
+  // multi-reviewer group, even a telemetry-capable harness has no measured
+  // reuse to report.
+  const hasMeasuredSequence =
+    normCreations.length > 0 && normReads.length > 0 && telemetryAvailable;
+  const cacheReuseVerified = hasMeasuredSequence && veracity.verified;
+
+  const creationsWithTokens = countTokens(normCreations);
+  const readsWithTokens = countTokens(normReads);
+
+  const baseReason = cacheReuseVeracity(caps).reason;
+  const veracityReason = hasMeasuredSequence
+    ? baseReason ?? null
+    : (baseReason ?? "no measured create-then-read sequence observed");
+
+  return Object.freeze({
+    schemaVersion: CACHE_TELEMETRY_SCHEMA_VERSION,
+    gate: plan.gate,
+    headSha: plan.headSha,
+    planHash: plan.planHash,
+    sharedPrefixHash: plan.sharedPrefixHash ?? null,
+    cacheBoundary: plan.requestGroups[0]?.cacheBoundary ?? CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+    capabilities: caps ? Object.freeze({ ...caps }) : null,
+    telemetryAvailable,
+    cacheReuseVerified,
+    veracityReason,
+    // "before" side
+    primerCacheCreations: normCreations,
+    creationCount: normCreations.length,
+    creationTokens: sumTokens(normCreations),
+    // "after" side
+    reviewerCacheReads: normReads,
+    readCount: normReads.length,
+    readTokens: sumTokens(normReads),
+    // aggregate read:create report
+    aggregate: Object.freeze({
+      creates: normCreations.length,
+      reads: normReads.length,
+      readToCreateRatio: normCreations.length > 0 ? normReads.length / normCreations.length : 0,
+      creationsWithTokens,
+      readsWithTokens,
+      measured: cacheReuseVerified,
+      report:
+        cacheReuseVerified
+          ? `verified ${normReads.length} cache read${normReads.length === 1 ? "" : "s"} after ${normCreations.length} cache creation${normCreations.length === 1 ? "" : "s"} (measureable read:create = ${normReads.length}:${normCreations.length})`
+          : `provider reuse could not be verified (usageTelemetry=${caps?.usageTelemetry ?? "missing"}) — only ordering + request-fingerprint invariants may be claimed`,
+    }),
+  });
+}
+
+/**
+ * Fail-closed validation of cache-telemetry evidence (Section D / GATE-EXEC-
+ * CACHE-TELEMETRY). The honesty invariant: no code path may describe an opaque
+ * harness's behaviour as a verified `1 write + N reads` result.
+ *
+ * @param {object} input
+ * @param {object} input.evidence - artifact from buildCacheTelemetryEvidence().
+ * @returns {{ ok: boolean, failures: Array<{check: string, reason: string}> }}
+ */
+export function validateCacheTelemetryEvidence({ evidence } = {}) {
+  const failures = [];
+  if (!evidence || typeof evidence !== "object") {
+    return { ok: false, failures: [{ check: "artifact", reason: "missing cache-telemetry evidence artifact" }] };
+  }
+
+  // Capability record must be present to reason about veracity.
+  if (!evidence.capabilities) {
+    failures.push({
+      check: "capability_record",
+      reason: "cache-telemetry evidence has no capability record — provider cache reuse cannot be classified",
+    });
+  }
+
+  // Honesty gate: verified reuse requires telemetry to actually be available.
+  if (evidence.cacheReuseVerified && !evidence.telemetryAvailable) {
+    failures.push({
+      check: "opaque_veracity",
+      reason: `cacheReuseVerified=true but usageTelemetry=${evidence.capabilities?.usageTelemetry ?? "missing"} — an opaque/unavailable harness must never claim verified provider reuse`,
+    });
+  }
+
+  // Verified reuse requires a measured create-then-read sequence (at least one
+  // creation and at least one read for a group). A claim of verified reuse with
+  // no measured sequence is not derived from evidence.
+  if (evidence.cacheReuseVerified) {
+    if (!(evidence.creationCount > 0 && evidence.readCount > 0)) {
+      failures.push({
+        check: "measured_sequence",
+        reason: `cacheReuseVerified=true but no measured create-then-read sequence (creations=${evidence.creationCount}, reads=${evidence.readCount})`,
+      });
+    }
+  }
+
+  // Self-consistency of the aggregate report against the recorded events.
+  if (evidence.creationCount !== (evidence.primerCacheCreations?.length ?? 0)) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `creationCount ${evidence.creationCount} != recorded primerCacheCreations.length ${evidence.primerCacheCreations?.length ?? 0}`,
+    });
+  }
+  if (evidence.readCount !== (evidence.reviewerCacheReads?.length ?? 0)) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `readCount ${evidence.readCount} != recorded reviewerCacheReads.length ${evidence.reviewerCacheReads?.length ?? 0}`,
+    });
+  }
+
+  // Token aggregates must equal the sum over finite event tokens.
+  const expectedCreationTokens = sumTokens(evidence.primerCacheCreations ?? []);
+  if (evidence.creationTokens !== expectedCreationTokens) {
+    failures.push({
+      check: "token_aggregate",
+      reason: `creationTokens ${evidence.creationTokens} != sum of primer creations ${expectedCreationTokens}`,
+    });
+  }
+  const expectedReadTokens = sumTokens(evidence.reviewerCacheReads ?? []);
+  if (evidence.readTokens !== expectedReadTokens) {
+    failures.push({
+      check: "token_aggregate",
+      reason: `readTokens ${evidence.readTokens} != sum of reviewer reads ${expectedReadTokens}`,
+    });
+  }
+
+  // Aggregate reads/creates must mirror the counts.
+  if (evidence.aggregate?.creates !== evidence.creationCount || evidence.aggregate?.reads !== evidence.readCount) {
+    failures.push({
+      check: "aggregate_consistency",
+      reason: `aggregate report (creates=${evidence.aggregate?.creates}, reads=${evidence.aggregate?.reads}) does not mirror recorded counts (creates=${evidence.creationCount}, reads=${evidence.readCount})`,
+    });
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
+/**
+ * Strict fail-closed enforcement surface (GATE-EXEC-CACHE-TELEMETRY): throws
+ * when cache-telemetry evidence is missing or invalid, naming the failing check.
+ * This is the refusal path a gate conductor calls after
+ * validateCacheTelemetryEvidence returns ok:false — it turns a reported failure
+ * into a hard stop.
+ *
+ * @param {object} input
+ * @param {object} input.evidence - artifact from buildCacheTelemetryEvidence().
+ * @returns {true}
+ * @throws {Error} when any cache-telemetry check fails.
+ */
+export function enforceCacheTelemetryEvidence({ evidence } = {}) {
+  const r = validateCacheTelemetryEvidence({ evidence });
+  if (!r.ok) {
+    throw new Error(
+      `GATE-EXEC-CACHE-TELEMETRY: cache-telemetry evidence failed validation; refusing to proceed (${r.failures.map((f) => `${f.check}: ${f.reason}`).join("; ")})`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Persist the evidence artifact to its deterministic path.
+ *
+ * @param {object} input
+ * @param {string} input.dir
+ * @param {object} input.evidence
+ * @returns {Promise<{ path: string }>}
+ */
+export async function writeCacheTelemetryEvidence({ dir, evidence } = {}) {
+  const target = cacheTelemetryPath({
+    dir,
+    gate: evidence.gate,
+    headSha: evidence.headSha,
+  });
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+  return { path: target };
+}

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -313,12 +313,22 @@ describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
       primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
       reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
     });
+    // Both events fields get the same truthy non-array treatment (the symmetric
+    // reviewerCacheReads arm and its safe-array fallback must not throw either).
     for (const bad of ["abc", { a: 1 }, 5]) {
-      const subverted = { ...ev, primerCacheCreations: bad };
-      assert.doesNotThrow(() => validateCacheTelemetryEvidence({ evidence: subverted }));
-      const r = validateCacheTelemetryEvidence({ evidence: subverted });
-      assert.equal(r.ok, false);
-      assert.ok(r.failures.some((f) => f.check === "aggregate_consistency"));
+      for (const [field, label] of [
+        ["primerCacheCreations", "primerCacheCreations"],
+        ["reviewerCacheReads", "reviewerCacheReads"],
+      ]) {
+        const subverted = { ...ev, [field]: bad };
+        assert.doesNotThrow(() => validateCacheTelemetryEvidence({ evidence: subverted }));
+        const r = validateCacheTelemetryEvidence({ evidence: subverted });
+        assert.equal(r.ok, false);
+        assert.ok(
+          r.failures.some((f) => f.check === "aggregate_consistency"),
+          `${label} non-array should yield an aggregate_consistency failure`,
+        );
+      }
     }
   });
 

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -277,6 +277,21 @@ describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
     assert.ok(r.failures.some((f) => f.check === "token_aggregate"));
   });
 
+  test("fails closed on a structurally incomplete artifact (missing identity fields)", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    // Drop the identity fields while keeping the event arrays/aggregates
+    // self-consistent — the artifact must still fail closed on the missing
+    // round identity rather than pass as valid evidence.
+    const { gate, headSha, planHash, schemaVersion, ...incomplete } = ev;
+    const r = validateCacheTelemetryEvidence({ evidence: incomplete });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "identity_field"));
+  });
+
   test("fails closed on a missing capability record (capability_record)", () => {
     const ev = buildCacheTelemetryEvidence({
       plan: claudePlan(),

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import {
+  CACHE_TELEMETRY_SCHEMA_VERSION,
+  buildCacheTelemetryEvidence,
+  cacheTelemetryPath,
+  enforceCacheTelemetryEvidence,
+  validateCacheTelemetryEvidence,
+  writeCacheTelemetryEvidence,
+} from "../src/loop/cache-telemetry-evidence.mjs";
+import {
+  CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+  buildReviewDispatchPlan,
+} from "../src/loop/review-dispatch-plan.mjs";
+
+const fp = "sha256:" + "a".repeat(64);
+
+function makePlan({ capabilities } = {}) {
+  return buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: "abcdef1234567890",
+    sharedPrefixHash: fp,
+    requestGroups: [
+      { model: "model-a", requestPrefixFingerprint: fp, cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX, ttlIntent: "1h", angles: ["correctness", "security"] },
+    ],
+    capabilities,
+  });
+}
+
+// A telemetry-capable harness (Section D: usageTelemetry=available) with one
+// cache creation and a multi-reviewer read group — the adapter-test analogue of
+// "one cache creation followed by cache reads for a multi-reviewer group".
+const claudePlan = () =>
+  makePlan({ capabilities: { harness: "claude" } });
+
+// An opaque harness (Section D: usageTelemetry=unavailable) — must NEVER be
+// described as a verified 1-write-N-reads result.
+const piPlan = () =>
+  makePlan({ capabilities: { harness: "pi" } });
+
+describe("cacheTelemetryPath — deterministic artifact path (AC-1)", () => {
+  test("derives a stable, gate+head-scoped path under a given dir", () => {
+    const p = cacheTelemetryPath({ dir: "tmp/gate-context", gate: "pre_approval_gate", headSha: "abcdef1234567890" });
+    assert.match(p, /^tmp\/gate-context\/pre_approval_gate-abcdef1234567890\.cache-telemetry\.json$/);
+    // Deterministic: same input -> same path.
+    assert.equal(
+      p,
+      cacheTelemetryPath({ dir: "tmp/gate-context", gate: "pre_approval_gate", headSha: "abcdef1234567890" }),
+    );
+  });
+
+  test("fails closed on missing gate/headSha", () => {
+    assert.throws(() => cacheTelemetryPath({ dir: "d", headSha: "abc" }));
+    assert.throws(() => cacheTelemetryPath({ dir: "d", gate: "g" }));
+  });
+});
+
+describe("buildCacheTelemetryEvidence — telemetry-capable harness records create+reads", () => {
+  test("records one creation + N reads and an aggregate read:create report (verified)", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [
+        { model: "model-a", primerForm: "lead_reviewer", tokens: 12000 },
+      ],
+      reviewerCacheReads: [
+        { model: "model-a", angle: "correctness", tokens: 200 },
+        { model: "model-a", angle: "security", tokens: 210 },
+      ],
+    });
+    assert.equal(ev.schemaVersion, CACHE_TELEMETRY_SCHEMA_VERSION);
+    assert.equal(ev.telemetryAvailable, true);
+    assert.equal(ev.cacheReuseVerified, true);
+    assert.equal(ev.creationCount, 1);
+    assert.equal(ev.readCount, 2);
+    assert.equal(ev.creationTokens, 12000);
+    assert.equal(ev.readTokens, 410);
+    assert.equal(ev.aggregate.creates, 1);
+    assert.equal(ev.aggregate.reads, 2);
+    assert.equal(ev.aggregate.readToCreateRatio, 2);
+    assert.equal(ev.aggregate.measured, true);
+    assert.match(ev.aggregate.report, /verified 2 cache reads after 1 cache creation/);
+    // Deterministic binding to the plan.
+    assert.equal(ev.planHash, claudePlan().planHash);
+    assert.equal(ev.sharedPrefixHash, fp);
+  });
+
+  test("fails validation if nothing observed even when telemetry-capable", () => {
+    // Telemetry available but NO create/read events measured: cannot claim
+    // verified reuse (measurement is empty).
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [],
+      reviewerCacheReads: [],
+    });
+    assert.equal(ev.cacheReuseVerified, false);
+    assert.match(ev.aggregate.report, /provider reuse could not be verified/);
+  });
+});
+
+describe("buildCacheTelemetryEvidence — opaque harness never claims verified reuse", () => {
+  test("opaque/unavailable telemetry forces cacheReuseVerified=false", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: piPlan(),
+      primerCacheCreations: [{ model: "model-a", primerForm: "dedicated_primer", tokens: null }],
+      reviewerCacheReads: [
+        { model: "model-a", angle: "correctness", tokens: null },
+        { model: "model-a", angle: "security", tokens: null },
+      ],
+    });
+    assert.equal(ev.telemetryAvailable, false);
+    assert.equal(ev.cacheReuseVerified, false);
+    assert.match(ev.aggregate.report, /provider reuse could not be verified/);
+    assert.match(ev.aggregate.report, /usageTelemetry=unavailable/);
+    assert.doesNotMatch(ev.aggregate.report, /verified 1 write/);
+    assert.doesNotMatch(ev.aggregate.report, /verified 2 cache reads/);
+  });
+
+  test("a plan without any capability record also fails closed", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: makePlan({ capabilities: undefined }),
+      primerCacheCreations: [{ model: "model-a" }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness" }],
+    });
+    assert.equal(ev.capabilities, null);
+    assert.equal(ev.cacheReuseVerified, false);
+    assert.match(ev.aggregate.report, /could not be verified/);
+  });
+});
+
+describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
+  test("passes a valid telemetry-capable artifact", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [
+        { model: "model-a", angle: "correctness", tokens: 200 },
+        { model: "model-a", angle: "security", tokens: 210 },
+      ],
+    });
+    const r = validateCacheTelemetryEvidence({ evidence: ev });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.failures, []);
+  });
+
+  test("fails closed on a claimed-verified result with unavailable telemetry", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: piPlan(),
+      primerCacheCreations: [{ model: "model-a" }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness" }],
+    });
+    // Mutate the honest verdict to simulate a code path trying to over-claim.
+    const subverted = { ...ev, telemetryAvailable: false, cacheReuseVerified: true };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "opaque_veracity"));
+  });
+
+  test("fails closed when verified reuse lacks a measured create-then-read sequence", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [],
+      reviewerCacheReads: [],
+    });
+    const subverted = { ...ev, cacheReuseVerified: true };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "measured_sequence"));
+  });
+
+  test("fails closed on a missing artifact", () => {
+    const r = validateCacheTelemetryEvidence({ evidence: null });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "artifact"));
+  });
+});
+
+describe("enforceCacheTelemetryEvidence — strict refusal surface", () => {
+  test("returns true for valid evidence", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    assert.equal(enforceCacheTelemetryEvidence({ evidence: ev }), true);
+  });
+
+  test("throws naming GATE-EXEC-CACHE-TELEMETRY for an over-claim", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: piPlan(),
+      primerCacheCreations: [{ model: "model-a" }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness" }],
+    });
+    assert.throws(
+      () => enforceCacheTelemetryEvidence({ evidence: { ...ev, cacheReuseVerified: true } }),
+      /GATE-EXEC-CACHE-TELEMETRY/,
+    );
+  });
+});
+
+describe("writeCacheTelemetryEvidence — deterministic persistence", () => {
+  test("writes the artifact to its deterministic path", async () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    const { rm } = await import("node:fs/promises");
+    const { path: target } = await writeCacheTelemetryEvidence({ dir: "tmp/cache-telemetry-test", evidence: ev });
+    assert.match(target, /cache-telemetry\.json$/);
+    const onDisk = JSON.parse(await readTestFile(target));
+    assert.equal(onDisk.cacheReuseVerified, true);
+    assert.equal(onDisk.aggregate.reads, 1);
+    await rm("tmp/cache-telemetry-test", { recursive: true, force: true });
+  });
+});
+
+async function readTestFile(p) {
+  const { readFile } = await import("node:fs/promises");
+  return readFile(p, "utf8");
+}

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -54,6 +54,11 @@ describe("cacheTelemetryPath — deterministic artifact path (AC-1)", () => {
     assert.throws(() => cacheTelemetryPath({ dir: "d", headSha: "abc" }));
     assert.throws(() => cacheTelemetryPath({ dir: "d", gate: "g" }));
   });
+
+  test("fails closed on a malformed (non-hex / wrong-length) headSha", () => {
+    assert.throws(() => cacheTelemetryPath({ dir: "d", gate: "g", headSha: "not-hex-sh" }));
+    assert.throws(() => cacheTelemetryPath({ dir: "d", gate: "g", headSha: "abc" })); // < 7 chars
+  });
 });
 
 describe("buildCacheTelemetryEvidence — telemetry-capable harness records create+reads", () => {
@@ -126,6 +131,63 @@ describe("buildCacheTelemetryEvidence — opaque harness never claims verified r
     assert.equal(ev.cacheReuseVerified, false);
     assert.match(ev.aggregate.report, /could not be verified/);
   });
+
+  test("fails closed on a non-numeric token value (no silent coercion)", () => {
+    const plan = claudePlan();
+    assert.throws(
+      () =>
+        buildCacheTelemetryEvidence({
+          plan,
+          primerCacheCreations: [{ model: "model-a", tokens: "12000" }],
+          reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+        }),
+      /tokens must be a finite non-negative number or null/,
+    );
+    assert.throws(
+      () =>
+        buildCacheTelemetryEvidence({
+          plan,
+          primerCacheCreations: [{ model: "model-a", tokens: -5 }],
+          reviewerCacheReads: [],
+        }),
+      /tokens must be a finite non-negative number or null/,
+    );
+  });
+
+  test("fails closed on a null/entry with empty model (nil-entry guard)", () => {
+    const plan = claudePlan();
+    assert.throws(
+      () =>
+        buildCacheTelemetryEvidence({
+          plan,
+          primerCacheCreations: [null],
+          reviewerCacheReads: [],
+        }),
+      /must be an object with a non-empty concrete model/,
+    );
+    assert.throws(
+      () =>
+        buildCacheTelemetryEvidence({
+          plan,
+          primerCacheCreations: [{ model: "" }],
+          reviewerCacheReads: [],
+        }),
+      /must be an object with a non-empty concrete model/,
+    );
+  });
+
+  test("fails closed on a missing requestGroups plan / non-array event lists", () => {
+    assert.throws(() => buildCacheTelemetryEvidence({ plan: {} }), /plan with requestGroups/);
+    const plan = claudePlan();
+    assert.throws(
+      () => buildCacheTelemetryEvidence({ plan, primerCacheCreations: "nope" }),
+      /primerCacheCreations must be an array/,
+    );
+    assert.throws(
+      () => buildCacheTelemetryEvidence({ plan, reviewerCacheReads: "nope" }),
+      /reviewerCacheReads must be an array/,
+    );
+  });
 });
 
 describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
@@ -154,6 +216,58 @@ describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
     const r = validateCacheTelemetryEvidence({ evidence: subverted });
     assert.equal(r.ok, false);
     assert.ok(r.failures.some((f) => f.check === "opaque_veracity"));
+  });
+
+  test("fails closed even when BOTH cacheReuseVerified and telemetryAvailable are flipped (re-derived from capabilities)", () => {
+    // The honesty gate must be driven by evidence.capabilities.usageTelemetry,
+    // not the stored telemetryAvailable boolean: flipping both booleans on an
+    // opaque (pi) artifact must still fail closed.
+    const ev = buildCacheTelemetryEvidence({
+      plan: piPlan(),
+      primerCacheCreations: [{ model: "model-a" }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness" }],
+    });
+    const subverted = { ...ev, telemetryAvailable: true, cacheReuseVerified: true };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "opaque_veracity"));
+  });
+
+  test("fails closed on a tampered aggregate report (aggregate_consistency)", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    // Forge a readToCreateRatio that contradicts the counts.
+    const subverted = { ...ev, aggregate: { ...ev.aggregate, readToCreateRatio: 99 } };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "aggregate_consistency"));
+  });
+
+  test("fails closed on a tampered token aggregate (token_aggregate)", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    const subverted = { ...ev, creationTokens: 1 };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "token_aggregate"));
+  });
+
+  test("fails closed on a missing capability record (capability_record)", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    const subverted = { ...ev, capabilities: null };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "capability_record"));
   });
 
   test("fails closed when verified reuse lacks a measured create-then-read sequence", () => {
@@ -199,6 +313,27 @@ describe("enforceCacheTelemetryEvidence — strict refusal surface", () => {
 });
 
 describe("writeCacheTelemetryEvidence — deterministic persistence", () => {
+  test("two identical builds produce byte-identical artifacts (content determinism)", () => {
+    const a = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [
+        { model: "model-a", angle: "correctness", tokens: 200 },
+        { model: "model-a", angle: "security", tokens: 210 },
+      ],
+    });
+    const b = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [
+        { model: "model-a", angle: "correctness", tokens: 200 },
+        { model: "model-a", angle: "security", tokens: 210 },
+      ],
+    });
+    assert.equal(JSON.stringify(a), JSON.stringify(b));
+    assert.deepEqual(a, b);
+  });
+
   test("writes the artifact to its deterministic path", async () => {
     const ev = buildCacheTelemetryEvidence({
       plan: claudePlan(),

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -182,6 +182,21 @@ describe("buildCacheTelemetryEvidence — opaque harness never claims verified r
       () => buildCacheTelemetryEvidence({ plan: { gate: "g", headSha: "abcdef1234", planHash: "h" } }),
       /plan with requestGroups/,
     );
+    const anyway = { requestGroups: [{ model: "model-a" }] };
+    // Each new build-time guard fires independently on an otherwise-valid plan.
+    assert.throws(
+      () => buildCacheTelemetryEvidence({ plan: { ...anyway, gate: "" } }),
+      /non-empty gate/,
+    );
+    assert.throws(
+      () => buildCacheTelemetryEvidence({ plan: { ...anyway, gate: "g", headSha: "zz!" } }),
+      /hex headSha/,
+    );
+    assert.throws(
+      () =>
+        buildCacheTelemetryEvidence({ plan: { ...anyway, gate: "g", headSha: "abcdef1234", planHash: "" } }),
+      /non-empty planHash/,
+    );
     const plan = claudePlan();
     assert.throws(
       () => buildCacheTelemetryEvidence({ plan, primerCacheCreations: "nope" }),
@@ -290,6 +305,52 @@ describe("validateCacheTelemetryEvidence — fail-closed honesty gate", () => {
     const r = validateCacheTelemetryEvidence({ evidence: null });
     assert.equal(r.ok, false);
     assert.ok(r.failures.some((f) => f.check === "artifact"));
+  });
+
+  test("returns structured failures (never throws) on a truthy non-array events field", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    for (const bad of ["abc", { a: 1 }, 5]) {
+      const subverted = { ...ev, primerCacheCreations: bad };
+      assert.doesNotThrow(() => validateCacheTelemetryEvidence({ evidence: subverted }));
+      const r = validateCacheTelemetryEvidence({ evidence: subverted });
+      assert.equal(r.ok, false);
+      assert.ok(r.failures.some((f) => f.check === "aggregate_consistency"));
+    }
+  });
+
+  test("returns structured failures (never throws) on null/non-object array elements", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    for (const bad of [[null], ["x"], [null, { model: "model-a", tokens: 5 }]]) {
+      const subverted = { ...ev, primerCacheCreations: bad, creationCount: bad.length };
+      assert.doesNotThrow(() => validateCacheTelemetryEvidence({ evidence: subverted }));
+      const r = validateCacheTelemetryEvidence({ evidence: subverted });
+      assert.equal(r.ok, false);
+    }
+  });
+
+  test("fails closed on report prose contradicting cacheReuseVerified", () => {
+    const ev = buildCacheTelemetryEvidence({
+      plan: claudePlan(),
+      primerCacheCreations: [{ model: "model-a", tokens: 12000 }],
+      reviewerCacheReads: [{ model: "model-a", angle: "correctness", tokens: 200 }],
+    });
+    // Report claims "verified ... cache read" while machine verdict stays false.
+    const subverted = {
+      ...ev,
+      cacheReuseVerified: false,
+      aggregate: { ...ev.aggregate, report: "verified 1 cache read after 1 cache creation" },
+    };
+    const r = validateCacheTelemetryEvidence({ evidence: subverted });
+    assert.equal(r.ok, false);
+    assert.ok(r.failures.some((f) => f.check === "aggregate_consistency"));
   });
 });
 

--- a/packages/core/test/cache-telemetry-evidence.test.mjs
+++ b/packages/core/test/cache-telemetry-evidence.test.mjs
@@ -178,6 +178,10 @@ describe("buildCacheTelemetryEvidence — opaque harness never claims verified r
 
   test("fails closed on a missing requestGroups plan / non-array event lists", () => {
     assert.throws(() => buildCacheTelemetryEvidence({ plan: {} }), /plan with requestGroups/);
+    assert.throws(
+      () => buildCacheTelemetryEvidence({ plan: { gate: "g", headSha: "abcdef1234", planHash: "h" } }),
+      /plan with requestGroups/,
+    );
     const plan = claudePlan();
     assert.throws(
       () => buildCacheTelemetryEvidence({ plan, primerCacheCreations: "nope" }),

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -1085,6 +1085,24 @@ export async function consolidateGateFanin(options) {
     } catch {
       throw new Error(`--cache-telemetry "${options.cacheTelemetry}" is not valid JSON`);
     }
+    // Bind the artifact to this round's --head-sha/--gate when those are
+    // provided: a cache-telemetry artifact is <gate>-<headSha>-scoped evidence
+    // (GATE-EXEC-CACHE-TELEMETRY), so a stale or mismatched artifact for a
+    // DIFFERENT head or gate must fail closed rather than pass as this round's
+    // telemetry.
+    if (
+      options.headSha !== undefined &&
+      String(evidence?.headSha ?? "").trim().toLowerCase() !== options.headSha
+    ) {
+      throw new Error(`--cache-telemetry "${options.cacheTelemetry}" is stamped for head ${JSON.stringify(
+        evidence?.headSha,
+      )} but this round consolidates head ${options.headSha} — a stale/mismatched cache-telemetry artifact must not be accepted for a different head`);
+    }
+    if (options.gate !== undefined && String(evidence?.gate ?? "").trim() !== options.gate) {
+      throw new Error(`--cache-telemetry "${options.cacheTelemetry}" is stamped for gate ${JSON.stringify(
+        evidence?.gate,
+      )} but this round consolidates gate ${options.gate} — a mismatched cache-telemetry artifact must not be accepted`);
+    }
     try {
       enforceCacheTelemetryEvidence({ evidence });
     } catch (err) {

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -63,6 +63,7 @@ import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixe
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
 import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, normalizeSeverity, severityRank, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
+import { enforceCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { enforcePrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 
 const USAGE = `Usage: consolidate-fanin.mjs --findings-dir <dir> [--head-sha <sha>] [--gate <draft_gate|pre_approval_gate>] [--out <path>] [--ledger-out <path>] [--pr-checklist-matrix clean] [--carried-angles <json> --carry-forward-plan <json>] [--repo-root <path>] [--expected-dispatch-units <n>] [--tmp-root <path>]
@@ -189,6 +190,15 @@ Optional:
   --primer-plan <path>           The dispatch plan (buildReviewDispatchPlan output, carrying its
                                  requestGroups / planHash / sharedPrefixHash) the evidence was
                                  derived from, as JSON. Required together with --primer-evidence.
+  --cache-telemetry <path>       The before/after cache-telemetry evidence artifact
+                                 (<gate>-<headSha>.cache-telemetry.json, Phase 1.5 step 5) as JSON.
+                                 When given, the fan-in validates it via enforceCacheTelemetryEvidence
+                                 (GATE-EXEC-CACHE-TELEMETRY) and FAILS CLOSED (exit 1) when the
+                                 artifact is missing, when verified provider reuse is claimed for an
+                                 opaque/unavailable-telemetry harness, when a verified result lacks a
+                                 measured create-then-read sequence, or when the aggregate/token
+                                 report contradicts the recorded events. Absent the flag, the fan-in
+                                 proceeds unchanged (recording telemetry is progressive/optional).
   --tmp-root <path>              The tmp/ directory holding the reviewer sentinels and per-gate briefing-prefix
                                  records read by the briefing-prefix verification (default:
                                  process.cwd()/tmp). Sentinels are read directly from this directory
@@ -573,6 +583,7 @@ export function parseConsolidateFaninCliArgs(argv) {
     repoRoot: undefined,
     expectedDispatchUnits: undefined,
     primerEvidence: undefined,
+    cacheTelemetry: undefined,
     primerPlan: undefined,
     tmpRoot: undefined,
   };
@@ -718,6 +729,14 @@ export function parseConsolidateFaninCliArgs(argv) {
         throw parseError("--primer-plan requires a non-empty path");
       }
       options.primerPlan = p;
+      continue;
+    }
+    if (token.name === "cache-telemetry") {
+      const p = requireTokenValue(token, parseError).trim();
+      if (p.length === 0) {
+        throw parseError("--cache-telemetry requires a non-empty path");
+      }
+      options.cacheTelemetry = p;
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -1032,6 +1051,42 @@ export async function consolidateGateFanin(options) {
     const plan = await readJson(options.primerPlan, "plan");
     try {
       enforcePrimerEvidence({ plan, evidence });
+    } catch (err) {
+      throw new Error(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // GATE-EXEC-CACHE-TELEMETRY (#1476): the fan-in enforcing the before/after
+  // cache-telemetry evidence as a real fail-closed input to consolidation. The
+  // cache-telemetry artifact (Phase 1.5 step 5, `<gate>-<headSha>`
+  // `.cache-telemetry.json`) is passed as a single JSON path; when present the
+  // fan-in re-validates it via enforceCacheTelemetryEvidence and FAILS CLOSED
+  // (this throw -> exit 1) when the artifact is missing, when verified provider
+  // reuse is claimed for an opaque/unavailable-telemetry harness
+  // (opaque_veracity), when a verified result lacks a measured create-then-read
+  // sequence (measured_sequence), when the aggregate/token report contradicts
+  // the recorded events (aggregate_consistency / token_aggregate), or when the
+  // capability record is missing (capability_record) — the refusal names the
+  // failing check. This is the wiring that gives GATE-EXEC-CACHE-TELEMETRY a
+  // real invocation site (previously it was dead code referenced only by its
+  // own error-message string). Absent the flag the fan-in proceeds unchanged:
+  // recording telemetry is progressive / optional, so rounds that never recorded
+  // it (all pre-slice-4 rounds) are not newly blocked.
+  if (options.cacheTelemetry !== undefined) {
+    let text;
+    try {
+      text = await readFile(options.cacheTelemetry, "utf8");
+    } catch (err) {
+      throw new Error(`--cache-telemetry "${options.cacheTelemetry}" could not be read: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    let evidence;
+    try {
+      evidence = JSON.parse(text);
+    } catch {
+      throw new Error(`--cache-telemetry "${options.cacheTelemetry}" is not valid JSON`);
+    }
+    try {
+      enforceCacheTelemetryEvidence({ evidence });
     } catch (err) {
       throw new Error(err instanceof Error ? err.message : String(err));
     }

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -742,16 +742,20 @@ barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
 
 <!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
-`GATE-EXEC-CACHE-TELEMETRY`: cache-telemetry evidence (Phase 1.5 step 5,
-`<gate>-<headSha>.cache-telemetry.json`) MUST be validated via
-`@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
+`GATE-EXEC-CACHE-TELEMETRY`: when a round records cache-telemetry evidence
+(Phase 1.5 step 5, `<gate>-<headSha>.cache-telemetry.json`) it MUST be validated
+via `@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
 and fail closed — refusing to proceed to consolidation — when the artifact is
-missing, when verified provider reuse is claimed for a harness whose usage
+missing/malformed, when verified provider reuse is claimed for a harness whose usage
 telemetry is unavailable/opaque (`opaque_veracity`), when verified reuse lacks a
 measured create-then-read sequence (`measured_sequence`), or when the aggregate
 /token report contradicts the recorded events (`aggregate_consistency` /
 `token_aggregate`) or the capability record is missing
-(`capability_record`). This enforces the Section D honesty invariant: a harness
+(`capability_record`). Recording telemetry is progressive/optional: a round that
+never records an artifact (e.g. a pre-slice-4 round, or one run with `--cache-telemetry`
+omitted) is not newly blocked — the fail-closed path engages ONLY when the artifact
+is supplied (the `--cache-telemetry` flag), so a supplied-but-invalid artifact never
+passes. This enforces the Section D honesty invariant: a harness
 whose cache reuse is not measurable must never be reported as a verified `1
 write + N reads` result.
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -278,7 +278,19 @@ per-gate accounting is an optional follow-up, not a precondition.)
    each primer to its own model + request-prefix fingerprint and each released reviewer
    to a primer that landed before it. This is what lets fan-in fail closed (see
    Phase 3 — Consolidation) instead of trusting the rule in prose.
-5. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
+5. **Record before/after cache-telemetry evidence** — where the harness exposes
+   cache usage telemetry (issue #1468 slice 4), record the cache-creation
+   (“before”) and cache-read (“after”) events to the deterministic path
+   `<gate>-<headSha>.cache-telemetry.json` beside the gate-context artifacts:
+   `@dev-loops/core/loop/cache-telemetry-evidence` (`cacheTelemetryPath` /
+   `buildCacheTelemetryEvidence` / `writeCacheTelemetryEvidence`). The artifact
+   pairs the request plan + capability record with the observed creation/read
+   events and an aggregate read:create report. Where the harness is opaque or
+   telemetry is unavailable, the same builder records `cacheReuseVerified:
+   false` with the reason and MUST NOT be described as a verified `1 write + N
+   reads` outcome — only the ordering + request-fingerprint invariants from
+   steps 3-4 may be claimed (Section D honesty gate).
+6. **Release the fan-out** over the SAME model and the SAME byte-identical prefix, so each
    reviewer READS the cache the primer wrote instead of racing to write its own. A
    differing model or prefix defeats reuse and is the same failure the byte-identity rule
    already guards against.
@@ -728,6 +740,20 @@ plan hash is missing or mismatched. The refusal names the failing check
 `shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
 barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
+
+<!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
+`GATE-EXEC-CACHE-TELEMETRY`: cache-telemetry evidence (Phase 1.5 step 5,
+`<gate>-<headSha>.cache-telemetry.json`) MUST be validated via
+`@dev-loops/core/loop/cache-telemetry-evidence` `validateCacheTelemetryEvidence`
+and fail closed — refusing to proceed to consolidation — when the artifact is
+missing, when verified provider reuse is claimed for a harness whose usage
+telemetry is unavailable/opaque (`opaque_veracity`), when verified reuse lacks a
+measured create-then-read sequence (`measured_sequence`), or when the aggregate
+/token report contradicts the recorded events (`aggregate_consistency` /
+`token_aggregate`) or the capability record is missing
+(`capability_record`). This enforces the Section D honesty invariant: a harness
+whose cache reuse is not measurable must never be reported as a verified `1
+write + N reads` result.
 
 Merge the parallel reviewer findings into one consolidated fix plan with the
 sanctioned fan-in CLI:

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -275,6 +275,11 @@
       "enforcement": "runtime"
     },
     {
+      "id": "GATE-EXEC-CACHE-TELEMETRY",
+      "enforcement": "runtime",
+      "enforcementNote": "fan-in validates the recorded before/after cache-telemetry evidence via packages/core/src/loop/cache-telemetry-evidence.mjs validateCacheTelemetryEvidence"
+    },
+    {
       "id": "GATE-EXEC-PRIMER-EVIDENCE",
       "enforcement": "runtime",
       "enforcementNote": "fan-in validates the recorded primer dispatch evidence via packages/core/src/loop/primer-evidence.mjs validatePrimerEvidence"

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -792,6 +792,21 @@ test("consolidateGateFanin fails closed on an unreadable/malformed cache-telemet
   );
 });
 
+test("consolidateGateFanin fails closed on a missing (unreadable) cache-telemetry path", async () => {
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await assert.rejects(
+        consolidateGateFanin({
+          findingsDir: dir,
+          cacheTelemetry: "/nonexistent/cache-telemetry.json",
+        }),
+        (err) => err.message.includes("could not be read"),
+      );
+    },
+  );
+});
+
 test("consolidateGateFanin proceeds unchanged without a cache-telemetry artifact", async () => {
   await withFindingsDir(
     { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -723,14 +723,52 @@ async function withTelemetryFile(filename, content, fn) {
 test("consolidateGateFanin enforces valid cache-telemetry evidence (GATE-EXEC-CACHE-TELEMETRY)", async () => {
   const evidence = makeTelemetryEvidence();
   await withFindingsDir(
-    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [], headSha: TELEMETRY_HEAD } },
     async (dir) => {
       await withTelemetryFile("cache-telemetry.json", evidence, async (tdir) => {
         const result = await consolidateGateFanin({
           findingsDir: dir,
           cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+          headSha: TELEMETRY_HEAD,
+          gate: "pre_approval_gate",
         });
         assert.equal(result.ok, true);
+      });
+    },
+  );
+});
+
+test("consolidateGateFanin fails closed on a cache-telemetry artifact stamped for a different head/gate", async () => {
+  // The artifact is <gate>-<headSha>-scoped evidence: a stale/mismatched
+  // artifact for a different head OR gate must fail closed rather than pass as
+  // this round's telemetry when --head-sha/--gate are provided.
+  const evidence = makeTelemetryEvidence(); // stamped for TELEMETRY_HEAD / pre_approval_gate
+  const wrongHead = { ...evidence, headSha: "ffffffffffffffffffffffffffffffffffffffff" };
+  const wrongGate = { ...evidence, gate: "draft_gate" };
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [], headSha: TELEMETRY_HEAD } },
+    async (dir) => {
+      await withTelemetryFile("cache-telemetry.json", wrongHead, async (tdir) => {
+        await assert.rejects(
+          consolidateGateFanin({
+            findingsDir: dir,
+            cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+            headSha: TELEMETRY_HEAD,
+            gate: "pre_approval_gate",
+          }),
+          (err) => err.message.includes("stale/mismatched cache-telemetry artifact"),
+        );
+      });
+      await withTelemetryFile("cache-telemetry.json", wrongGate, async (tdir) => {
+        await assert.rejects(
+          consolidateGateFanin({
+            findingsDir: dir,
+            cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+            headSha: TELEMETRY_HEAD,
+            gate: "pre_approval_gate",
+          }),
+          (err) => err.message.includes("mismatched cache-telemetry artifact"),
+        );
       });
     },
   );

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -12,6 +12,7 @@ import {
 import { writeGateFindingsLog } from "../../scripts/github/write-gate-findings-log.mjs";
 import { normalizeStructuredFindings, renderGateReviewCommentBody } from "../../scripts/github/upsert-checkpoint-verdict.mjs";
 import { checkFanoutAngleCoverage } from "@dev-loops/core/loop/gate-fanin";
+import { buildCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { buildPrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 import { buildReviewDispatchPlan, CACHE_BOUNDARY_AFTER_SHARED_PREFIX, PRIMER_FORM_LEAD_REVIEWER } from "@dev-loops/core/loop/review-dispatch-plan";
 import { runNode } from "../_helpers.mjs";
@@ -668,6 +669,136 @@ test("parseConsolidateFaninCliArgs rejects --primer-evidence without --primer-pl
   assert.throws(
     () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--primer-plan", "/tmp/p.json"]),
     /--primer-evidence and --primer-plan must be given together/,
+  );
+});
+
+// --------------------------------------------------------------------------
+// GATE-EXEC-CACHE-TELEMETRY wiring (#1476): the fan-in enforces the before/after
+// cache-telemetry evidence via enforceCacheTelemetryEvidence, failing closed on
+// an opaque/over-claimed/unmeasured artifact — and proceeds unchanged when the
+// flag is absent (progressive/optional recording).
+// --------------------------------------------------------------------------
+
+const TELEMETRY_HEAD = "abcdef1234567890abcdef1234567890abcdef12";
+
+function makeTelemetryPlan() {
+  return buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: TELEMETRY_HEAD,
+    sharedPrefixHash: PRIMER_FP,
+    requestGroups: [
+      {
+        model: "model-a",
+        requestPrefixFingerprint: PRIMER_FP,
+        cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+        ttlIntent: "1h",
+        angles: ["scope"],
+      },
+    ],
+    capabilities: { harness: "claude" },
+  });
+}
+
+function makeTelemetryEvidence() {
+  return buildCacheTelemetryEvidence({
+    plan: makeTelemetryPlan(),
+    primerCacheCreations: [{ model: "model-a", primerForm: "lead_reviewer", tokens: 12000 }],
+    reviewerCacheReads: [
+      { model: "model-a", angle: "scope", tokens: 200 },
+      { model: "model-a", angle: "dry", tokens: 210 },
+    ],
+  });
+}
+
+async function withTelemetryFile(filename, content, fn) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "cache-telemetry-"));
+  try {
+    await writeFile(path.join(dir, filename), typeof content === "string" ? content : JSON.stringify(content), "utf8");
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("consolidateGateFanin enforces valid cache-telemetry evidence (GATE-EXEC-CACHE-TELEMETRY)", async () => {
+  const evidence = makeTelemetryEvidence();
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withTelemetryFile("cache-telemetry.json", evidence, async (tdir) => {
+        const result = await consolidateGateFanin({
+          findingsDir: dir,
+          cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+        });
+        assert.equal(result.ok, true);
+      });
+    },
+  );
+});
+
+test("consolidateGateFanin fails closed on cache telemetry over-claiming opaque reuse", async () => {
+  // Build under an opaque (pi) harness then mutate the verdict to simulate an
+  // over-claim; the fan-in must refuse it as an opaque_veracity violation.
+  const plan = buildReviewDispatchPlan({
+    gate: "pre_approval_gate",
+    headSha: TELEMETRY_HEAD,
+    requestGroups: [
+      {
+        model: "model-a",
+        requestPrefixFingerprint: PRIMER_FP,
+        cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+        ttlIntent: "1h",
+        angles: ["scope"],
+      },
+    ],
+    capabilities: { harness: "pi" },
+  });
+  const honest = buildCacheTelemetryEvidence({
+    plan,
+    primerCacheCreations: [{ model: "model-a" }],
+    reviewerCacheReads: [{ model: "model-a", angle: "scope" }],
+  });
+  const subverted = { ...honest, cacheReuseVerified: true };
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withTelemetryFile("cache-telemetry.json", subverted, async (tdir) => {
+        await assert.rejects(
+          consolidateGateFanin({
+            findingsDir: dir,
+            cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+          }),
+          (err) => err.message.includes("GATE-EXEC-CACHE-TELEMETRY") && err.message.includes("opaque_veracity"),
+        );
+      });
+    },
+  );
+});
+
+test("consolidateGateFanin fails closed on an unreadable/malformed cache-telemetry artifact", async () => {
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      await withTelemetryFile("cache-telemetry.json", "{ not json", async (tdir) => {
+        await assert.rejects(
+          consolidateGateFanin({
+            findingsDir: dir,
+            cacheTelemetry: path.join(tdir, "cache-telemetry.json"),
+          }),
+          (err) => err.message.includes("not valid JSON"),
+        );
+      });
+    },
+  );
+});
+
+test("consolidateGateFanin proceeds unchanged without a cache-telemetry artifact", async () => {
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [] } },
+    async (dir) => {
+      const result = await consolidateGateFanin({ findingsDir: dir });
+      assert.equal(result.ok, true);
+    },
   );
 });
 


### PR DESCRIPTION
## Summary

Slice 4 of #1468 (cache-aware review dispatch): adds the harness-capability-aware cache telemetry adapter plus a deterministic before/after cache-state evidence artifact to the cache-aware review dispatch, building on slices 1-3 (dispatch plan, fingerprinting, stable/volatile split, primer-dispatch evidence). Where a harness exposes cache usage telemetry it records the measured create-then-read sequence; where it is opaque it records `cacheReuseVerified: false` and never claims a verified `1 write + N reads` outcome (Section D honesty gate).

## Acceptance criteria

- [x] At least one telemetry-capable integration or reproducible adapter test records one cache creation followed by cache reads for a multi-reviewer group.
- [x] A before/after evidence artifact reports cache creation and read counts, or — where the harness is opaque — states clearly that provider reuse could not be verified.
- [x] No code path or document describes an opaque harness's behaviour as a verified 1-write-N-reads result.
- [x] The evidence artifact is written at a deterministic path and is consumable by the gate ledger without re-derivation.

## Non-goals

- Claiming provider cache reuse from artifact hashes or request fingerprints alone.
- Turning telemetry recording into a merge-blocking requirement (recording is progressive/optional; a round that omits the artifact is not rejected).
- Changing gate verdict semantics or what any angle evaluates.

## Definition of done

- [x] Every acceptance criterion is covered by an executable test or captured harness evidence.
- [x] `npm run verify` passes and `node scripts/claude/generate-claude-assets.mjs --check` leaves the tree clean (`assets:check` + `schema:check` clean).
- [x] Contract doc (`skills/docs/gate-review-sub-loop-contract.md`) and its generated `.claude` mirror are updated in the same change; `required-rules.json` registers `GATE-EXEC-CACHE-TELEMETRY`.
- [x] Existing fresh-context, one-reviewer-per-angle, briefing-prefix hash, carry-forward and fan-in guarantees remain green.

## Validation

`npm run verify`, `assets:check`, `schema:check`, and `test:docs` all pass. Run via the gate's `run-gate-validation.mjs` at each head.

Closes #1476
