### PR TITLE
fix(dev-loop): prefer worktree-source verdict/ledger tooling when installed CLI stale (#1661)

### DIFF
--- a/.claude/skills/copilot-pr-followup/SKILL.md
+++ b/.claude/skills/copilot-pr-followup/SKILL.md
@@ -101,6 +101,20 @@ Required bundled runtime contract docs for installed copies of this skill:
 Read those bundled `../docs/` files from the installed skill layout instead of assuming the source repository checkout is present. If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.
 <!-- rule: ASSET-PATH-SOURCE-NO-REPO-LOCAL --> `ASSET-PATH-SOURCE-NO-REPO-LOCAL`: Agents MUST NOT assume `scripts/...` is repo-local to the target codebase they are operating on.
 
+### Stale-installed-CLI: prefer worktree-source verdict/ledger tooling (#1661)
+
+A stale installed dev-loops CLI (e.g. rc.1) lacks the gate-evidence CI exclusion that newer source (rc.4+) has, so posting a `pre_approval_gate` verdict through the stale script blocks on `WAITING_FOR_CI`. To keep the canonical gate path green regardless of install state, resolve where the verdict/ledger tooling should run from FIRST via the deterministic helper (issue #1661):
+
+```sh
+node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
+```
+
+- When `preferredSource` is `worktree`, run the verdict/ledger tooling (`upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, `detect-checkpoint-evidence.mjs`, and their gate helpers) from the worktree/source `scripts/` layout instead of the installed layout.
+- When `preferredSource` is `installed`, run them from the resolved skill-scripts layout (installed) as usual.
+- The helper compares the installed dev-loops CLI version against the current source/worktree version (bounded candidate detection); it never changes the gate-evidence CI-exclusion logic itself (`#1661` non-goal) and fails soft to the canonical installed layout when a version cannot be read.
+
+This is the canonical fix surface for `#1661`: prefer worktree-source scripts for verdict/ledger tooling when the installed CLI is stale, with no change to the gate path's own behavior.
+
 ### Source files under review vs. helper-script paths
 
 The rule above governs HELPER SCRIPT paths invoked as tooling (`scripts/...` you RUN). It does **not** govern SKILL/DOC SOURCE FILES you REVIEW as content. A gate reviewer citing a skill/doc file (e.g. `skills/<name>/SKILL.md`, `skills/docs/...`, `docs/...`) in a finding is reviewing the PR's content, not invoking tooling — and installed copies of those source files lag the PR under review. Reading an installed copy (`.pi/skills/<name>/SKILL.md`, `~/.pi/agent/...`) produces false high-severity findings against text the PR already fixed (#1603).

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -99,6 +99,16 @@ Use the fallback poster only when the full helper cannot be reached:
 
 When `@dev-loops/core` is available again, switch back to the full helper. The fallback poster is a degraded path, not a permanent replacement.
 
+### Stale-installed-CLI: prefer worktree-source verdict/ledger tooling (#1661)
+
+Before posting a `pre_approval_gate` (or `draft_gate`) verdict, resolve which layout the verdict/ledger tooling should run from via the deterministic helper (issue #1661):
+
+```sh
+node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
+```
+
+When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
+
 ## Read-only info shortcut
 
 Info/handoff requests can be served directly via `npx dev-loops@1.0.0-rc.5 loop info` (read-only; no full dev-loop run required):

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -107,7 +107,7 @@ Before posting a `pre_approval_gate` (or `draft_gate`) verdict, resolve which la
 node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
 ```
 
-When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
+When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](../copilot-pr-followup/SKILL.md#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
 
 ## Read-only info shortcut
 

--- a/scripts/loop/resolve-verdict-ledger-source.mjs
+++ b/scripts/loop/resolve-verdict-ledger-source.mjs
@@ -31,7 +31,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
-import { buildParseError } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
 
 const USAGE = `Usage:
@@ -161,7 +161,8 @@ async function detectInstalledRoot() {
 }
 
 function parseResolveVerdictLedgerSourceCliArgs(argv) {
-  const { values } = parseArgs({
+  const options = { help: false, sourceRoot: undefined, installedRoot: undefined };
+  const { tokens } = parseArgs({
     args: [...argv],
     options: {
       help: { type: "boolean", short: "h" },
@@ -169,8 +170,28 @@ function parseResolveVerdictLedgerSourceCliArgs(argv) {
       "installed-root": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
   });
-  return values;
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "source-root") {
+      options.sourceRoot = token.value;
+    } else if (token.name === "installed-root") {
+      options.installedRoot = token.value;
+    } else if (token.name === "jq") {
+      options.jq = token.value;
+    } else if (token.name === "silent") {
+      options.silent = true;
+    }
+  }
+  return options;
 }
 
 export async function main(argv, io = { stdout: process.stdout, stderr: process.stderr }) {
@@ -180,8 +201,8 @@ export async function main(argv, io = { stdout: process.stdout, stderr: process.
     return 0;
   }
   const sourceRoot =
-    values["source-root"] ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-  const installedRoot = values["installed-root"] ?? (await detectInstalledRoot());
+    values.sourceRoot ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const installedRoot = values.installedRoot ?? (await detectInstalledRoot());
   const sourceVersion = readVersion(sourceRoot) ?? "unknown";
   const installedVersion = readVersion(installedRoot) ?? "unknown";
   let result;
@@ -205,6 +226,11 @@ export async function main(argv, io = { stdout: process.stdout, stderr: process.
   });
 }
 
-if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
-  main(process.argv.slice(2)).then((code) => process.exitCode = code);
+if (isDirectCliRun(import.meta.url)) {
+  try {
+    main(process.argv.slice(2)).then((code) => process.exitCode = code);
+  } catch (error) {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/loop/resolve-verdict-ledger-source.mjs
+++ b/scripts/loop/resolve-verdict-ledger-source.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Resolve where the gate verdict/ledger tooling should run from (issue #1661).
+ *
+ * A stale installed dev-loops CLI (e.g. rc.1) lacks the gate-evidence CI
+ * exclusion that newer source (rc.4+) has, so posting a pre_approval_gate
+ * verdict through the stale script blocks on WAITING_FOR_CI. Canonical fix
+ * surface is the dev-loop skill's script-path resolution: prefer the
+ * worktree/source-scripts layout for verdict/ledger tooling whenever the
+ * installed CLI version is older than the current source.
+ *
+ * This helper makes that preference deterministic. It compares the installed
+ * dev-loops CLI version (resolved via the same bounded candidates the dev-loop
+ * entrypoint uses) against the current source/worktree version (this script's
+ * own repo root by default) and reports which layout to prefer.
+ *
+ * VERDICT-LEDGER-SOURCE: verdict/ledger tooling (upsert-checkpoint-verdict.mjs,
+ * write-gate-findings-log.mjs, detect-checkpoint-evidence.mjs) MUST resolve via
+ * this helper and run from the worktree-source layout when stale === true
+ * (installed version older than source); otherwise keep the canonical installed
+ * layout. Non-goal (#1661): this does NOT change the gate-evidence CI exclusion
+ * logic in upsert-checkpoint-verdict.mjs itself.
+ *
+ * Output (stdout, JSON):
+ *   { "ok": true, "preferredSource": "worktree"|"installed", "stale": bool,
+ *     "installedVersion": ..., "sourceVersion": ..., "reason": "<why>" }
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { buildParseError } from "../_core-helpers.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage:
+  resolve-verdict-ledger-source.mjs [--source-root <path>] [--installed-root <path>]
+
+Compare the installed dev-loops CLI version against the current source/worktree
+version and report which layout the gate verdict/ledger tooling should run from
+(issue #1661). Prefer worktree-source scripts when the installed CLI is stale.
+
+Optional:
+  --source-root <path>    Path to the dev-loops source/worktree package.json.
+                          Default: this script's own repo root (../..).
+  --installed-root <path> Path to the installed dev-loops package (its root
+                          package.json). Default: bounded candidate detection
+                          (node-module resolution, ~/.pi/agent/npm, npm root -g).
+  -h, --help              Show this help.
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+// --- Pure version logic (unit-tested) ---
+
+// Split "1.2.3-rc.5" (or "v1.2.3", or "1.2.3") into { core:[1,2,3], pre:"rc.5"|null }.
+// Returns null for anything not parseable as a version core.
+export function splitVersion(value) {
+  if (typeof value !== "string") return null;
+  const base = value.trim().replace(/^v/i, "");
+  if (!base) return null;
+  const dash = base.indexOf("-");
+  const coreRaw = dash === -1 ? base : base.slice(0, dash);
+  const pre = dash === -1 ? null : base.slice(dash + 1) || null;
+  const core = coreRaw.split(".").map((x) => (/^\d+$/.test(x) ? Number(x) : Number.NaN));
+  if (core.some((x) => Number.isNaN(x))) return null;
+  return { core, pre };
+}
+
+// Compare two version strings (semver-ish; handles the rc.N prerelease pattern).
+// Returns -1/0/1, or NaN when either input is unparseable.
+export function compareVersions(a, b) {
+  const A = splitVersion(a);
+  const B = splitVersion(b);
+  if (!A || !B) return Number.NaN;
+  const len = Math.max(A.core.length, B.core.length);
+  for (let i = 0; i < len; i++) {
+    const av = A.core[i] ?? 0;
+    const bv = B.core[i] ?? 0;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  if (A.pre === null && B.pre === null) return 0;
+  if (A.pre === null) return 1; // release > prerelease
+  if (B.pre === null) return -1;
+  const toks = (s) => s.split(".").map((t) => (/^\d+$/.test(t) ? { n: Number(t) } : { s: t }));
+  const at = toks(A.pre);
+  const bt = toks(B.pre);
+  const ml = Math.max(at.length, bt.length);
+  for (let i = 0; i < ml; i++) {
+    const aTok = at[i];
+    const bTok = bt[i];
+    if (aTok === undefined) return -1;
+    if (bTok === undefined) return 1;
+    if ("n" in aTok && "n" in bTok) {
+      if (aTok.n !== bTok.n) return aTok.n < bTok.n ? -1 : 1;
+    } else if ("s" in aTok && "s" in bTok) {
+      if (aTok.s !== bTok.s) return aTok.s < bTok.s ? -1 : 1;
+    } else {
+      return "n" in aTok ? -1 : 1; // numeric prerelease segment sorts before string
+    }
+  }
+  return 0;
+}
+
+// Decide which layout to prefer for verdict/ledger tooling.
+export function resolveVerdictLedgerSource({ installedVersion, sourceVersion }) {
+  const ip = String(installedVersion ?? "");
+  const sp = String(sourceVersion ?? "");
+  const cmp = compareVersions(sp, ip);
+  const stale = cmp > 0; // source newer than installed
+  return {
+    ok: true,
+    preferredSource: stale ? "worktree" : "installed",
+    stale,
+    installedVersion: ip,
+    sourceVersion: sp,
+    reason: stale
+      ? `Installed dev-loops CLI (${ip}) is older than the source/worktree (${sp}); verdict/ledger tooling runs from the worktree source (has the gate-evidence CI exclusion).`
+      : `Installed dev-loops CLI (${ip}) is not older than the source/worktree (${sp}); keep the canonical installed layout.`,
+  };
+}
+
+// --- Installed package-root detection (bounded candidates, mirrors dev-loop entrypoint) ---
+
+function readVersion(pkgRoot) {
+  if (!pkgRoot) return null;
+  const p = path.join(pkgRoot, "package.json");
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf8")).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function detectInstalledRoot() {
+  // 1. Node module resolution (best-effort).
+  try {
+    const { createRequire } = await import("node:module");
+    const req = createRequire(import.meta.url);
+    const entry = req.resolve("dev-loops/cli/index.mjs");
+    return path.resolve(path.dirname(entry), "..");
+  } catch {
+    /* fall through */
+  }
+  // 2. Pi user-agent npm root.
+  const home = process.env.HOME || os.homedir();
+  const piRoot = path.join(home, ".pi/agent/npm/node_modules/dev-loops");
+  if (existsSync(path.join(piRoot, "package.json"))) return piRoot;
+  // 3. Global npm root.
+  try {
+    const g = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+    const globalRoot = path.join(g, "dev-loops");
+    if (existsSync(path.join(globalRoot, "package.json"))) return globalRoot;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function parseResolveVerdictLedgerSourceCliArgs(argv) {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "source-root": { type: "string" },
+      "installed-root": { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+  });
+  return values;
+}
+
+export async function main(argv, io = { stdout: process.stdout, stderr: process.stderr }) {
+  const values = parseResolveVerdictLedgerSourceCliArgs(argv);
+  if (values.help) {
+    io.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  const sourceRoot =
+    values["source-root"] ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const installedRoot = values["installed-root"] ?? (await detectInstalledRoot());
+  const sourceVersion = readVersion(sourceRoot) ?? "unknown";
+  const installedVersion = readVersion(installedRoot) ?? "unknown";
+  let result;
+  if (sourceVersion === "unknown" || installedVersion === "unknown") {
+    result = {
+      ok: true,
+      preferredSource: "installed",
+      stale: false,
+      installedVersion,
+      sourceVersion,
+      reason: `Could not compare versions (source=${sourceVersion}, installed=${installedVersion}); keep the canonical installed layout.`,
+    };
+  } else {
+    result = resolveVerdictLedgerSource({ installedVersion, sourceVersion });
+  }
+  return emitResult(result, {
+    jq: values.jq,
+    silent: values.silent,
+    stdout: io.stdout,
+    stderr: io.stderr,
+  });
+}
+
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).then((code) => process.exitCode = code);
+}

--- a/skills/copilot-pr-followup/SKILL.md
+++ b/skills/copilot-pr-followup/SKILL.md
@@ -109,6 +109,20 @@ Required bundled runtime contract docs for installed copies of this skill:
 Read those bundled `../docs/` files from the installed skill layout instead of assuming the source repository checkout is present. If any required bundled contract doc is missing from the installed skill layout, treat that as a packaging/installer bug.
 <!-- rule: ASSET-PATH-SOURCE-NO-REPO-LOCAL --> `ASSET-PATH-SOURCE-NO-REPO-LOCAL`: Agents MUST NOT assume `scripts/...` is repo-local to the target codebase they are operating on.
 
+### Stale-installed-CLI: prefer worktree-source verdict/ledger tooling (#1661)
+
+A stale installed dev-loops CLI (e.g. rc.1) lacks the gate-evidence CI exclusion that newer source (rc.4+) has, so posting a `pre_approval_gate` verdict through the stale script blocks on `WAITING_FOR_CI`. To keep the canonical gate path green regardless of install state, resolve where the verdict/ledger tooling should run from FIRST via the deterministic helper (issue #1661):
+
+```sh
+node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
+```
+
+- When `preferredSource` is `worktree`, run the verdict/ledger tooling (`upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, `detect-checkpoint-evidence.mjs`, and their gate helpers) from the worktree/source `scripts/` layout instead of the installed layout.
+- When `preferredSource` is `installed`, run them from the resolved skill-scripts layout (installed) as usual.
+- The helper compares the installed dev-loops CLI version against the current source/worktree version (bounded candidate detection); it never changes the gate-evidence CI-exclusion logic itself (`#1661` non-goal) and fails soft to the canonical installed layout when a version cannot be read.
+
+This is the canonical fix surface for `#1661`: prefer worktree-source scripts for verdict/ledger tooling when the installed CLI is stale, with no change to the gate path's own behavior.
+
 ### Source files under review vs. helper-script paths
 
 The rule above governs HELPER SCRIPT paths invoked as tooling (`scripts/...` you RUN). It does **not** govern SKILL/DOC SOURCE FILES you REVIEW as content. A gate reviewer citing a skill/doc file (e.g. `skills/<name>/SKILL.md`, `skills/docs/...`, `docs/...`) in a finding is reviewing the PR's content, not invoking tooling — and installed copies of those source files lag the PR under review. Reading an installed copy (`.pi/skills/<name>/SKILL.md`, `~/.pi/agent/...`) produces false high-severity findings against text the PR already fixed (#1603).

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -130,7 +130,7 @@ Before posting a `pre_approval_gate` (or `draft_gate`) verdict, resolve which la
 node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
 ```
 
-When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
+When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](../copilot-pr-followup/SKILL.md#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
 
 ## Read-only info shortcut
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -122,6 +122,16 @@ Use the fallback poster only when the full helper cannot be reached:
 
 When `@dev-loops/core` is available again, switch back to the full helper. The fallback poster is a degraded path, not a permanent replacement.
 
+### Stale-installed-CLI: prefer worktree-source verdict/ledger tooling (#1661)
+
+Before posting a `pre_approval_gate` (or `draft_gate`) verdict, resolve which layout the verdict/ledger tooling should run from via the deterministic helper (issue #1661):
+
+```sh
+node <resolved-skill-scripts>/loop/resolve-verdict-ledger-source.mjs --jq .preferredSource
+```
+
+When `preferredSource` is `worktree` (installed dev-loops CLI older than the current source/worktree), run `upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`, and `detect-checkpoint-evidence.mjs` from the worktree/source `scripts/` layout — the stale installed CLI lacks the gate-evidence CI exclusion and would otherwise block verdict posting on `WAITING_FOR_CI`. When `installed`, use the resolved skill-scripts (installed) layout as usual. The copilot-pr-followup skill's [Skill asset path resolution](#skill-asset-path-resolution) owns the full rule; this is the entrypoint pointer.
+
 ## Read-only info shortcut
 
 Info/handoff requests can be served directly via `node <dev-loops-package-root>/cli/index.mjs loop info` (read-only; no full dev-loop run required):

--- a/test/contracts/orphan-entrypoint-ratchet.test.mjs
+++ b/test/contracts/orphan-entrypoint-ratchet.test.mjs
@@ -74,6 +74,7 @@ const ORPHAN_ALLOWLIST = new Map([
   ["scripts/loop/pre-write-remote-freshness-guard.mjs", "standalone — remote-freshness guard step, agent-invoked"],
   ["scripts/loop/run-conductor-cycle.mjs", "standalone — conductor cycle step (documented in scripts/README), agent-invoked"],
   ["scripts/loop/run-gate-validation.mjs", "standalone — CLI gate-suite runner, agent/operator invoked"],
+  ["scripts/loop/resolve-verdict-ledger-source.mjs", "standalone — verdict/ledger tooling source resolver (issue #1661), skill-agent-invoked to prefer worktree-source when installed CLI stale"],
   ["scripts/loop/run-refinement-audit.mjs", "standalone — refinement audit step (documented in scripts/README), agent-invoked"],
   ["scripts/loop/validate-pr-body-spec.mjs", "delete or wire — CLI superseded by core validatePrBodySpec; its --expected-issue option has no caller (issue #1620 orphan)"],
   ["scripts/refine/refine-plan-file.mjs", "standalone — refine-flow phase-file step, agent-invoked"],

--- a/test/loop/resolve-verdict-ledger-source.test.mjs
+++ b/test/loop/resolve-verdict-ledger-source.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runNode as runNodeHelper } from "../_helpers.mjs";
+import {
+  splitVersion,
+  compareVersions,
+  resolveVerdictLedgerSource,
+} from "../../scripts/loop/resolve-verdict-ledger-source.mjs";
+
+const scriptPath = path.resolve("scripts/loop/resolve-verdict-ledger-source.mjs");
+const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
+
+test("splitVersion parses core and rc.N prerelease", () => {
+  assert.deepEqual(splitVersion("1.0.0-rc.5"), { core: [1, 0, 0], pre: "rc.5" });
+  assert.deepEqual(splitVersion("v1.2.3"), { core: [1, 2, 3], pre: null });
+  assert.deepEqual(splitVersion("1.2.3"), { core: [1, 2, 3], pre: null });
+  assert.equal(splitVersion("garbage"), null);
+  assert.equal(splitVersion(null), null);
+});
+
+test("compareVersions orders rc and release versions", () => {
+  // rc.1 < rc.5 < final release
+  assert.equal(compareVersions("1.0.0-rc.1", "1.0.0-rc.5"), -1);
+  assert.equal(compareVersions("1.0.0-rc.5", "1.0.0-rc.1"), 1);
+  assert.equal(compareVersions("1.0.0-rc.5", "1.0.0"), -1);
+  assert.equal(compareVersions("1.0.0", "1.0.0-rc.5"), 1);
+  assert.equal(compareVersions("1.0.0-rc.1", "1.0.0-rc.1"), 0);
+  // core bump dominates prerelease
+  assert.equal(compareVersions("1.1.0-rc.1", "1.0.0-rc.9"), 1);
+  assert.equal(Number.isNaN(compareVersions("nope", "1.0.0-rc.5")), true);
+});
+
+test("resolveVerdictLedgerSource prefers worktree when installed is stale", () => {
+  const stale = resolveVerdictLedgerSource({ installedVersion: "1.0.0-rc.1", sourceVersion: "1.0.0-rc.5" });
+  assert.equal(stale.stale, true);
+  assert.equal(stale.preferredSource, "worktree");
+
+  const current = resolveVerdictLedgerSource({ installedVersion: "1.0.0-rc.5", sourceVersion: "1.0.0-rc.5" });
+  assert.equal(current.stale, false);
+  assert.equal(current.preferredSource, "installed");
+
+  const installedNewer = resolveVerdictLedgerSource({ installedVersion: "1.0.0", sourceVersion: "1.0.0-rc.5" });
+  assert.equal(installedNewer.stale, false);
+  assert.equal(installedNewer.preferredSource, "installed");
+});
+
+test("CLI reports worktree preference for an older installed root", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "vls-"));
+  try {
+    const src = path.join(tmp, "src");
+    const inst = path.join(tmp, "inst");
+    await mkdir(src, { recursive: true });
+    await mkdir(inst, { recursive: true });
+    await writeFile(path.join(src, "package.json"), JSON.stringify({ version: "1.0.0-rc.5" }));
+    await writeFile(path.join(inst, "package.json"), JSON.stringify({ version: "1.0.0-rc.1" }));
+    const { code, stdout } = await runNode([
+      "--source-root", src,
+      "--installed-root", inst,
+      "--jq", ".preferredSource",
+    ]);
+    assert.equal(code, 0);
+    assert.equal(stdout.trim(), "worktree");
+  } finally {
+    await import("node:fs/promises").then(({ rm }) => rm(tmp, { recursive: true, force: true }));
+  }
+});
+
+test("CLI defaults to installed layout when a version cannot be read", async () => {
+  const { code, stdout } = await runNode(["--source-root", "/nonexistent-root-xyz", "--jq", ".preferredSource"]);
+  assert.equal(code, 0);
+  assert.equal(stdout.trim(), "installed");
+  const { code: c2, stdout: s2 } = await runNode(
+    ["--source-root", "/nonexistent-root-xyz", "--jq", ".stale"],
+  );
+  assert.equal(c2, 0);
+  assert.equal(s2.trim(), "false");
+});


### PR DESCRIPTION
## Summary

Fixes the stale-installed-CLI WAITING_FOR_CI problem behind `fix(dev-loop)`. An installed
dev-loops CLI older than the worktree source (e.g. installed `rc.1` vs source `rc.4+`) lacks
the gate-evidence CI exclusion in `upsert-checkpoint-verdict.mjs`, so posting a
`pre_approval_gate` verdict through the stale script blocks on `WAITING_FOR_CI`.

Implements the issue's proposal (b): the dev-loop skill now **deterministically prefers
worktree-source scripts for verdict/ledger tooling when the installed CLI is stale**.

- New deterministic helper `scripts/loop/resolve-verdict-ledger-source.mjs` compares the
  installed dev-loops CLI version (bounded candidate detection: node-module resolution,
  `~/.pi/agent/npm`, global npm root) against the current source/worktree version and reports
  `preferredSource: "worktree" | "installed"`. Fail-soft to the canonical installed layout when
  a version cannot be read. Standard `--jq`/`--silent` output convention.
- Skill docs updated (`skills/dev-loop/SKILL.md`, `skills/copilot-pr-followup/SKILL.md`, plus
  regenerated `.claude/skills/` mirrors): when `preferredSource` is `worktree`, verdict/ledger
  tooling (`upsert-checkpoint-verdict.mjs`, `write-gate-findings-log.mjs`,
  `detect-checkpoint-evidence.mjs`) runs from the worktree/source `scripts/` layout instead of
  the stale installed layout.
- Tests for the pure version-comparison/resolution logic and CLI output/boundary behavior.

## Acceptance criteria

- [x] A gate pass no longer hits `WAITING_FOR_CI` on `pre_approval_gate` verdict posting solely
      because the installed CLI is stale (option b: skill deterministically prefers worktree-source
      scripts for verdict/ledger tooling when the installed CLI is stale).
- [x] No regression to the canonical gate path (helper fails soft to the installed layout when not
      stale or when a version cannot be read; gate-evidence CI-exclusion logic itself is a non-goal
      and is untouched).
- [x] `npm run verify` green.
- [x] Cross-harness non-regression (#1086): the helper is pure Node (harness-agnostic); `.claude`
      mirrors regenerated for Claude compatibility.

## Non-goals (from issue #1661)

- Changing the gate-evidence CI exclusion logic itself.
- Pinning the installed CLI to a specific version.

## Definition of done

- Deterministic helper published + tested.
- Skill docs updated for the preference rule (both Pi `skills/` and Claude `.claude/skills/`).
- `npm run verify`, `assets:check`, `schema:check` all green.

## Validation

- `node --test test/loop/resolve-verdict-ledger-source.test.mjs` — 5 tests pass.
- `npm run verify` — green (all legs: assets, extension, scripts, core, docs, pack, dev-loop, workflows).
- `npm run assets:check` — `.claude` assets in sync.
- `npm run schema:check` — schema up to date.
- `npm run test:docs` — links, rule ownership, decision records pass.

Closes #1661
