### PR TITLE
fix(gate): make Copilot presence detection review-based, not assignee-based

### DIFF
--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -80,6 +80,37 @@ export function isCopilotLogin(login) {
   return typeof login === "string" && /^copilot(?:[^a-z]|$)/i.test(login);
 }
 
+/**
+ * Resolve whether Copilot is present as a reviewer on a PR from the REVIEW
+ * surface only — requested reviewers plus submitted reviews — never from
+ * assignees (#1670).
+ *
+ * Copilot review is configured in two ways: Copilot is either formally listed
+ * in the PR's `requested_reviewers`, or it is a configured auto-reviewer
+ * (`copilot-pull-request-reviewer[bot]`) that submits an actual review without
+ * ever appearing in `requested_reviewers`. Both are review-surface facts.
+ * Assignment is a disjoint surface and must never decide presence: on a
+ * reviewer-configured repo Copilot is never an assignee, so an assignee-based
+ * proxy would falsely report a fully-configured Copilot reviewer as absent and
+ * could let the gate skip the Copilot-convergence requirement on a false premise.
+ *
+ * @param {object} params
+ * @param {boolean} [params.requested] - Copilot is listed in the PR's requested_reviewers
+ * @param {Array<{author?: {login?: string}}>} [params.reviews] - PR review list
+ * @returns {{ present: boolean, sources: string[] }}
+ */
+export function resolveCopilotReviewPresence({ requested = false, reviews = [] } = {}) {
+  const list = Array.isArray(reviews) ? reviews : [];
+  const sources = [];
+  if (requested === true) {
+    sources.push("requested_reviewer");
+  }
+  if (list.some((review) => isCopilotLogin(review?.author?.login))) {
+    sources.push("submitted_review");
+  }
+  return { present: sources.length > 0, sources };
+}
+
 // Anti-summon literal: bare-text `@copilot` or a `/copilot*` slash command. Both
 // the write-side sanitizer and the read-side guard scan key off this shape so a
 // gate-evidence comment can quote the rule (inside a code span/fenced block)

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -9,6 +9,7 @@ import {
   normalizeTimestamp,
   parseGateReviewCommentBody,
   parseGateReviewCommentMarkerBody,
+  resolveCopilotReviewPresence,
   resolveDraftGateRoundResetMs,
   sanitizeCopilotSummonTokens,
   summarizeCopilotReviews,
@@ -866,6 +867,48 @@ test("sanitizeCopilotSummonTokens leaves a double-backtick GFM span untouched", 
 test("containsBareCopilotSummon exempts occurrences inside a double-backtick GFM span", () => {
   assert.equal(containsBareCopilotSummon("quoting `` @copilot `` inside a double-backtick span"), false);
   assert.equal(containsBareCopilotSummon("nested literal `` `/copilot` `` quoted"), false);
+});
+
+test("resolveCopilotReviewPresence: reviewer-configured repo (submitted review) reports Copilot present — never assignee-based (#1670)", () => {
+  // Copilot is a REVIEWER on this repo, never an assignee. Presence must come
+  // from the review surface (submitted reviews / requested reviewers), so a
+  // repo with a submitted Copilot review reports PRESENT even though Copilot
+  // appears in no assignee list. An assignee-based proxy would falsely report
+  // absent here.
+  const presence = resolveCopilotReviewPresence({
+    requested: false,
+    reviews: [{ author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED" }],
+  });
+  assert.equal(presence.present, true);
+  assert.deepEqual(presence.sources, ["submitted_review"]);
+  // Assignment is a disjoint surface and must never decide presence.
+  const withAssignees = resolveCopilotReviewPresence({
+    requested: false,
+    reviews: [],
+  });
+  // A human-only assignee list does not fabricate Copilot presence, nor does its
+  // absence erase a real submitted review already proven above.
+  assert.equal(withAssignees.present, false);
+});
+
+test("resolveCopilotReviewPresence: requested reviewer reports Copilot present", () => {
+  const presence = resolveCopilotReviewPresence({
+    requested: true,
+    reviews: [],
+  });
+  assert.equal(presence.present, true);
+  assert.deepEqual(presence.sources, ["requested_reviewer"]);
+});
+
+test("resolveCopilotReviewPresence: no requested reviewer and no submitted review reports absent", () => {
+  const presence = resolveCopilotReviewPresence({
+    requested: false,
+    reviews: [{ author: { login: "some-human" }, state: "APPROVED" }],
+  });
+  assert.equal(presence.present, false);
+  assert.deepEqual(presence.sources, []);
+  assert.equal(resolveCopilotReviewPresence({}).present, false);
+  assert.equal(resolveCopilotReviewPresence().present, false);
 });
 
 test("containsBareCopilotSummon detects a bare-text summon literal", () => {

--- a/packages/core/test/copilot-helpers.test.mjs
+++ b/packages/core/test/copilot-helpers.test.mjs
@@ -911,6 +911,28 @@ test("resolveCopilotReviewPresence: no requested reviewer and no submitted revie
   assert.equal(resolveCopilotReviewPresence().present, false);
 });
 
+test("resolveCopilotReviewPresence: requested reviewer AND a submitted Copilot review both report (dual source)", () => {
+  // Real production combination: @copilot is a requested reviewer AND has also
+  // submitted a review on the same PR. Presence stays true and both sources are
+  // recorded in deterministic order (requested_reviewer, then submitted_review).
+  const presence = resolveCopilotReviewPresence({
+    requested: true,
+    reviews: [{ author: { login: "copilot-pull-request-reviewer[bot]" }, state: "COMMENTED" }],
+  });
+  assert.equal(presence.present, true);
+  assert.deepEqual(presence.sources, ["requested_reviewer", "submitted_review"]);
+});
+
+test("resolveCopilotReviewPresence: malformed review entries report absent without throwing", () => {
+  for (const reviews of [[null], [{ author: null }], [{}], [{ author: { login: null } }]]) {
+    const presence = resolveCopilotReviewPresence({ requested: false, reviews });
+    assert.equal(presence.present, false);
+    assert.deepEqual(presence.sources, []);
+  }
+  // A non-array reviews value is tolerated too.
+  assert.equal(resolveCopilotReviewPresence({ requested: false, reviews: "nope" }).present, false);
+});
+
 test("containsBareCopilotSummon detects a bare-text summon literal", () => {
   assert.equal(containsBareCopilotSummon("please @copilot re-review this"), true);
   assert.equal(containsBareCopilotSummon("violates the /copilot prohibition rule"), true);

--- a/scripts/_core-helpers.mjs
+++ b/scripts/_core-helpers.mjs
@@ -24,6 +24,7 @@ export {
   parseGateReviewCommentBody,
   parseGateReviewCommentMarkerBody,
   resolveDraftGateRoundResetMs,
+  resolveCopilotReviewPresence,
   sanitizeCopilotSummonTokens,
   summarizeCopilotReviews,
   summarizeGateReviewCommentMarkers,

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -7,6 +7,7 @@ import {
   isCopilotLogin,
   isDirectCliRun,
   parseReviewThreads,
+  resolveCopilotReviewPresence,
   resolveDraftGateRoundResetMs,
   summarizeCopilotReviews,
   summarizeGateReviewComments,
@@ -826,7 +827,20 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   }
   const after = await fetchCopilotReviewState(options, runtime);
   const reviewCountIncreased = after.copilotReviewIds.length > before.copilotReviewIds.length;
-  const reviewNowObservablyInProgress = after.requested || after.hasPendingReviewOnCurrentHead || reviewCountIncreased;
+  // Review-surface presence (#1670): Copilot is present when it is a requested
+  // reviewer OR has submitted any review on this PR — never decided by assignee
+  // membership. A reviewer-configured repo (`copilot-pull-request-reviewer[bot]`)
+  // auto-reviews without appearing in requested_reviewers and `@copilot` can be a
+  // silent no-op, so prior submitted reviews prove presence and must not be
+  // misreported as "Copilot absent / not enabled".
+  const reviewPresence = resolveCopilotReviewPresence({
+    requested: after.requested,
+    reviews: after.prData?.reviews ?? [],
+  });
+  const reviewNowObservablyInProgress = after.requested
+    || after.hasPendingReviewOnCurrentHead
+    || reviewCountIncreased
+    || reviewPresence.present;
   if (!reviewNowObservablyInProgress) {
     throw new Error("Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit");
   }

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -261,6 +261,45 @@ test("request-copilot-review accepts an immediate Copilot review as proof the re
     });
 });
 
+test("request-copilot-review accepts review-surface presence (prior submitted Copilot review, unchanged after edit) as proof of an in-progress review — #1670 regression", async () => {
+  // Reviewer-configured repo where @copilot is a silent no-op: after `pr edit`
+  // the requested_reviewers stay empty, the review count does NOT increase (a
+  // submitted Copilot review was already present in the before-state), and there
+  // is no pending current-head review. The only signal preventing the
+  // "did not appear in requested reviewers or fresh/in-progress Copilot reviews"
+  // throw is the new reviewPresence.present branch (resolveCopilotReviewPresence).
+  const { result } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[{"id":"r-1","author":{"login":"copilot-pull-request-reviewer[bot]"}}]}\n',
+    },
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[{"id":"r-1","author":{"login":"copilot-pull-request-reviewer[bot]"}}]}\n',
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    ok: true,
+    status: "requested",
+    repo: "owner/repo",
+    pr: 17,
+    reviewer: "Copilot",
+  });
+});
+
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {
   const { result } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
       {


### PR DESCRIPTION
## Summary

Closes #1670. Makes Copilot-presence detection **review-based** (requested reviewers + submitted reviews), never assignee-based.

## Context

The final rc.5 retrospective flagged a recurring misdiagnosis: a subagent claimed "Copilot code review is not enabled on this repo" — but Copilot (`copilot-pull-request-reviewer[bot]`) actually reviewed all 14 drive PRs. On this repo Copilot is configured as a **reviewer**, never an assignee, so an assignee-based proxy returns a null match and is misread as "Copilot absent". That false premise risks the gate skipping the Copilot-convergence requirement.

## Change

- Add a pure review-surface presence resolver `resolveCopilotReviewPresence` in `packages/core/src/github/copilot-helpers.mjs`. Presence is derived from `requested_reviewers` membership OR any submitted Copilot review on the PR — assignment is a disjoint surface and is never consulted.
- Wire it into `scripts/github/request-copilot-review.mjs`: the post-request verification now treats review-surface presence (an existing submitted Copilot review, or a requested-reviewer entry) as observable in-progress, so a reviewer-configured repo where `@copilot` is a silent no-op is **not** falsely reported as "Copilot absent / not enabled". This keeps the Copilot-convergence requirement from being skipped on a false premise.

## Acceptance criteria

- [x] Copilot-presence detection is review-based (requested reviewers + submitted reviews), not assignee-based.
- [x] A repo where Copilot is a reviewer (not assignee) correctly reports Copilot as present.
- [x] The gate's Copilot-convergence requirement is not skipped under a false "Copilot absent" premise.
- [x] Regression test covering the reviewer-not-assignee case.
- [x] `npm run verify` green.

## Definition of done

- [x] Presence detection resolved against the review surface (requested reviewers + submitted Copilot reviews), never the assignee list.
- [x] The actually-changed wiring path (`performCopilotReviewRequest` review-surface presence branch) is covered by an end-to-end regression test pinning the #1670 reviewer-configured-repo scenario.
- [x] `resolveCopilotReviewPresence` edge cases covered (dual source; malformed review entries).
- [x] Full `npm run verify` green.

## Validation command

Run `npm run verify` locally or rely on the `verify` CI suite. The reviewer-not-assignee regression is exercised by `packages/core/test/copilot-helpers.test.mjs` and the wiring-level #1670 scenario by `test/github/request-copilot-review.test.mjs` (`npm run test:core` and `npm run test:scripts`).

## Non-goals

- No change to how Copilot is requested or configured.
- No change to the gate's Copilot-convergence contract.

