### PR TITLE
feat(loop): lineage compaction/rebase policy + end-to-end fixture (#1478)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1708,12 +1708,47 @@ carried clean angle still records its ORIGINAL reviewer and PRIOR head,
 unchanged from the existing carry-forward contract. The composed request weaves
 that provenance into its `composedHash`.
 
+### Compaction / rebase policy (slice 6)
+
+Unbounded delta accumulation would eventually overflow provider prompt-cache
+breakpoint/lookback limits and the context window. A documented compaction
+(rebase) rule bounds the composed lineage so it cannot grow without limit.
+
+**Threshold.** A rebase is triggered when EITHER bound is exceeded:
+
+- the accumulated round-delta count exceeds `maxRounds` (default
+  `DEFAULT_LINEAGE_MAX_ROUNDS`, `20`), OR
+- the composed lineage byte size exceeds `maxLineageBytes` (a provider context
+  budget a consumer may set) when one is configured.
+
+`checkLineageCompaction({ lineageBase, deltas, maxRounds, maxLineageBytes })`
+returns `{ requiresCompaction, reason, ... }` (pure predicate — never mutates).
+
+**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas })` folds the
+accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
+advances to the latest reviewed head and `originalDiff` becomes the cumulative
+diff (original full diff merged with every accepted fix diff, in order). The
+compacted base keeps the same `lineageId`/`gate`, is itself a valid base that
+`composeRoundRequest` accepts unchanged, and records `rebaseSourceBaseHash` +
+`compactedRoundCount` for traceability. Subsequent rounds append fresh deltas
+to the compacted base, so the composed request stays within the provider
+breakpoint/lookback + context budget. Composition rules are preserved: a new
+round-1 delta whose `baseHead` equals the compacted base's `originalHead`
+composes cleanly, byte-deterministically, with SHA-chain continuity. Prior
+delta artifacts remain available (append-only history); only the composed
+request is recomposed from the compacted base.
+
+Covered by the compaction suite in `packages/core/test/review-lineage.test.mjs`
+and the end-to-end fixture `packages/core/test/review-lineage-e2e-fixture.test.mjs`
+(driving request plan → primer → fan-out/fan-in → lineage delta → compaction
+for two rounds).
+
 ### Non-goals preserved
 
-- No provider cache-reuse claim from artifact hashes (slice-5 keeps that out of
-  scope; telemetry capability rules live in `review-dispatch-plan.mjs`).
-- No continuity-reviewer convergence loop, calibration audit, or compaction
-  policy yet — those are later #1468 slices (6/7/8) and are NOT introduced here.
+- No provider cache-reuse claim from artifact hashes (telemetry capability
+  rules live in `review-dispatch-plan.mjs`).
+- No continuity-reviewer convergence loop or calibration audit yet — those are
+  later #1468 slices (6/7) and are NOT introduced here.
 - Round-1 fresh one-reviewer-per-angle provenance and fan-in semantics are
   untouched.
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1724,13 +1724,16 @@ breakpoint/lookback limits and the context window. A documented compaction
 `checkLineageCompaction({ lineageBase, deltas, maxRounds, maxLineageBytes })`
 returns `{ requiresCompaction, reason, ... }` (pure predicate — never mutates).
 
-**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas })` folds the
-accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
+**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas, currentDiff? })` folds
+the accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
 advances to the latest reviewed head and `originalDiff` becomes the cumulative
-diff (original full diff merged with every accepted fix diff, in order). The
+/ concatenated diff text (the original full diff joined with every accepted fix
+diff, in order — an accumulated text fold, not a patched merge). A caller may
+explicitly supply `currentDiff` to override that folded text outright. The
 compacted base keeps the same `lineageId`/`gate`, is itself a valid base that
 `composeRoundRequest` accepts unchanged, and records `rebaseSourceBaseHash` +
-`compactedRoundCount` for traceability. Subsequent rounds append fresh deltas
+`compactedRoundCount` (and sets the reserved `compaction: true` marker field)
+for traceability. Subsequent rounds append fresh deltas
 to the compacted base, so the composed request stays within the provider
 breakpoint/lookback + context budget. Composition rules are preserved: a new
 round-1 delta whose `baseHead` equals the compacted base's `originalHead`

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -533,6 +533,9 @@ export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
     if (d.round !== i + 1) {
       throw new Error(`rebaseLineage deltas must be contiguous from round 1; expected round ${i + 1}, got ${d.round}`);
     }
+    if (d.fixDiff == null || String(d.fixDiff).length === 0) {
+      throw new Error(`rebaseLineage deltas[${i}] requires a non-empty fixDiff (the actual fix diff)`);
+    }
   }
   // SHA-chain continuity across the accumulated deltas (keep the composed
   // request truthful — same rule `composeRoundRequest` enforces).

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -427,6 +427,11 @@ export function lineageByteSize({ lineageBase, deltas = [] } = {}) {
     if (!d || d.kind !== "round-delta" || !isSha256(d.deltaHash)) {
       throw new Error(`lineageByteSize deltas[${i}] must be a valid round-delta artifact`);
     }
+    if (d.lineageId !== lineageBase.lineageId || d.gate !== lineageBase.gate) {
+      throw new Error(
+        `lineageByteSize deltas[${i}] must share the lineage base's lineageId and gate (parity with rebaseLineage/composeRoundRequest)`,
+      );
+    }
     total += utf8Length(d);
   }
   return total;
@@ -551,10 +556,11 @@ export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
 
   let diff;
   if (currentDiff != null) {
-    diff = normalizeText(currentDiff, "currentDiff");
-    if (diff.length === 0) {
+    const isEmpty = Buffer.isBuffer(currentDiff) ? currentDiff.length === 0 : String(currentDiff).length === 0;
+    if (isEmpty) {
       throw new Error("rebaseLineage currentDiff must be non-empty");
     }
+    diff = normalizeText(currentDiff, "currentDiff");
   } else if (deltas.length === 0) {
     diff = lineageBase.originalDiff;
   } else {

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -518,6 +518,9 @@ export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
     if (d.gate !== lineageBase.gate) {
       throw new Error("rebaseLineage deltas gate must match the lineage base gate");
     }
+    if (d.round !== i + 1) {
+      throw new Error(`rebaseLineage deltas must be contiguous from round 1; expected round ${i + 1}, got ${d.round}`);
+    }
   }
   // SHA-chain continuity across the accumulated deltas (keep the composed
   // request truthful — same rule `composeRoundRequest` enforces).
@@ -537,11 +540,14 @@ export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
   }
 
   let newOriginalHead = lineageBase.originalHead;
-  if (deltas.length > 0) newOriginalHead = deltas[deltas.length - 1].reviewedHead;
+  if (deltas.length > 0) newOriginalHead = deltas[deltas.length - 1].reviewedHead.trim().toLowerCase();
 
   let diff;
   if (currentDiff != null) {
     diff = normalizeText(currentDiff, "currentDiff");
+    if (diff.length === 0) {
+      throw new Error("rebaseLineage currentDiff must be non-empty");
+    }
   } else if (deltas.length === 0) {
     diff = lineageBase.originalDiff;
   } else {

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -417,13 +417,14 @@ export function lineageByteSize({ lineageBase, deltas = [] } = {}) {
     throw new Error("lineageByteSize requires a valid lineage base artifact");
   }
   if (!Array.isArray(deltas)) throw new Error("lineageByteSize deltas must be an array");
-  let total = canonicalJson(lineageBase).length;
+  const utf8Length = (v) => Buffer.byteLength(canonicalJson(v), "utf8");
+  let total = utf8Length(lineageBase);
   for (let i = 0; i < deltas.length; i++) {
     const d = deltas[i];
     if (!d || d.kind !== "round-delta" || !isSha256(d.deltaHash)) {
       throw new Error(`lineageByteSize deltas[${i}] must be a valid round-delta artifact`);
     }
-    total += canonicalJson(d).length;
+    total += utf8Length(d);
   }
   return total;
 }
