### PR TITLE
fix(conductor): decouple merge-success run-state from post-merge local-verify exit (#1638)

### DIFF
--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1146,10 +1146,12 @@ function outputTextIndicatesSuccessfulMerge(text) {
   // lines and would false-downgrade a genuinely failed run.
   //
   // Both signals are read as their own line and the extracted value must be
-  // exactly a positive merge signal: reversal/narrative phrasing
-  // ("PR merged: #X was then reverted", "was the PR merged: #X") or a bold
-  // `**Artifact state:** merged` recap cannot reshape a failed run into
-  // COMPLETED. This parallels the first-line semantics parseArtifactState uses.
+  // exactly a positive merge signal: narrative/reversal phrasing
+  // ("PR merged: #X was then reverted", "was the PR merged: #X") can never
+  // match because extraction is line-anchored and value-exact. Markdown bold
+  // around the canonical label (`**Artifact state:**`, `**PR merged:**`) is
+  // tolerated as formatting, mirroring parseArtifactState's formatting
+  // tolerance. This parallels the first-line semantics parseArtifactState uses.
   const padded = `\n${text}`;
   const prMergedLine = padded.match(/^\**PR merged:\**\s*([^\n]+)$/imu)?.[1];
   if (prMergedLine !== undefined && /^#\s*\d+\s*$/iu.test(prMergedLine.trim())) {

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1011,12 +1011,17 @@ export async function listRepoAsyncRuns(
   // Decouple merge-success routing from post-merge local-verify exit (#1638).
   // The meta mapping in scanSessionArtifactRoot (`exitCode !== 0 -> FAILED`) is
   // correct for a gate or merge failure, but a dev-loop run that lands a clean
-  // merge then runs a post-merge local `npm run verify` can exit non-zero purely
-  // on environmental (non-code) suites (missing gh/run-id context in a worktree).
+  // merge then runs a post-merge local `npm run verify` can exit non-zero on
+  // environmental (non-code) suites (missing gh/run-id context in a worktree).
   // That must not reclassify a successful merge as FAILED. This pass runs AFTER
   // every root scanner has merged evidence (so an async-run FAILED cannot
-  // re-introduce itself), reclassifies merge-success runs to COMPLETED, and
-  // surfaces the non-zero post-merge verify as a warning note, not a hard failure.
+  // re-introduce itself) and only downgrades FAILED -> COMPLETED when the run's
+  // AUTHORITATIVE output surface (its own output artifact or result summary)
+  // records a successful merge. The raw output log is deliberately NOT a merge
+  // source: a stale/incidental "PR merged" recap in a log must never veto the
+  // authoritative state, masking a genuine failure. We assert only the facts
+  // we can prove (merge recorded + child exited non-zero) and surface a neutral
+  // warning — never a fabricated "environmental" cause.
   for (const record of records.values()) {
     if (record.runState !== RUN_STATE.FAILED) {
       continue;
@@ -1025,14 +1030,10 @@ export async function listRepoAsyncRuns(
     if (typeof record.outputArtifactPath === "string") {
       outputTexts.push(await readTextIfExists(record.outputArtifactPath));
     }
-    const summarySource = record.resultSummaryPath ?? record.resultPath ?? null;
     if (typeof record.resultSummaryText === "string") {
       outputTexts.push(record.resultSummaryText);
-    } else if (typeof summarySource === "string") {
-      outputTexts.push(await readTextIfExists(summarySource));
-    }
-    if (typeof record.outputLogPath === "string") {
-      outputTexts.push(await readTextIfExists(record.outputLogPath));
+    } else if (typeof record.resultSummaryPath === "string" || typeof record.resultPath === "string") {
+      outputTexts.push(await readTextIfExists(record.resultSummaryPath ?? record.resultPath));
     }
     const mergeSuccess = outputTexts.some((text) => text !== null && outputTextIndicatesSuccessfulMerge(text));
     if (!mergeSuccess) {
@@ -1042,8 +1043,8 @@ export async function listRepoAsyncRuns(
     record.evidence = {
       ...record.evidence,
       mergeSuccess: true,
-      postMergeVerifyNonZero: true,
-      warning: "post-merge local verify exited non-zero on environmental (non-code) suites; run reported completed on clean merge",
+      childNonZeroExit: true,
+      warning: "run recorded a successful merge but the child exited non-zero post-merge; reported COMPLETED on clean merge — confirm the non-zero exit was post-merge verification noise (CI is authoritative for gate evidence), not a real post-merge regression",
     };
   }
   return [...records.values()]
@@ -1132,10 +1133,14 @@ function outputTextIndicatesSuccessfulMerge(text) {
   if (typeof text !== "string") {
     return false;
   }
-  const normalized = text.toLowerCase();
-  return parseArtifactState(text) === "merged"
-    || /\bpr merged:\s*#\d+\b/u.test(normalized)
-    || /\bartifact state:\s*merged\b/u.test(normalized);
+  // Strictly-positive, run-terminal merge signals only — the same canonical
+  // set classifyResumeBucket treats as DONE_OR_MERGED. Deliberately NOT the
+  // bare `parseArtifactState(...) === "merged"` short-circuit, because
+  // parseArtifactState's `\bmerged\b` word check also matches negatives
+  // ("artifacts not merged", "merge still pending") in the Status/artifact
+  // lines and would false-downgrade a genuinely failed run.
+  return /\bPR merged:\s*#\d+\b/iu.test(text)
+    || /\bArtifact state:\s*merged\b/iu.test(text);
 }
 function parseLoopState(text) {
   const patterns = [

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1008,6 +1008,44 @@ export async function listRepoAsyncRuns(
       await scanAsyncResultRoot(resultsRoot, records);
     }
   }
+  // Decouple merge-success routing from post-merge local-verify exit (#1638).
+  // The meta mapping in scanSessionArtifactRoot (`exitCode !== 0 -> FAILED`) is
+  // correct for a gate or merge failure, but a dev-loop run that lands a clean
+  // merge then runs a post-merge local `npm run verify` can exit non-zero purely
+  // on environmental (non-code) suites (missing gh/run-id context in a worktree).
+  // That must not reclassify a successful merge as FAILED. This pass runs AFTER
+  // every root scanner has merged evidence (so an async-run FAILED cannot
+  // re-introduce itself), reclassifies merge-success runs to COMPLETED, and
+  // surfaces the non-zero post-merge verify as a warning note, not a hard failure.
+  for (const record of records.values()) {
+    if (record.runState !== RUN_STATE.FAILED) {
+      continue;
+    }
+    const outputTexts = [];
+    if (typeof record.outputArtifactPath === "string") {
+      outputTexts.push(await readTextIfExists(record.outputArtifactPath));
+    }
+    const summarySource = record.resultSummaryPath ?? record.resultPath ?? null;
+    if (typeof record.resultSummaryText === "string") {
+      outputTexts.push(record.resultSummaryText);
+    } else if (typeof summarySource === "string") {
+      outputTexts.push(await readTextIfExists(summarySource));
+    }
+    if (typeof record.outputLogPath === "string") {
+      outputTexts.push(await readTextIfExists(record.outputLogPath));
+    }
+    const mergeSuccess = outputTexts.some((text) => text !== null && outputTextIndicatesSuccessfulMerge(text));
+    if (!mergeSuccess) {
+      continue;
+    }
+    record.runState = RUN_STATE.COMPLETED;
+    record.evidence = {
+      ...record.evidence,
+      mergeSuccess: true,
+      postMergeVerifyNonZero: true,
+      warning: "post-merge local verify exited non-zero on environmental (non-code) suites; run reported completed on clean merge",
+    };
+  }
   return [...records.values()]
     .filter((record) => record.agent === "dev-loop")
     .filter((record) => recordMatchesRepo(record, repoIsolation))
@@ -1089,6 +1127,15 @@ function parseArtifactState(text) {
     return "open";
   }
   return null;
+}
+function outputTextIndicatesSuccessfulMerge(text) {
+  if (typeof text !== "string") {
+    return false;
+  }
+  const normalized = text.toLowerCase();
+  return parseArtifactState(text) === "merged"
+    || /\bpr merged:\s*#\d+\b/u.test(normalized)
+    || /\bartifact state:\s*merged\b/u.test(normalized);
 }
 function parseLoopState(text) {
   const patterns = [

--- a/scripts/loop/conductor-monitor.mjs
+++ b/scripts/loop/conductor-monitor.mjs
@@ -1040,10 +1040,15 @@ export async function listRepoAsyncRuns(
       continue;
     }
     record.runState = RUN_STATE.COMPLETED;
+    // Only assert childNonZeroExit when the underlying evidence proves the child
+    // actually exited non-zero (the meta exitCode path). A record reconstructed
+    // from a result-summary state label (scanAsyncResultRoot) never observed an
+    // exit code, so the flag would otherwise fabricate a fact we cannot prove.
+    const childExitCode = Number.isInteger(record.evidence?.exitCode) ? record.evidence.exitCode : null;
     record.evidence = {
       ...record.evidence,
       mergeSuccess: true,
-      childNonZeroExit: true,
+      ...(childExitCode !== null ? { childNonZeroExit: childExitCode !== 0 } : {}),
       warning: "run recorded a successful merge but the child exited non-zero post-merge; reported COMPLETED on clean merge — confirm the non-zero exit was post-merge verification noise (CI is authoritative for gate evidence), not a real post-merge regression",
     };
   }
@@ -1139,8 +1144,22 @@ function outputTextIndicatesSuccessfulMerge(text) {
   // parseArtifactState's `\bmerged\b` word check also matches negatives
   // ("artifacts not merged", "merge still pending") in the Status/artifact
   // lines and would false-downgrade a genuinely failed run.
-  return /\bPR merged:\s*#\d+\b/iu.test(text)
-    || /\bArtifact state:\s*merged\b/iu.test(text);
+  //
+  // Both signals are read as their own line and the extracted value must be
+  // exactly a positive merge signal: reversal/narrative phrasing
+  // ("PR merged: #X was then reverted", "was the PR merged: #X") or a bold
+  // `**Artifact state:** merged` recap cannot reshape a failed run into
+  // COMPLETED. This parallels the first-line semantics parseArtifactState uses.
+  const padded = `\n${text}`;
+  const prMergedLine = padded.match(/^\**PR merged:\**\s*([^\n]+)$/imu)?.[1];
+  if (prMergedLine !== undefined && /^#\s*\d+\s*$/iu.test(prMergedLine.trim())) {
+    return true;
+  }
+  const artifactStateValue = padded.match(/^\**Artifact state:\**\s*([^\n]+)$/imu)?.[1];
+  if (artifactStateValue !== undefined && stripFormatting(artifactStateValue).toLowerCase() === "merged") {
+    return true;
+  }
+  return false;
 }
 function parseLoopState(text) {
   const patterns = [

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { runConductorMonitor, isPrHealthy, fetchGithubStatus } from "../../scripts/loop/conductor-monitor.mjs";
+import { runConductorMonitor, isPrHealthy, fetchGithubStatus, listRepoAsyncRuns } from "../../scripts/loop/conductor-monitor.mjs";
 import { makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/conductor-monitor.mjs");
@@ -1764,4 +1764,50 @@ test("isPrHealthy treats unresolved threads as unhealthy with crediblyGreen CI",
     },
   });
   assert.equal(healthy, false);
+});
+
+test("conductor-monitor decouples merge-success run-state from non-zero post-merge local-verify exit (#1638)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-conductor-monitor-merge-success-"));
+
+  try {
+    const { repoRoot, sessionsRoot, asyncRunsRoot, asyncResultsRoot } = await createAutoResumeRoots(tempDir);
+    // A run whose post-merge local verify exited non-zero (environmental suites)
+    // but whose output artifact records a successful merge.
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-merged-1638",
+      cwd: repoRoot,
+      timestampMs: 1700000099000,
+      exitCode: 1,
+      outputText: "Active PR: owner/repo#1638\nArtifact state: merged\nPR merged: #1638\n",
+    });
+    // Control: an identically-failing exit with an open, unmerged artifact stays FAILED.
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-open-1638",
+      cwd: repoRoot,
+      timestampMs: 1700000099000,
+      exitCode: 1,
+      outputText: "Active PR: owner/repo#1648\nArtifact state: open\nLoop state: unresolved_feedback_present\n",
+    });
+
+    const runs = await listRepoAsyncRuns(
+      { repo: "owner/repo" },
+      { repoRoot, sessionRoots: [sessionsRoot], asyncRunRoots: [asyncRunsRoot], asyncResultRoots: [asyncResultsRoot] },
+    );
+
+    const mergedRun = runs.find((run) => run.runId === "run-merged-1638");
+    assert.ok(mergedRun, "merged run should be listed");
+    assert.equal(mergedRun.runState, "completed");
+    assert.equal(mergedRun.evidence.postMergeVerifyNonZero, true);
+    assert.equal(mergedRun.evidence.mergeSuccess, true);
+    assert.match(mergedRun.evidence.warning, /environmental \(non-code\) suites/u);
+
+    const openRun = runs.find((run) => run.runId === "run-open-1638");
+    assert.ok(openRun, "open run should be listed");
+    assert.equal(openRun.runState, "failed");
+    assert.equal(openRun.evidence.postMergeVerifyNonZero, undefined);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -1823,6 +1823,49 @@ test("conductor-monitor decouples merge-success run-state from non-zero post-mer
       { repoRoot, sessionRoots: [sessionsRoot], asyncRunRoots: [asyncRunsRoot], asyncResultRoots: [asyncResultsRoot] },
     );
     assert.equal(runs2.find((run) => run.runId === "run-notmerged-1638").runState, "failed");
+
+    // Reversal/narrative phrasing must NOT false-downgrade a genuinely failed run
+    // (e.g. a post-merge-revert narrative that only mentions the merge as a recap).
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-reverted-1638",
+      cwd: repoRoot,
+      timestampMs: 1700000099000,
+      exitCode: 1,
+      outputText: "Active PR: owner/repo#1664\nArtifact state: open\nPR merged: #1664 was then reverted due to CI failure\n",
+    });
+    const runs3 = await listRepoAsyncRuns(
+      { repo: "owner/repo" },
+      { repoRoot, sessionRoots: [sessionsRoot], asyncRunRoots: [asyncRunsRoot], asyncResultRoots: [asyncResultsRoot] },
+    );
+    assert.equal(runs3.find((run) => run.runId === "run-reverted-1638").runState, "failed", "reversal narrative must stay FAILED");
+
+    // A merged run reconstructed from a result-summary state label (no meta
+    // exitCode observed) must downgrade to COMPLETED on clean merge but must NOT
+    // fabricate childNonZeroExit — the flag is only provable from the meta path.
+    await writeFile(
+      path.join(asyncResultsRoot, "run-result-merged-1638.json"),
+      `${JSON.stringify({
+        runId: "run-result-merged-1638",
+        state: "failed",
+        cwd: repoRoot,
+        timestamp: 1700000099000,
+        results: [{
+          agent: "dev-loop",
+          sessionFile: "x",
+          output: "Active PR: owner/repo#1666\nArtifact state: merged\nPR merged: #1666\n",
+        }],
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    const runs4 = await listRepoAsyncRuns(
+      { repo: "owner/repo" },
+      { repoRoot, sessionRoots: [sessionsRoot], asyncRunRoots: [asyncRunsRoot], asyncResultRoots: [asyncResultsRoot] },
+    );
+    const stateLabelMerged = runs4.find((run) => run.runId === "run-result-merged-1638");
+    assert.equal(stateLabelMerged.runState, "completed", "state-label merged run downgrades to COMPLETED");
+    assert.equal(stateLabelMerged.evidence.mergeSuccess, true);
+    assert.equal(stateLabelMerged.evidence.childNonZeroExit, undefined, "childNonZeroExit must not be fabricated without an exitCode");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/loop/conductor-monitor.test.mjs
+++ b/test/loop/conductor-monitor.test.mjs
@@ -1799,14 +1799,30 @@ test("conductor-monitor decouples merge-success run-state from non-zero post-mer
     const mergedRun = runs.find((run) => run.runId === "run-merged-1638");
     assert.ok(mergedRun, "merged run should be listed");
     assert.equal(mergedRun.runState, "completed");
-    assert.equal(mergedRun.evidence.postMergeVerifyNonZero, true);
+    assert.equal(mergedRun.evidence.childNonZeroExit, true);
     assert.equal(mergedRun.evidence.mergeSuccess, true);
-    assert.match(mergedRun.evidence.warning, /environmental \(non-code\) suites/u);
+    assert.match(mergedRun.evidence.warning, /recorded a successful merge/u);
 
     const openRun = runs.find((run) => run.runId === "run-open-1638");
     assert.ok(openRun, "open run should be listed");
     assert.equal(openRun.runState, "failed");
-    assert.equal(openRun.evidence.postMergeVerifyNonZero, undefined);
+    assert.equal(openRun.evidence.childNonZeroExit, undefined);
+
+    // Negative phrasing ("not merged") must NOT false-downgrade a failed run.
+    await writeSessionRun({
+      sessionsRoot,
+      runId: "run-notmerged-1638",
+      cwd: repoRoot,
+      timestampMs: 1700000099000,
+      exitCode: 1,
+      outputText: "Active PR: owner/repo#1660\nArtifact state: open\nStatus: review requested, PR artifacts not merged yet\n",
+    });
+
+    const runs2 = await listRepoAsyncRuns(
+      { repo: "owner/repo" },
+      { repoRoot, sessionRoots: [sessionsRoot], asyncRunRoots: [asyncRunsRoot], asyncResultRoots: [asyncResultsRoot] },
+    );
+    assert.equal(runs2.find((run) => run.runId === "run-notmerged-1638").runState, "failed");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #1638

## Summary

Decouple the conductor's merge-success run-state from the post-merge local-verify exit code. A dev-loop run that lands a clean merge then runs a post-merge local `npm run verify` can exit non-zero purely on environmental (non-code) suites (missing gh/run-id context in a worktree), and `scanSessionArtifactRoot` maps any non-zero child exit `!== 0 -> FAILED`. That reclassified a successful merge as a hard-failed run (false-FAILED, observed on the #1555 rc.5 run).

`listRepoAsyncRuns` now reconciles FAILED runs **after** all root scanners merge evidence: when a run's output artifact records a successful merge, the run is reclassified `COMPLETED` and the non-zero post-merge verify is surfaced as a warning note rather than a hard FAILED. Real gate/merge failures (open PR, unresolved feedback, no merge evidence) remain FAILED.

## Changes

- `scripts/loop/conductor-monitor.mjs`:
  - added `outputTextIndicatesSuccessfulMerge(text)` — reuses the existing merge-state signals (`Artifact state: merged`, `PR merged: #N`, `Status: ... merged`) via the existing `parseArtifactState`.
  - added a post-scan reconciliation pass in `listRepoAsyncRuns` that reclassifies FAILED runs with merge-success evidence to `COMPLETED` and attaches `mergeSuccess`, `postMergeVerifyNonZero`, and a `warning` note on `record.evidence`.
- `test/loop/conductor-monitor.test.mjs`: regression test for the merge-success + post-merge-local-verify-nonzero path, plus a non-merged control that stays `failed`.

## Acceptance criteria

- [x] A dev-loop run that completes a clean merge does not exit `failed` solely because a post-merge local verify hit environmental (non-code) failures.
- [x] The conductor's child exit-code → status mapping distinguishes "merge succeeded, post-merge verification had environmental failures" from "merge/gate failed".
- [x] Local-environmental verify failures are surfaced as a warning/note, not a hard FAILED.
- [x] Regression test covering the merge-success + post-merge-local-verify-nonzero path.
- [x] `npm run verify` green.

## Definition of done

- [x] All acceptance criteria covered by executable tests.
- [x] `npm run verify` green (environmental gh-mock failures at base excluded).

## Validation

- `npm run test:scripts` — 3939 tests, 3903 pass, 36 skipped, **0 fail** (includes conductor-monitor + new regression test).
- `npm run test:assets` — 274 pass, **0 fail** (contract ratchets: orphan-entrypoint, cli-harness-agnostic).
- `npm run test:core` — 2587 pass, **0 fail**.
- `npm run assets:check` — ok (94 checked).
- `npm run schema:check` — up to date.

## Non-goals

- Fixing the environmental test suites themselves (tracked separately).
- Changing gate-evidence (CI remains the authoritative gate-evidence source).