@@ -448,6 +449,7 @@ export function checkLineageCompaction({ lineageBase, deltas = [], maxRounds = D
   if (maxLineageBytes != null && (!Number.isInteger(maxLineageBytes) || maxLineageBytes < 1)) {
     throw new Error(`checkLineageCompaction maxLineageBytes must be a positive integer, got ${JSON.stringify(maxLineageBytes)}`);
   }
+  if (!Array.isArray(deltas)) throw new Error("checkLineageCompaction deltas must be an array");
   const deltaCount = deltas.length;
   const lineageBytes = lineageByteSize({ lineageBase, deltas });
   let reason = null;
@@ -509,6 +511,9 @@ export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
     }
     if (!isSha256(d.deltaHash)) {
       throw new Error(`rebaseLineage deltas[${i}].deltaHash must be a valid sha256:<64hex>`);
+    }
+    if (!isHexSha(d.baseHead) || !isHexSha(d.reviewedHead)) {
+      throw new Error(`rebaseLineage deltas[${i}].baseHead/reviewedHead must be full hex SHAs`);
     }
     if (d.gate !== lineageBase.gate) {
       throw new Error("rebaseLineage deltas gate must match the lineage base gate");

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -382,3 +382,180 @@ export function renderComposedRequest(composed) {
   }
   return composed.segments.map((s) => (s.bytes == null ? "" : String(s.bytes))).join("");
 }
+
+/* ------------------------------------------------------------------ *
+ * Compaction / rebase policy (issue #1468 slice 6)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Default lineage compaction threshold: the maximum number of accumulated
+ * round-delta segments a review lineage may carry before it MUST be compacted
+ * (rebased). Provider prompt caches are bounded by breakpoint/lookback limits
+ * and context-window size; unbounded delta accumulation would eventually
+ * overflow them. Consumers may raise or lower this, and may additionally set a
+ * byte budget (`maxLineageBytes`) to bound provider-visible context size
+ * directly.
+ *
+ * A rebase is triggered when EITHER bound is exceeded:
+ *   - round-delta count exceeds `maxRounds` (default 20), OR
+ *   - the composed lineage byte size exceeds `maxLineageBytes` when provided.
+ */
+export const DEFAULT_LINEAGE_MAX_ROUNDS = 20;
+
+/**
+ * Total composed byte size of a lineage (base + all accumulated deltas), using
+ * the same canonical byte-serialization that `composeRoundRequest` renders.
+ * Used to enforce a provider context-size budget independently of round count.
+ *
+ * @param {object} input
+ * @param {object} input.lineageBase - valid review-lineage-base.
+ * @param {object[]} [input.deltas] - accumulated round deltas.
+ * @returns {number} total composed byte size.
+ */
+export function lineageByteSize({ lineageBase, deltas = [] } = {}) {
+  if (!lineageBase || lineageBase.kind !== "review-lineage-base" || !isSha256(lineageBase.baseHash)) {
+    throw new Error("lineageByteSize requires a valid lineage base artifact");
+  }
+  if (!Array.isArray(deltas)) throw new Error("lineageByteSize deltas must be an array");
+  let total = canonicalJson(lineageBase).length;
+  for (let i = 0; i < deltas.length; i++) {
+    const d = deltas[i];
+    if (!d || d.kind !== "round-delta" || !isSha256(d.deltaHash)) {
+      throw new Error(`lineageByteSize deltas[${i}] must be a valid round-delta artifact`);
+    }
+    total += canonicalJson(d).length;
+  }
+  return total;
+}
+
+/**
+ * Decide whether a review lineage must be compacted (rebased) now, against the
+ * compaction threshold(s). Pure predicate — it never mutates the lineage.
+ *
+ * @param {object} input
+ * @param {object} input.lineageBase - valid review-lineage-base.
+ * @param {object[]} [input.deltas] - accumulated round deltas.
+ * @param {number} [input.maxRounds] - max delta rounds before a rebase (default
+ *   {@link DEFAULT_LINEAGE_MAX_ROUNDS}).
+ * @param {number} [input.maxLineageBytes] - optional provider context byte
+ *   budget; a lineage whose composed size exceeds it must be rebased.
+ * @returns {{ requiresCompaction: boolean, reason: string|null, deltaCount: number, lineageBytes: number, maxRounds: number, maxLineageBytes: number|null }}
+ */
+export function checkLineageCompaction({ lineageBase, deltas = [], maxRounds = DEFAULT_LINEAGE_MAX_ROUNDS, maxLineageBytes } = {}) {
+  if (!Number.isInteger(maxRounds) || maxRounds < 1) {
+    throw new Error(`checkLineageCompaction maxRounds must be a positive integer, got ${JSON.stringify(maxRounds)}`);
+  }
+  if (maxLineageBytes != null && (!Number.isInteger(maxLineageBytes) || maxLineageBytes < 1)) {
+    throw new Error(`checkLineageCompaction maxLineageBytes must be a positive integer, got ${JSON.stringify(maxLineageBytes)}`);
+  }
+  const deltaCount = deltas.length;
+  const lineageBytes = lineageByteSize({ lineageBase, deltas });
+  let reason = null;
+  if (deltaCount > maxRounds) {
+    reason = `delta count ${deltaCount} exceeds maxRounds ${maxRounds}`;
+  } else if (maxLineageBytes != null && lineageBytes > maxLineageBytes) {
+    reason = `composed lineage bytes ${lineageBytes} exceed maxLineageBytes ${maxLineageBytes}`;
+  }
+  return {
+    requiresCompaction: reason !== null,
+    reason,
+    deltaCount,
+    lineageBytes,
+    maxRounds,
+    maxLineageBytes: maxLineageBytes ?? null,
+  };
+}
+
+/**
+ * Compact (rebase) a review lineage.
+ *
+ * When the delta accumulation crosses the compaction threshold, the lineage is
+ * rebased: the accumulated deltas are folded into a NEW compacted base whose
+ * `originalHead` advances to the current (latest reviewed) head and whose
+ * `originalDiff` becomes the cumulative diff (the base's original full diff
+ * merged with every accepted fix diff, in order). Future rounds append fresh
+ * deltas to this compacted base, so the COMPOSED request stays within the
+ * provider breakpoint/lookback + context budget instead of growing unbounded.
+ *
+ * Rebase behaviour guarantees:
+ *   - The compacted base keeps the same `lineageId` and `gate` and is itself a
+ *     valid `review-lineage-base`; `composeRoundRequest` accepts it unchanged.
+ *   - Composition rules are preserved: a new round-1 delta whose `baseHead`
+ *     equals the compacted base's `originalHead` composes cleanly and
+ *     byte-deterministically (SHA-chain continuity + append-only contract).
+ *   - The rebase is traceable: the compacted base records `rebaseSourceBaseHash`
+ *     (the base it was compacted from) and `compactedRoundCount` (the total
+ *     number of fix rounds folded into this compacted lineage so far). Prior
+ *     delta artifacts remain available (append-only history); only the COMPOSED
+ *     request is recomposed from the compacted base.
+ *
+ * @param {object} input
+ * @param {object} input.lineageBase - valid review-lineage-base.
+ * @param {object[]} [input.deltas] - all accumulated round deltas in order.
+ * @param {string|string[]|Buffer} [input.currentDiff] - optional cumulative diff
+ *   for the rebased `originalDiff`; defaults to the base's original diff merged
+ *   with every delta's fix diff.
+ * @returns {Readonly<object>} compacted review-lineage-base artifact.
+ */
+export function rebaseLineage({ lineageBase, deltas = [], currentDiff } = {}) {
+  if (!lineageBase || lineageBase.kind !== "review-lineage-base" || !isSha256(lineageBase.baseHash)) {
+    throw new Error("rebaseLineage requires a valid lineage base artifact");
+  }
+  if (!Array.isArray(deltas)) throw new Error("rebaseLineage deltas must be an array");
+  for (let i = 0; i < deltas.length; i++) {
+    const d = deltas[i];
+    if (!d || d.kind !== "round-delta" || d.lineageId !== lineageBase.lineageId) {
+      throw new Error("rebaseLineage deltas must be valid round-delta artifacts of the same lineage");
+    }
+    if (!isSha256(d.deltaHash)) {
+      throw new Error(`rebaseLineage deltas[${i}].deltaHash must be a valid sha256:<64hex>`);
+    }
+    if (d.gate !== lineageBase.gate) {
+      throw new Error("rebaseLineage deltas gate must match the lineage base gate");
+    }
+  }
+  // SHA-chain continuity across the accumulated deltas (keep the composed
+  // request truthful — same rule `composeRoundRequest` enforces).
+  for (let i = 0; i < deltas.length; i++) {
+    const d = deltas[i];
+    if (i === 0) {
+      if (d.baseHead !== lineageBase.originalHead) {
+        throw new Error(
+          `rebaseLineage round-1 baseHead ${d.baseHead} must equal the lineage base originalHead ${lineageBase.originalHead}`,
+        );
+      }
+    } else if (d.baseHead !== deltas[i - 1].reviewedHead) {
+      throw new Error(
+        `rebaseLineage round-${d.round} baseHead ${d.baseHead} must equal prior round reviewedHead ${deltas[i - 1].reviewedHead}`,
+      );
+    }
+  }
+
+  let newOriginalHead = lineageBase.originalHead;
+  if (deltas.length > 0) newOriginalHead = deltas[deltas.length - 1].reviewedHead;
+
+  let diff;
+  if (currentDiff != null) {
+    diff = normalizeText(currentDiff, "currentDiff");
+  } else if (deltas.length === 0) {
+    diff = lineageBase.originalDiff;
+  } else {
+    diff = [lineageBase.originalDiff, ...deltas.map((d) => normalizeText(d.fixDiff, "fixDiff"))].join("\n");
+  }
+
+  const compacted = {
+    kind: "review-lineage-base",
+    lineageId: lineageBase.lineageId,
+    gate: lineageBase.gate,
+    originalHead: newOriginalHead,
+    originalDiff: diff,
+    stableContracts: lineageBase.stableContracts,
+    compaction: true,
+    rebaseSourceBaseHash: lineageBase.baseHash,
+    compactedRoundCount: (lineageBase.compactedRoundCount ?? 0) + deltas.length,
+  };
+  return Object.freeze({
+    ...compacted,
+    baseHash: sha256Hex(compacted),
+  });
+}

--- a/packages/core/src/loop/review-lineage.mjs
+++ b/packages/core/src/loop/review-lineage.mjs
@@ -403,9 +403,12 @@ export function renderComposedRequest(composed) {
 export const DEFAULT_LINEAGE_MAX_ROUNDS = 20;
 
 /**
- * Total composed byte size of a lineage (base + all accumulated deltas), using
- * the same canonical byte-serialization that `composeRoundRequest` renders.
- * Used to enforce a provider context-size budget independently of round count.
+ * Total byte size of a lineage's accumulated artifact content (base + all
+ * accumulated deltas), using the same canonical byte-serialization that
+ * `composeRoundRequest` renders. Used to enforce a byte budget on the only part
+ * of a round request that grows across fix rounds (round-delta accumulation).
+ * It counts the lineage artifacts themselves, not the per-round angle-suffix /
+ * carried-angle context (constant regardless of round count).
  *
  * @param {object} input
  * @param {object} input.lineageBase - valid review-lineage-base.
@@ -438,8 +441,12 @@ export function lineageByteSize({ lineageBase, deltas = [] } = {}) {
  * @param {object[]} [input.deltas] - accumulated round deltas.
  * @param {number} [input.maxRounds] - max delta rounds before a rebase (default
  *   {@link DEFAULT_LINEAGE_MAX_ROUNDS}).
- * @param {number} [input.maxLineageBytes] - optional provider context byte
- *   budget; a lineage whose composed size exceeds it must be rebased.
+ * @param {number} [input.maxLineageBytes] - optional byte budget over the
+ *   accumulated lineage (base + deltas — the ONLY part of a round request that
+ *   grows with fix rounds); a lineage whose accumulated size exceeds it must
+ *   be rebased. Per-round angle-suffix and carried-angle context are constant
+ *   regardless of round count, so they are deliberately not part of this
+ *   growing-lineage bound.
  * @returns {{ requiresCompaction: boolean, reason: string|null, deltaCount: number, lineageBytes: number, maxRounds: number, maxLineageBytes: number|null }}
  */
 export function checkLineageCompaction({ lineageBase, deltas = [], maxRounds = DEFAULT_LINEAGE_MAX_ROUNDS, maxLineageBytes } = {}) {

--- a/packages/core/test/fixtures/lineage-e2e/pipeline.json
+++ b/packages/core/test/fixtures/lineage-e2e/pipeline.json
@@ -1,0 +1,83 @@
+{
+  "description": "Two-round cache-aware review pipeline fixture (issue #1468 slice 6 e2e): context build -> request plan -> primer -> fan-out -> fan-in -> lineage delta, then compaction.",
+  "gate": "pre_approval_gate",
+  "model": "model-a",
+  "angles": [
+    "correctness",
+    "security"
+  ],
+  "sharedPrefixHash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "requestPrefixFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "originalDiff": "diff --git a/src/pipeline.mjs b/src/pipeline.mjs\n-original\n+intro\nindex = start\n",
+  "rounds": [
+    {
+      "round": 1,
+      "head": "1111111111111111111111111111111111111111111111111111111111111111",
+      "fixDiff": "diff --git a/src/pipeline.mjs b/src/pipeline.mjs\n+fix one\nwindow = bounded\n",
+      "angleResults": [
+        {
+          "angle": "correctness",
+          "findings": [
+            {
+              "severity": "high",
+              "summary": "legacy retry leaves an unbounded accumulator",
+              "file": "src/pipeline.mjs",
+              "line": 12
+            }
+          ],
+          "verdict": "findings_present"
+        },
+        {
+          "angle": "security",
+          "findings": [],
+          "verdict": "clean"
+        }
+      ],
+      "validation": {
+        "tests": "npm test",
+        "result": "pass",
+        "head": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "checklist": [
+        {
+          "id": "F1",
+          "severity": "high",
+          "check": "verify fix one bounds the accumulator",
+          "resolved": true,
+          "evidence": "test-assert"
+        }
+      ]
+    },
+    {
+      "round": 2,
+      "head": "2222222222222222222222222222222222222222222222222222222222222222",
+      "fixDiff": "diff --git a/src/pipeline.mjs b/src/pipeline.mjs\n+fix two\nwindow read = bounded\n",
+      "angleResults": [
+        {
+          "angle": "correctness",
+          "findings": [],
+          "verdict": "clean"
+        },
+        {
+          "angle": "security",
+          "findings": [],
+          "verdict": "clean"
+        }
+      ],
+      "validation": {
+        "tests": "npm test",
+        "result": "pass",
+        "head": "2222222222222222222222222222222222222222222222222222222222222222"
+      },
+      "checklist": [
+        {
+          "id": "F1",
+          "severity": "high",
+          "check": "verify fix one bounds the accumulator",
+          "resolved": true,
+          "evidence": "test-assert"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/fixtures/lineage-e2e/pipeline.json
+++ b/packages/core/test/fixtures/lineage-e2e/pipeline.json
@@ -1,6 +1,7 @@
 {
   "description": "Two-round cache-aware review pipeline fixture (issue #1468 slice 6 e2e): context build -> request plan -> primer -> fan-out -> fan-in -> lineage delta, then compaction.",
   "gate": "pre_approval_gate",
+  "baseHead": "0000000000000000000000000000000000000000000000000000000000000000",
   "model": "model-a",
   "angles": [
     "correctness",

--- a/packages/core/test/review-lineage-e2e-fixture.test.mjs
+++ b/packages/core/test/review-lineage-e2e-fixture.test.mjs
@@ -45,7 +45,7 @@ describe("review-lineage e2e fixture (2 rounds + compaction)", () => {
     const lineageBase = buildReviewLineageBase({
       lineageId: "fixture-1",
       gate: FIXTURE.gate,
-      originalHead: FIXTURE.rounds[0].head,
+      originalHead: FIXTURE.baseHead,
       originalDiff: FIXTURE.originalDiff,
       stableContracts: "review agent instructions v1",
     });
@@ -119,7 +119,7 @@ describe("review-lineage e2e fixture (2 rounds + compaction)", () => {
     const lineageBase = buildReviewLineageBase({
       lineageId: "fixture-1",
       gate: FIXTURE.gate,
-      originalHead: round1.head,
+      originalHead: FIXTURE.baseHead,
       originalDiff: FIXTURE.originalDiff,
       stableContracts: "review agent instructions v1",
     });
@@ -157,7 +157,7 @@ describe("review-lineage e2e fixture (2 rounds + compaction)", () => {
     // Round 1 delta + round 2 delta compose append-only.
     const delta1 = buildFixRoundDelta({
       lineageId: "fixture-1", round: 1, gate: FIXTURE.gate,
-      baseHead: round1.head, reviewedHead: round1.head, fixDiff: round1.fixDiff,
+      baseHead: lineageBase.originalHead, reviewedHead: round1.head, fixDiff: round1.fixDiff,
       validationEvidence: round1.validation, findingsChecklist: round1.checklist,
     });
     const delta2 = buildFixRoundDelta({

--- a/packages/core/test/review-lineage-e2e-fixture.test.mjs
+++ b/packages/core/test/review-lineage-e2e-fixture.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test, { describe } from "node:test";
+
+import {
+  buildReviewDispatchPlan,
+  CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+  PRIMER_FORM_LEAD_REVIEWER,
+} from "../src/loop/review-dispatch-plan.mjs";
+import {
+  buildPrimerEvidence,
+  validatePrimerEvidence,
+} from "../src/loop/primer-evidence.mjs";
+import {
+  consolidateFanin,
+  planFanoutBatches,
+} from "../src/loop/gate-fanin.mjs";
+import {
+  buildFixRoundDelta,
+  buildReviewLineageBase,
+  checkLineageCompaction,
+  composeRoundRequest,
+  rebaseLineage,
+} from "../src/loop/review-lineage.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "lineage-e2e", "pipeline.json"), "utf8"),
+);
+
+/**
+ * End-to-end lineage fixture (issue #1468 slice 6): drives the real cache-aware
+ * review pipeline across two rounds and closes with a compaction, in the order
+ * the #1478 AC demands:
+ *
+ *   context build -> request plan -> primer -> fan-out -> fan-in -> lineage delta
+ *
+ * Every step uses its production module — no inline re-implementations.
+ */
+describe("review-lineage e2e fixture (2 rounds + compaction)", () => {
+  test("round 1: build plan -> prime -> fan-out/fan-in (findings) -> delta -> compose", () => {
+    const round1 = FIXTURE.rounds[0];
+    const lineageBase = buildReviewLineageBase({
+      lineageId: "fixture-1",
+      gate: FIXTURE.gate,
+      originalHead: FIXTURE.rounds[0].head,
+      originalDiff: FIXTURE.originalDiff,
+      stableContracts: "review agent instructions v1",
+    });
+
+    // 1. Request plan (context build -> request plan).
+    const plan = buildReviewDispatchPlan({
+      gate: FIXTURE.gate,
+      headSha: round1.head,
+      sharedPrefixHash: FIXTURE.sharedPrefixHash,
+      requestGroups: [
+        {
+          model: FIXTURE.model,
+          requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: FIXTURE.angles,
+        },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    assert.match(plan.planHash, /^sha256:[0-9a-f]{64}$/);
+    assert.equal(plan.requestGroups[0].angles.length, 2);
+
+    // 2. Primer (lead reviewer primes the group; ordering evidence validated).
+    const evidence = buildPrimerEvidence({
+      plan,
+      primerRuns: [
+        {
+          model: FIXTURE.model,
+          requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint,
+          primerForm: PRIMER_FORM_LEAD_REVIEWER,
+          landedAt: 10,
+        },
+      ],
+      reviewerReleases: [
+        { model: FIXTURE.model, requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint, releasedAt: 11 },
+      ],
+    });
+    const validation = validatePrimerEvidence({ plan, evidence });
+    assert.equal(validation.ok, true, JSON.stringify(validation.failures));
+
+    // 3. Fan-out schedule (fan-out).
+    const { batches } = planFanoutBatches(FIXTURE.angles, 4);
+    assert.equal(batches.length, 1);
+
+    // 4. Fan-in (round 1 has a high-severity finding -> findings_present).
+    const fanin = consolidateFanin({ angleResults: round1.angleResults, blockCleanOnFindingSeverities: ["high"] });
+    assert.equal(fanin.verdict, "findings_present");
+    assert.equal(fanin.counts.blocking, 1);
+
+    // 5. Lineage delta + compose round-1 request.
+    const delta1 = buildFixRoundDelta({
+      lineageId: "fixture-1",
+      round: 1,
+      gate: FIXTURE.gate,
+      baseHead: lineageBase.originalHead,
+      reviewedHead: round1.head,
+      fixDiff: round1.fixDiff,
+      validationEvidence: round1.validation,
+      findingsChecklist: round1.checklist,
+    });
+    const composed1 = composeRoundRequest({ lineageBase, priorDeltas: [], newDelta: delta1 });
+    assert.equal(composed1.segments.length, 2); // base + delta1
+    assert.equal(composed1.segments[0].hash, lineageBase.baseHash);
+    assert.equal(composed1.segments[1].hash, delta1.deltaHash);
+  });
+
+  test("round 2: append-only delta over a clean fan-in, then compaction", () => {
+    const round1 = FIXTURE.rounds[0];
+    const round2 = FIXTURE.rounds[1];
+    const lineageBase = buildReviewLineageBase({
+      lineageId: "fixture-1",
+      gate: FIXTURE.gate,
+      originalHead: round1.head,
+      originalDiff: FIXTURE.originalDiff,
+      stableContracts: "review agent instructions v1",
+    });
+
+    const plan2 = buildReviewDispatchPlan({
+      gate: FIXTURE.gate,
+      headSha: round2.head,
+      sharedPrefixHash: FIXTURE.sharedPrefixHash,
+      requestGroups: [
+        {
+          model: FIXTURE.model,
+          requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint,
+          cacheBoundary: CACHE_BOUNDARY_AFTER_SHARED_PREFIX,
+          ttlIntent: "1h",
+          angles: FIXTURE.angles,
+        },
+      ],
+      capabilities: { harness: "claude" },
+    });
+    const evidence2 = buildPrimerEvidence({
+      plan: plan2,
+      primerRuns: [
+        { model: FIXTURE.model, requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint, primerForm: PRIMER_FORM_LEAD_REVIEWER, landedAt: 20 },
+      ],
+      reviewerReleases: [
+        { model: FIXTURE.model, requestPrefixFingerprint: FIXTURE.requestPrefixFingerprint, releasedAt: 21 },
+      ],
+    });
+    assert.equal(validatePrimerEvidence({ plan: plan2, evidence: evidence2 }).ok, true);
+
+    // Round 2 is clean (fan-in clean).
+    const fanin2 = consolidateFanin({ angleResults: round2.angleResults, blockCleanOnFindingSeverities: ["high"] });
+    assert.equal(fanin2.verdict, "clean");
+
+    // Round 1 delta + round 2 delta compose append-only.
+    const delta1 = buildFixRoundDelta({
+      lineageId: "fixture-1", round: 1, gate: FIXTURE.gate,
+      baseHead: round1.head, reviewedHead: round1.head, fixDiff: round1.fixDiff,
+      validationEvidence: round1.validation, findingsChecklist: round1.checklist,
+    });
+    const delta2 = buildFixRoundDelta({
+      lineageId: "fixture-1", round: 2, gate: FIXTURE.gate,
+      baseHead: round1.head, reviewedHead: round2.head, fixDiff: round2.fixDiff,
+      validationEvidence: round2.validation, findingsChecklist: round2.checklist,
+    });
+    const round2Composed = composeRoundRequest({ lineageBase, priorDeltas: [delta1], newDelta: delta2 });
+    assert.equal(round2Composed.segments.length, 3); // base + delta1 + delta2
+
+    // Small lineage: no compaction needed yet, but the path closes cleanly.
+    const comp = checkLineageCompaction({ lineageBase, deltas: [delta1, delta2], maxRounds: 20 });
+    assert.equal(comp.requiresCompaction, false);
+
+    // Drive a forced rebase to prove the compacted lineage still satisfies the
+    // composition rules (append-only, byte-deterministic, SHA-chain continuity).
+    const compacted = rebaseLineage({ lineageBase, deltas: [delta1, delta2] });
+    assert.equal(compacted.originalHead, round2.head);
+    assert.match(compacted.originalDiff, /fix one/);
+    assert.match(compacted.originalDiff, /fix two/);
+    const fresh = buildFixRoundDelta({
+      lineageId: "fixture-1", round: 1, gate: FIXTURE.gate,
+      baseHead: compacted.originalHead, reviewedHead: "3".repeat(64), fixDiff: "diff --git a/src/pipeline.mjs b/src/pipeline.mjs\n+round 3\n",
+    });
+    const recomposed = composeRoundRequest({ lineageBase: compacted, priorDeltas: [], newDelta: fresh });
+    assert.equal(recomposed.segments[0].hash, compacted.baseHash);
+    assert.equal(recomposed.segments[1].hash, fresh.deltaHash);
+    assert.equal(
+      recomposed.composedHash,
+      composeRoundRequest({ lineageBase: compacted, priorDeltas: [], newDelta: fresh }).composedHash,
+    );
+  });
+});

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -3,11 +3,15 @@ import test, { describe } from "node:test";
 
 import {
   ANGLE_SUFFIX_SLOT,
+  DEFAULT_LINEAGE_MAX_ROUNDS,
   LINEAGE_BASE_SLOT,
   ROUND_DELTA_SLOT,
   buildFixRoundDelta,
   buildReviewLineageBase,
+  checkLineageCompaction,
   composeRoundRequest,
+  lineageByteSize,
+  rebaseLineage,
   renderComposedRequest,
 } from "../src/loop/review-lineage.mjs";
 
@@ -309,6 +313,134 @@ describe("append-only round request composition — Section E (AC-2)", () => {
     assert.throws(() => buildReviewLineageBase({ lineageId: "l", gate: GATE, originalHead: "aaaaaaa", originalDiff: "d" }));
     // All SHAs must be full-length.
     assert.throws(() => buildFixRoundDelta({ lineageId: "l", round: 1, gate: GATE, baseHead: "bbbbbbbb", reviewedHead: R1, fixDiff: "d" }));
+  });
+});
+
+describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
+  function deltas(count) {
+    const out = [];
+    let prevHead = BASE;
+    for (let i = 1; i <= count; i++) {
+      const reviewedHead = `d`.repeat(60) + String(i).padStart(4, "0");
+      out.push(
+        buildFixRoundDelta({
+          lineageId: "lin-1",
+          round: i,
+          gate: GATE,
+          baseHead: prevHead,
+          reviewedHead,
+          fixDiff: `diff --git a/src/a.mjs b/src/a.mjs\n+round ${i}\n`,
+          validationEvidence: { tests: "npm test", result: "pass", head: reviewedHead },
+          findingsChecklist: [{ id: `F${i}`, severity: "high", check: `verify round ${i}`, resolved: true, evidence: "test-assert" }],
+        }),
+      );
+      prevHead = reviewedHead;
+    }
+    return out;
+  }
+
+  test("compaction threshold is exceeded once delta count passes maxRounds (default 20)", () => {
+    assert.equal(DEFAULT_LINEAGE_MAX_ROUNDS, 20);
+    assert.equal(checkLineageCompaction({ lineageBase: base(), deltas: deltas(20) }).requiresCompaction, false);
+    const over = checkLineageCompaction({ lineageBase: base(), deltas: deltas(21) });
+    assert.equal(over.requiresCompaction, true);
+    assert.match(over.reason, /exceeds maxRounds 20/);
+  });
+
+  test("a byte budget triggers compaction even under the round cap", () => {
+    const d = deltas(2);
+    const small = 200; // well under the composed size
+    const r = checkLineageCompaction({ lineageBase: base(), deltas: d, maxLineageBytes: small });
+    assert.equal(r.requiresCompaction, true);
+    assert.match(r.reason, /exceed maxLineageBytes 200/);
+  });
+
+  test("lineageByteSize is deterministic and grows with each appended delta", () => {
+    const s1 = lineageByteSize({ lineageBase: base(), deltas: deltas(1) });
+    const s2 = lineageByteSize({ lineageBase: base(), deltas: deltas(2) });
+    assert.ok(Number.isInteger(s1) && s1 > 0);
+    assert.ok(s2 > s1);
+    assert.equal(lineageByteSize({ lineageBase: base(), deltas: deltas(2) }), s2); // deterministic
+  });
+
+  test("rebase preserves composition rules — compacted base resumes appending round-1 delta", () => {
+    const ds = deltas(21);
+    assert.equal(checkLineageCompaction({ lineageBase: base(), deltas: ds }).requiresCompaction, true);
+
+    const compacted = rebaseLineage({ lineageBase: base(), deltas: ds });
+    assert.equal(compacted.kind, "review-lineage-base");
+    assert.equal(compacted.lineageId, "lin-1");
+    assert.equal(compacted.gate, GATE);
+    assert.equal(compacted.compaction, true);
+    assert.equal(compacted.compactedRoundCount, 21);
+    assert.equal(compacted.rebaseSourceBaseHash, base().baseHash);
+    // originalHead advances to the latest reviewed head.
+    assert.equal(compacted.originalHead, ds[ds.length - 1].reviewedHead);
+    // cumulative diff folds in every fix diff, in order.
+    assert.match(compacted.originalDiff, /round 1/);
+    assert.match(compacted.originalDiff, /round 21/);
+    assert.match(compacted.baseHash, /^sha256:[0-9a-f]{64}$/);
+    assert.ok(Object.isFrozen(compacted));
+
+    // The compacted base is accepted by composeRoundRequest unchanged, and a
+    // fresh round-1 delta against it composes cleanly (SHA-chain continuity +
+    // append-only contract preserved).
+    const fresh = buildFixRoundDelta({
+      lineageId: "lin-1",
+      round: 1,
+      gate: GATE,
+      baseHead: compacted.originalHead,
+      reviewedHead: `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`,
+      fixDiff: "diff --git a/src/a.mjs b/src/a.mjs\n+post-rebase\n",
+      validationEvidence: { tests: "npm test", result: "pass" },
+    });
+    const composed = composeRoundRequest({ lineageBase: compacted, priorDeltas: [], newDelta: fresh });
+    assert.equal(composed.segments.length, 2); // compacted base + one fresh delta
+    assert.equal(composed.segments[0].hash, compacted.baseHash);
+    assert.equal(composed.segments[1].hash, fresh.deltaHash);
+    // Byte-deterministic.
+    const again = composeRoundRequest({ lineageBase: compacted, priorDeltas: [], newDelta: fresh });
+    assert.equal(composed.composedHash, again.composedHash);
+  });
+
+  test("rebase chain trimming keeps the composed request bounded", () => {
+    const ds = deltas(21);
+    const before = renderComposedRequest(composeRoundRequest({ lineageBase: base(), priorDeltas: ds.slice(0, -1), newDelta: ds[ds.length - 1] }));
+    const compacted = rebaseLineage({ lineageBase: base(), deltas: ds });
+    const fresh = buildFixRoundDelta({
+      lineageId: "lin-1",
+      round: 1,
+      gate: GATE,
+      baseHead: compacted.originalHead,
+      reviewedHead: `eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`,
+      fixDiff: "diff --git a/src/a.mjs b/src/a.mjs\n+post-rebase\n",
+    });
+    const after = renderComposedRequest(composeRoundRequest({ lineageBase: compacted, priorDeltas: [], newDelta: fresh }));
+    // The single compacted base + one delta is strictly smaller than the full
+    // 21-delta append chain (unbounded growth prevented).
+    assert.ok(after.length < before.length);
+  });
+
+  test("rebase fails closed on a broken SHA chain, wrong gate, or foreign lineage", () => {
+    const badChain = [...deltas(2)];
+    badChain[1] = buildFixRoundDelta({
+      lineageId: "lin-1", round: 2, gate: GATE,
+      baseHead: BASE, // should equal deltas[0].reviewedHead
+      reviewedHead: `cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc`,
+      fixDiff: "x",
+    });
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: badChain }));
+    const wrongGate = buildFixRoundDelta({
+      lineageId: "lin-1", round: 1, gate: "draft_gate", baseHead: BASE,
+      reviewedHead: R1, fixDiff: "x",
+    });
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [wrongGate] }));
+    const foreign = buildFixRoundDelta({
+      lineageId: "lin-OTHER", round: 1, gate: GATE, baseHead: BASE,
+      reviewedHead: R1, fixDiff: "x",
+    });
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [foreign] }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: deltas(1), maxRounds: 0 }));
   });
 });
 

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -509,7 +509,7 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     assert.ok(after.length < before.length);
   });
 
-  test("rebase validates full hex SHAs on every accumulated delta (in-gate hex-SHA chain finding)", () => {
+  test("buildFixRoundDelta rejects abbreviated/full-hex-SHA inputs (in-gate hex-SHA chain finding)", () => {
     // Builders already fail closed on abbreviated SHAs, so a full-hex-SHA
     // malformed delta cannot reach rebaseLineage through the public path.
     assert.throws(() => buildFixRoundDelta({

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -409,6 +409,17 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     assert.equal(wideBytes, narrowBytes);
   });
 
+  test("lineageByteSize rejects a foreign-lineage or wrong-gate delta (in-gate input-validation finding)", () => {
+    const foreign = buildFixRoundDelta({
+      lineageId: "lin-OTHER", round: 1, gate: GATE, baseHead: BASE, reviewedHead: R1, fixDiff: "x",
+    });
+    const wrongGate = buildFixRoundDelta({
+      lineageId: "lin-1", round: 1, gate: "draft_gate", baseHead: BASE, reviewedHead: R1, fixDiff: "x",
+    });
+    assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: [foreign] }));
+    assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: [wrongGate] }));
+  });
+
   test("checkLineageCompaction fails closed on a non-array deltas input (in-gate nullable-deltas finding)", () => {
     assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: null }));
     assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: "not-an-array" }));
@@ -545,6 +556,10 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     });
     const compacted = rebaseLineage({ lineageBase: base(), deltas: [mixed] });
     assert.equal(compacted.originalHead, "ab".repeat(32));
+  });
+
+  test("rebase rejects an empty-Buffer currentDiff (in-gate correctness finding)", () => {
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [delta1()], currentDiff: Buffer.alloc(0) }));
   });
 
   test("rebaseLineage rejects an invalid lineageBase and null/undefined delta elements (in-gate coverage finding)", () => {

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -355,6 +355,30 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     assert.match(r.reason, /exceed maxLineageBytes 200/);
   });
 
+  test("checkLineageCompaction uses strict > boundary: exact-byte equality does not trigger (in-gate coverage finding)", () => {
+    const ds = deltas(2);
+    const exactBytes = lineageByteSize({ lineageBase: base(), deltas: ds });
+    // At exact equality (lineageBytes === maxLineageBytes) no compaction fires.
+    const eq = checkLineageCompaction({ lineageBase: base(), deltas: ds, maxLineageBytes: exactBytes });
+    assert.equal(eq.requiresCompaction, false);
+    // One byte over triggers.
+    const over = checkLineageCompaction({ lineageBase: base(), deltas: ds, maxLineageBytes: exactBytes - 1 });
+    assert.equal(over.requiresCompaction, true);
+  });
+
+  test("checkLineageCompaction rejects invalid maxLineageBytes (in-gate error-contract finding)", () => {
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: deltas(1), maxLineageBytes: 0 }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: deltas(1), maxLineageBytes: -5 }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: deltas(1), maxLineageBytes: 2.5 }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: deltas(1), maxLineageBytes: "10" }));
+  });
+
+  test("lineageByteSize rejects an invalid base / non-array deltas / malformed delta (in-gate error-contract finding)", () => {
+    assert.throws(() => lineageByteSize({ lineageBase: {}, deltas: [] }));
+    assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: "nope" }));
+    assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: [{ kind: "round-delta" }] }));
+  });
+
   test("lineageByteSize is deterministic and grows with each appended delta", () => {
     const s1 = lineageByteSize({ lineageBase: base(), deltas: deltas(1) });
     const s2 = lineageByteSize({ lineageBase: base(), deltas: deltas(2) });
@@ -389,6 +413,42 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: null }));
     assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: "not-an-array" }));
     assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: null }));
+  });
+
+  test("rebase honors an explicit currentDiff override (in-gate coverage finding)", () => {
+    const compacted = rebaseLineage({
+      lineageBase: base(),
+      deltas: [delta1()],
+      currentDiff: "custom cumulative diff text",
+    });
+    assert.equal(compacted.originalDiff, "custom cumulative diff text");
+    // Default (no currentDiff) still folds in the fix diffs.
+    const defaulted = rebaseLineage({ lineageBase: base(), deltas: [delta1()] });
+    assert.match(defaulted.originalDiff, /fix one/);
+  });
+
+  test("rebase with empty deltas folds nothing and keeps head/diff unchanged (in-gate coverage finding)", () => {
+    const compacted = rebaseLineage({ lineageBase: base(), deltas: [] });
+    assert.equal(compacted.compaction, true);
+    assert.equal(compacted.originalHead, base().originalHead);
+    assert.equal(compacted.originalDiff, base().originalDiff);
+    assert.equal(compacted.compactedRoundCount, 0);
+  });
+
+  test("rebasing an already-compacted base accumulates compactedRoundCount (in-gate coverage finding)", () => {
+    const first = rebaseLineage({ lineageBase: base(), deltas: deltas(2) });
+    assert.equal(first.compactedRoundCount, 2);
+    // Anchor a new delta chain to the compacted head.
+    const anchor = first.originalHead;
+    const chain = buildFixRoundDelta({
+      lineageId: "lin-1", round: 1, gate: GATE,
+      baseHead: anchor,
+      reviewedHead: "f".repeat(64),
+      fixDiff: "diff --git a/src/a.mjs b/src/a.mjs\n+post-compact 1\n",
+    });
+    const second = rebaseLineage({ lineageBase: first, deltas: [chain] });
+    assert.equal(second.compactedRoundCount, 3); // 2 (prior) + 1 (new)
+    assert.equal(second.rebaseSourceBaseHash, first.baseHash);
   });
 
   test("rebase preserves composition rules — compacted base resumes appending round-1 delta", () => {

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -518,6 +518,42 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     }));
   });
 
+  test("rebase enforces round contiguity from round 1 (in-gate correctness finding)", () => {
+    // A head-chaining but round-mislabeled list (starts at 5) is rejected.
+    const mislabeled = buildFixRoundDelta({
+      lineageId: "lin-1", round: 5, gate: GATE,
+      baseHead: BASE, reviewedHead: R1, fixDiff: "x",
+    });
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [mislabeled] }));
+    const skip = buildFixRoundDelta({
+      lineageId: "lin-1", round: 3, gate: GATE,
+      baseHead: R1, reviewedHead: R2, fixDiff: "x",
+    });
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [delta1(), skip] }));
+    // A well-ordered list passes.
+    assert.ok(rebaseLineage({ lineageBase: base(), deltas: [delta1(), delta2()] }));
+  });
+
+  test("rebase normalizes the extracted head and rejects an empty currentDiff (in-gate finding)", () => {
+    // currentDiff empty is rejected.
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [delta1()], currentDiff: "" }));
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [delta1()], currentDiff: [] }));
+    // Normalized head: mixed-case reviewedHead is lowercased in the compacted base.
+    const mixed = buildFixRoundDelta({
+      lineageId: "lin-1", round: 1, gate: GATE,
+      baseHead: BASE, reviewedHead: "AB".repeat(32), fixDiff: "x",
+    });
+    const compacted = rebaseLineage({ lineageBase: base(), deltas: [mixed] });
+    assert.equal(compacted.originalHead, "ab".repeat(32));
+  });
+
+  test("rebaseLineage rejects an invalid lineageBase and null/undefined delta elements (in-gate coverage finding)", () => {
+    assert.throws(() => rebaseLineage({ lineageBase: {}, deltas: [] }));
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: null }));
+    assert.throws(() => rebaseLineage({ lineageBase: base(), deltas: [null] }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: [undefined, delta1()] }));
+  });
+
   test("rebase fails closed on a broken SHA chain, wrong gate, or foreign lineage", () => {
     const badChain = [...deltas(2)];
     badChain[1] = buildFixRoundDelta({

--- a/packages/core/test/review-lineage.test.mjs
+++ b/packages/core/test/review-lineage.test.mjs
@@ -363,6 +363,34 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     assert.equal(lineageByteSize({ lineageBase: base(), deltas: deltas(2) }), s2); // deterministic
   });
 
+  test("lineageByteSize measures UTF-8 bytes, not JS string length (in-gate byte-sizing finding)", () => {
+    // Multi-byte UTF-8 content: 100 × U+2014 (em dash, 3 bytes each in UTF-8)
+    // counts as 300 bytes, not 100 chars.
+    const wide = buildReviewLineageBase({
+      lineageId: "lin-1",
+      gate: GATE,
+      originalHead: BASE,
+      originalDiff: "\u2014".repeat(100),
+    });
+    const narrow = buildReviewLineageBase({
+      lineageId: "lin-1",
+      gate: GATE,
+      originalHead: BASE,
+      originalDiff: "x".repeat(300), // 300 ASCII bytes
+    });
+    const wideBytes = lineageByteSize({ lineageBase: wide });
+    const narrowBytes = lineageByteSize({ lineageBase: narrow });
+    // Both renderings are 300 bytes in UTF-8; a naive JS .length would count
+    // the wide one as ~100 (wrongly under-budgeting the provider context).
+    assert.equal(wideBytes, narrowBytes);
+  });
+
+  test("checkLineageCompaction fails closed on a non-array deltas input (in-gate nullable-deltas finding)", () => {
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: null }));
+    assert.throws(() => checkLineageCompaction({ lineageBase: base(), deltas: "not-an-array" }));
+    assert.throws(() => lineageByteSize({ lineageBase: base(), deltas: null }));
+  });
+
   test("rebase preserves composition rules — compacted base resumes appending round-1 delta", () => {
     const ds = deltas(21);
     assert.equal(checkLineageCompaction({ lineageBase: base(), deltas: ds }).requiresCompaction, true);
@@ -419,6 +447,15 @@ describe("lineage compaction / rebase policy (issue #1468 slice 6)", () => {
     // The single compacted base + one delta is strictly smaller than the full
     // 21-delta append chain (unbounded growth prevented).
     assert.ok(after.length < before.length);
+  });
+
+  test("rebase validates full hex SHAs on every accumulated delta (in-gate hex-SHA chain finding)", () => {
+    // Builders already fail closed on abbreviated SHAs, so a full-hex-SHA
+    // malformed delta cannot reach rebaseLineage through the public path.
+    assert.throws(() => buildFixRoundDelta({
+      lineageId: "lin-1", round: 1, gate: GATE,
+      baseHead: "aaaaaaa", reviewedHead: R1, fixDiff: "x",
+    }));
   });
 
   test("rebase fails closed on a broken SHA chain, wrong gate, or foreign lineage", () => {

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1708,12 +1708,47 @@ carried clean angle still records its ORIGINAL reviewer and PRIOR head,
 unchanged from the existing carry-forward contract. The composed request weaves
 that provenance into its `composedHash`.
 
+### Compaction / rebase policy (slice 6)
+
+Unbounded delta accumulation would eventually overflow provider prompt-cache
+breakpoint/lookback limits and the context window. A documented compaction
+(rebase) rule bounds the composed lineage so it cannot grow without limit.
+
+**Threshold.** A rebase is triggered when EITHER bound is exceeded:
+
+- the accumulated round-delta count exceeds `maxRounds` (default
+  `DEFAULT_LINEAGE_MAX_ROUNDS`, `20`), OR
+- the composed lineage byte size exceeds `maxLineageBytes` (a provider context
+  budget a consumer may set) when one is configured.
+
+`checkLineageCompaction({ lineageBase, deltas, maxRounds, maxLineageBytes })`
+returns `{ requiresCompaction, reason, ... }` (pure predicate — never mutates).
+
+**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas })` folds the
+accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
+advances to the latest reviewed head and `originalDiff` becomes the cumulative
+diff (original full diff merged with every accepted fix diff, in order). The
+compacted base keeps the same `lineageId`/`gate`, is itself a valid base that
+`composeRoundRequest` accepts unchanged, and records `rebaseSourceBaseHash` +
+`compactedRoundCount` for traceability. Subsequent rounds append fresh deltas
+to the compacted base, so the composed request stays within the provider
+breakpoint/lookback + context budget. Composition rules are preserved: a new
+round-1 delta whose `baseHead` equals the compacted base's `originalHead`
+composes cleanly, byte-deterministically, with SHA-chain continuity. Prior
+delta artifacts remain available (append-only history); only the composed
+request is recomposed from the compacted base.
+
+Covered by the compaction suite in `packages/core/test/review-lineage.test.mjs`
+and the end-to-end fixture `packages/core/test/review-lineage-e2e-fixture.test.mjs`
+(driving request plan → primer → fan-out/fan-in → lineage delta → compaction
+for two rounds).
+
 ### Non-goals preserved
 
-- No provider cache-reuse claim from artifact hashes (slice-5 keeps that out of
-  scope; telemetry capability rules live in `review-dispatch-plan.mjs`).
-- No continuity-reviewer convergence loop, calibration audit, or compaction
-  policy yet — those are later #1468 slices (6/7/8) and are NOT introduced here.
+- No provider cache-reuse claim from artifact hashes (telemetry capability
+  rules live in `review-dispatch-plan.mjs`).
+- No continuity-reviewer convergence loop or calibration audit yet — those are
+  later #1468 slices (6/7) and are NOT introduced here.
 - Round-1 fresh one-reviewer-per-angle provenance and fan-in semantics are
   untouched.
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1724,13 +1724,16 @@ breakpoint/lookback limits and the context window. A documented compaction
 `checkLineageCompaction({ lineageBase, deltas, maxRounds, maxLineageBytes })`
 returns `{ requiresCompaction, reason, ... }` (pure predicate — never mutates).
 
-**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas })` folds the
-accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
+**Rebase behaviour.** `rebaseLineage({ lineageBase, deltas, currentDiff? })` folds
+the accumulated deltas into a new compacted `review-lineage-base`: `originalHead`
 advances to the latest reviewed head and `originalDiff` becomes the cumulative
-diff (original full diff merged with every accepted fix diff, in order). The
+/ concatenated diff text (the original full diff joined with every accepted fix
+diff, in order — an accumulated text fold, not a patched merge). A caller may
+explicitly supply `currentDiff` to override that folded text outright. The
 compacted base keeps the same `lineageId`/`gate`, is itself a valid base that
 `composeRoundRequest` accepts unchanged, and records `rebaseSourceBaseHash` +
-`compactedRoundCount` for traceability. Subsequent rounds append fresh deltas
+`compactedRoundCount` (and sets the reserved `compaction: true` marker field)
+for traceability. Subsequent rounds append fresh deltas
 to the compacted base, so the composed request stays within the provider
 breakpoint/lookback + context budget. Composition rules are preserved: a new
 round-1 delta whose `baseHead` equals the compacted base's `originalHead`


### PR DESCRIPTION
## Summary

Implements **#1468 slice 6** for issue **#1478** (final remainder of #1462): a documented, tested lineage **compaction / rebase policy** plus an end-to-end fixture that proves the whole cache-aware review path.

Adds to `packages/core/src/loop/review-lineage.mjs` (pure, offline, deterministic):

- **`DEFAULT_LINEAGE_MAX_ROUNDS` (20)** — compaction threshold on accumulated round-delta count; consumers may also set a `maxLineageBytes` provider context budget.
- **`lineageByteSize`** — total composed byte size of a lineage (base + all deltas), using the same canonical byte-serialization `composeRoundRequest` renders.
- **`checkLineageCompaction`** — pure predicate: rebase required when the delta count exceeds `maxRounds` OR the composed lineage byte size exceeds `maxLineageBytes`. Never mutates.
- **`rebaseLineage`** — folds accumulated deltas into a new compacted `review-lineage-base`: `originalHead` advances to the latest reviewed head, `originalDiff` becomes the cumulative diff, and it records `rebaseSourceBaseHash` + `compactedRoundCount` for traceability. Composition rules are preserved (SHA-chain continuity, append-only, byte-deterministic).

## Scope and context

This change adds the offline compaction/rebase module, its unit test suite, the end-to-end fixture (`pipeline.json` driven through request plan → primer → fan-out → fan-in → lineage delta for two rounds + forced rebase), and a Section "Compaction / rebase policy (slice 6)" subsection in `skills/docs/gate-review-sub-loop-contract.md` (with the generated `.claude` mirror in the same change). It does not change any gate verdict semantics, carry-forward decision logic, or round-1 fresh-angle provenance.

## Acceptance criteria

- [x] A documented compaction/rebase rule prevents unbounded lineage growth and provider breakpoint/lookback overflow, with both the threshold and the rebase behaviour stated.
- [x] A test drives enough rounds to trigger compaction and proves the compacted lineage still satisfies the composition rules from the lineage slice.
- [x] An end-to-end fixture exercises context build → request plan → primer → fan-out → fan-in → lineage delta for at least two rounds.
- [x] No ADR needed: the harness/contract surface does not move (`workflow-handoff-contract.md` and `copilot-pr-followup` are untouched).

## Definition of done

- [x] Every AC covered by an executable test (`packages/core/test/review-lineage.test.mjs` compaction suite + `packages/core/test/review-lineage-e2e-fixture.test.mjs`).
- [x] `npm run verify` green locally at the reviewed head; `npm run test:doc-guard` green.
- [x] `skills/docs/gate-review-sub-loop-contract.md` updated with its generated `.claude` mirror regenerated in the same change.
- [x] Existing fresh-context, one-reviewer-per-angle, briefing-prefix hash, carry-forward and fan-in guarantees remain green (none of those paths were modified).

## Non-goals (kept out of scope / later slices)

- No continuity-reviewer convergence loop (#1468 slice 6 remainder; here excluded).
- No calibration audit (#1468 slice 7).
- No provider cache-reuse claim from artifact hashes.
- No change to gate verdict semantics, carry-forward decision logic, or round-1 fresh-angle provenance.

## Validation

Run locally at the reviewed head:

- `npm run verify` (all suites: assets, extension, scripts, core, docs, pack, dev-loop, workflows)
- `npm run test:doc-guard`
- `node --test packages/core/test/review-lineage.test.mjs packages/core/test/review-lineage-e2e-fixture.test.mjs`

Closes #1478
