### PR TITLE
fix(gate): encode runs.all dispatch-key + fail-closed requirement (#1681)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -447,6 +447,26 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
 - produces a focused findings artifact PER ANGLE it covers, each with its own verdict (clean/findings_present) and file references, stamped per the head-stamp rule below — a grouped reviewer writes as many artifacts, at the existing per-angle paths, as it has angles, never one merged artifact for the group
 - completion is detected via the harness completion notification, or the reviewer's findings artifact(s) at their deterministic output paths; the orchestrator awaits fan-in on those paths and joins via the sanctioned fan-in CLI `dev-loops gate consolidate-fanin` (backed by `consolidateFanin`; Phase 3). The forbidden fan-in wait improvisations (transcript-tailing, `node -e`/`python3` tool-JSON parsing, `sleep`-poll loops) and this sanctioned wait are owned by `ANTIPATTERN-FANIN-WAIT` in [anti-patterns](./anti-patterns.md).
 
+<!-- rule: GATE-EXEC-FANOUT-DISPATCH-KEY -->
+`GATE-EXEC-FANOUT-DISPATCH-KEY`: Every `runs.all` / batch reviewer dispatch MUST carry a unique
+`key` field on EACH item (#1681). The Pi harness's `runs.all` workflowScript API requires each
+collection item to declare its own `key`; omitting it fails the whole dispatch with an `invalid
+key` validation error, which historically degraded a `requireFanoutEvidence` gate to a single
+inline reviewer. This rule encodes the fix so the conductor never drops the `key` and never lets
+a dispatch failure silently collapse fan-out:
+
+- Build each dispatch item with a distinct `key` (a per-angle or per-group slug), so the batch
+  validates on the harness; a missing or blank `key` on an item is a dispatch bug, not a harness
+  quirk to work around at fan-in.
+- When a fan-out dispatch fails for ANY reason (including `invalid key`), the conductor MUST
+  stop and report rather than degrading to an `inline_single_agent` verdict on a gate where
+  `gates.requireFanoutEvidence` is enabled. Merge-time and post-time enforcement both refuse an
+  inline verdict on such a gate through the shared `evaluateInlineFanoutMode` path
+  (`buildPreMergeGateCheck` in `detect-checkpoint-evidence.mjs`, and `upsert-checkpoint-verdict.mjs`),
+  so a degraded gate fails closed rather than passing as fan-out evidence. The only inline
+  acceptance is the light-mode `scopeUnderThreshold` carve-out (or an explicit operator decision
+  per PR), never a silent fallback.
+
 **Grouped dispatch (default).** Before fanning out, the conductor resolves this round's
 dispatch units by calling `resolveFanoutGroups(config, gate, resolvedAngles, { fullLabel })`
 (`@dev-loops/core/config`): configured `gates.fanout.groups` are matched first (an angle in

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -447,6 +447,26 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
 - produces a focused findings artifact PER ANGLE it covers, each with its own verdict (clean/findings_present) and file references, stamped per the head-stamp rule below — a grouped reviewer writes as many artifacts, at the existing per-angle paths, as it has angles, never one merged artifact for the group
 - completion is detected via the harness completion notification, or the reviewer's findings artifact(s) at their deterministic output paths; the orchestrator awaits fan-in on those paths and joins via the sanctioned fan-in CLI `dev-loops gate consolidate-fanin` (backed by `consolidateFanin`; Phase 3). The forbidden fan-in wait improvisations (transcript-tailing, `node -e`/`python3` tool-JSON parsing, `sleep`-poll loops) and this sanctioned wait are owned by `ANTIPATTERN-FANIN-WAIT` in [anti-patterns](./anti-patterns.md).
 
+<!-- rule: GATE-EXEC-FANOUT-DISPATCH-KEY -->
+`GATE-EXEC-FANOUT-DISPATCH-KEY`: Every `runs.all` / batch reviewer dispatch MUST carry a unique
+`key` field on EACH item (#1681). The Pi harness's `runs.all` workflowScript API requires each
+collection item to declare its own `key`; omitting it fails the whole dispatch with an `invalid
+key` validation error, which historically degraded a `requireFanoutEvidence` gate to a single
+inline reviewer. This rule encodes the fix so the conductor never drops the `key` and never lets
+a dispatch failure silently collapse fan-out:
+
+- Build each dispatch item with a distinct `key` (a per-angle or per-group slug), so the batch
+  validates on the harness; a missing or blank `key` on an item is a dispatch bug, not a harness
+  quirk to work around at fan-in.
+- When a fan-out dispatch fails for ANY reason (including `invalid key`), the conductor MUST
+  stop and report rather than degrading to an `inline_single_agent` verdict on a gate where
+  `gates.requireFanoutEvidence` is enabled. Merge-time and post-time enforcement both refuse an
+  inline verdict on such a gate through the shared `evaluateInlineFanoutMode` path
+  (`buildPreMergeGateCheck` in `detect-checkpoint-evidence.mjs`, and `upsert-checkpoint-verdict.mjs`),
+  so a degraded gate fails closed rather than passing as fan-out evidence. The only inline
+  acceptance is the light-mode `scopeUnderThreshold` carve-out (or an explicit operator decision
+  per PR), never a silent fallback.
+
 **Grouped dispatch (default).** Before fanning out, the conductor resolves this round's
 dispatch units by calling `resolveFanoutGroups(config, gate, resolvedAngles, { fullLabel })`
 (`@dev-loops/core/config`): configured `gates.fanout.groups` are matched first (an angle in

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -236,10 +236,6 @@
       "enforcement": "runtime"
     },
     {
-      "id": "GATE-EXEC-FANOUT-DISPATCH-KEY",
-      "enforcement": "doc"
-    },
-    {
       "id": "GATE-EXEC-DEFERRAL-RECORD",
       "enforcement": "runtime"
     },
@@ -248,6 +244,10 @@
     },
     {
       "id": "GATE-EXEC-DISPOSITION-LEDGER"
+    },
+    {
+      "id": "GATE-EXEC-FANOUT-DISPATCH-KEY",
+      "enforcement": "doc"
     },
     {
       "id": "GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK"

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -236,6 +236,10 @@
       "enforcement": "runtime"
     },
     {
+      "id": "GATE-EXEC-FANOUT-DISPATCH-KEY",
+      "enforcement": "doc"
+    },
+    {
       "id": "GATE-EXEC-DEFERRAL-RECORD",
       "enforcement": "runtime"
     },

--- a/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
+++ b/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
@@ -13,7 +13,11 @@ function extractRuleBlock(content, id) {
   assert.ok(start !== -1, `expected rule marker ${id} to be present`);
   const remaining = lines.slice(start + 1);
   const end = remaining.findIndex(
-    (line) => /<!--\s*rule:\s*[A-Z][A-Z0-9-]*\s*-->/.test(line) || /^\*\*[^*].*\*\*\s*$/.test(line.trim()),
+    // A bold heading terminates the rule block even when it carries trailing
+    // prose on the same line (e.g. `**Grouped dispatch (default).** Before …`),
+    // so the block never swallows the next section: match any line that STARTS
+    // a bold heading, not one that must also end in `**` on the same line.
+    (line) => /<!--\s*rule:\s*[A-Z][A-Z0-9-]*\s*-->/.test(line) || /^\*\*[^*]/.test(line.trim()),
   );
   assert.ok(end !== -1, `expected rule block ${id} to be terminated by the next rule marker or bold heading`);
   const block = remaining.slice(0, end);
@@ -41,6 +45,9 @@ test("gate fan-out contract owns the runs.all dispatch-key + fail-closed require
   assert.match(content, /a per-angle or per-group slug/);
 
   const owned = extractRuleBlock(content, "GATE-EXEC-FANOUT-DISPATCH-KEY");
+  // Negative case: the owned block must terminate at the next bold heading
+  // (`**Grouped dispatch (default).**`), never swallow the following section.
+  assert.equal(owned.includes("Grouped dispatch (default)"), false, "rule block must terminate at the next bold heading, not extend into the grouped-dispatch section");
   // The harness `key`-field requirement is encoded (AC1).
   assert.match(owned, /runs\.all/);
   assert.match(owned, /`key` field on EACH item/);

--- a/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
+++ b/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
@@ -1,0 +1,47 @@
+import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
+import { assertRuleOwned } from "./_rule-helpers.mjs";
+
+// The rule prose spans several lines, so grab the full block from the marker up to
+// the next `<!-- rule:` marker (or end of doc) rather than the single owned line.
+function extractRuleBlock(content, id) {
+  const marker = new RegExp(`<!--\\s*rule:\\s*${id}\\s*-->`);
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex((line) => marker.test(line));
+  assert.ok(start !== -1, `expected rule marker ${id} to be present`);
+  const remaining = lines.slice(start + 1);
+  const end = remaining.findIndex(
+    (line) => /<!--\s*rule:\s*[A-Z][A-Z0-9-]*\s*-->/.test(line) || /^\*\*[^*].*\*\*\s*$/.test(line.trim()),
+  );
+  const block = remaining.slice(0, end === -1 ? remaining.length : end);
+  return block.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * #1681 — runs.all workflowScript dispatch "invalid key"
+ *
+ * The Pi harness's `runs.all` workflowScript API requires every collection item
+ * to declare its own `key` field. A fan-out that omits it fails the whole
+ * dispatch with an "invalid key" validation error, which previously degraded a
+ * requireFanoutEvidence gate to a single inline reviewer. This test pins the
+ * authoritative gate contract so the conductor always emits the `key` field and
+ * fails closed (never silently degrades to inline_single_agent) on a dispatch
+ * failure.
+ */
+test("gate fan-out contract owns the runs.all dispatch-key + fail-closed requirement", async () => {
+  const content = await readRepo("skills/docs/gate-review-sub-loop-contract.md");
+
+  // The rule must live in exactly the canonical gate contract doc, nowhere else.
+  assertRuleOwned("GATE-EXEC-FANOUT-DISPATCH-KEY", "skills/docs/gate-review-sub-loop-contract.md");
+  assert.match(content, /GATE-EXEC-FANOUT-DISPATCH-KEY/);
+
+  const owned = extractRuleBlock(content, "GATE-EXEC-FANOUT-DISPATCH-KEY");
+  // The harness `key`-field requirement is encoded.
+  assert.match(owned, /runs\.all/);
+  assert.match(owned, /`key` field on EACH item/);
+  assert.match(owned, /invalid key/);
+  // The conductor fail-closed obligation is encoded (AC2): refusal to degrade
+  // to inline_single_agent on a requireFanoutEvidence gate.
+  assert.match(owned, /fails closed/);
+  assert.match(owned, /inline_single_agent/);
+  assert.match(owned, /requireFanoutEvidence/);
+});

--- a/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
+++ b/test/contracts/gate-fanout-dispatch-key-contract.test.mjs
@@ -2,7 +2,10 @@ import { assert, readRepo, test } from "../imported-assets-helpers.mjs";
 import { assertRuleOwned } from "./_rule-helpers.mjs";
 
 // The rule prose spans several lines, so grab the full block from the marker up to
-// the next `<!-- rule:` marker (or end of doc) rather than the single owned line.
+// the next `<!-- rule:` marker or a non-empty bold heading (never silently to EOF).
+// An unanchored block is a test error, not a pass: if neither end condition matches,
+// assert fails so a reworded/reflowed heading cannot silently broaden the owned
+// block and mask a cut-off rule.
 function extractRuleBlock(content, id) {
   const marker = new RegExp(`<!--\\s*rule:\\s*${id}\\s*-->`);
   const lines = content.split(/\r?\n/);
@@ -12,7 +15,8 @@ function extractRuleBlock(content, id) {
   const end = remaining.findIndex(
     (line) => /<!--\s*rule:\s*[A-Z][A-Z0-9-]*\s*-->/.test(line) || /^\*\*[^*].*\*\*\s*$/.test(line.trim()),
   );
-  const block = remaining.slice(0, end === -1 ? remaining.length : end);
+  assert.ok(end !== -1, `expected rule block ${id} to be terminated by the next rule marker or bold heading`);
+  const block = remaining.slice(0, end);
   return block.join(" ").replace(/\s+/g, " ").trim();
 }
 
@@ -33,12 +37,18 @@ test("gate fan-out contract owns the runs.all dispatch-key + fail-closed require
   // The rule must live in exactly the canonical gate contract doc, nowhere else.
   assertRuleOwned("GATE-EXEC-FANOUT-DISPATCH-KEY", "skills/docs/gate-review-sub-loop-contract.md");
   assert.match(content, /GATE-EXEC-FANOUT-DISPATCH-KEY/);
+  // The grouped-dispatch per-group slug mention is present so grouped fan-out is pinned.
+  assert.match(content, /a per-angle or per-group slug/);
 
   const owned = extractRuleBlock(content, "GATE-EXEC-FANOUT-DISPATCH-KEY");
-  // The harness `key`-field requirement is encoded.
+  // The harness `key`-field requirement is encoded (AC1).
   assert.match(owned, /runs\.all/);
   assert.match(owned, /`key` field on EACH item/);
   assert.match(owned, /invalid key/);
+  // AC1's uniqueness + missing/blank-key edge cases are pinned, so a normative
+  // weakening (MUST->MAY, dropping `unique`/`missing or blank`) cannot pass.
+  assert.match(owned, /unique/);
+  assert.match(owned, /missing or blank/);
   // The conductor fail-closed obligation is encoded (AC2): refusal to degrade
   // to inline_single_agent on a requireFanoutEvidence gate.
   assert.match(owned, /fails closed/);


### PR DESCRIPTION
## Change summary

Fixes #1681 — `runs.all` workflowScript dispatch "invalid key".

The Pi harness's `runs.all` workflowScript API requires every collection item to declare its own `key` field. A gate fan-out that omits it fails the whole dispatch with an `invalid key` validation error, which historically degraded a `requireFanoutEvidence` gate to a single inline reviewer (`inline_single_agent`) — a gate-integrity violation.

This change encodes the fix in the authoritative gate contract so the conductor never drops the `key` and never lets a dispatch failure silently collapse fan-out:

- **Dispatch-key requirement (AC1):** every `runs.all` / batch reviewer dispatch MUST carry a unique `key` field on each item (a per-angle or per-group slug), so the batch validates on the harness. A missing/blank `key` is a dispatch bug, not a harness quirk to work around at fan-in.
- **Conductor fail-closed obligation (AC2):** when a fan-out dispatch fails for any reason (including `invalid key`), the conductor MUST stop and report rather than degrading to `inline_single_agent` on a gate where `gates.requireFanoutEvidence` is enabled. Merge-time and post-time enforcement already refuse an inline verdict on such a gate via the shared `evaluateInlineFanoutMode` path (`buildPreMergeGateCheck` in `detect-checkpoint-evidence.mjs`, `upsert-checkpoint-verdict.mjs`); the only inline acceptance is the light-mode `scopeUnderThreshold` carve-out or an explicit operator decision per PR — never a silent fallback.
- **Regression coverage:** a contract test pins the requirement in the canonical gate doc so it cannot silently regress.

## Scope

- `skills/docs/gate-review-sub-loop-contract.md` — new owned rule `GATE-EXEC-FANOUT-DISPATCH-KEY`
- `skills/docs/required-rules.json` — register the rule
- `.claude/skills/docs/gate-review-sub-loop-contract.md` — generated mirror (regenerated via `generate-claude-assets.mjs`)
- `test/contracts/gate-fanout-dispatch-key-contract.test.mjs` — regression test

## Acceptance criteria

- [x] `runs.all` dispatch requirement (unique `key` per item) is encoded in the authoritative gate contract.
- [x] The conductor fails closed (refuses silent `inline_single_agent` degradation) when fan-out dispatch fails on a `requireFanoutEvidence` gate.
- [x] Regression test covering the dispatch-failure case is added and green.
- [x] `npm run verify` green; `assets:check` and `schema:check` pass.

## Non-goals

- No change to the `requireFanoutEvidence` contract.
- No change to the `inline_single_agent` execution mode itself (it remains a sanctioned fallback for light-mode, not for `requireFanoutEvidence` gates).

## Definition of done

- [x] Scope-bounded to #1681 (no `requireFanoutEvidence` contract change, no `inline_single_agent` execution-mode change).
- [x] Test-first: regression test written first (red), then the doc rule (green).
- [x] `npm run verify` clean (all suites pass).
- [x] `assets:check` and `schema:check` pass; `validate-rule-ownership` passes.
- [x] Cross-harness non-regression (#1086): change is doc/contract + test only, no runtime harness-derived code touched.

## Validation

- `npm run verify` — clean (test:assets / test:extension / test:scripts / test:core / test:docs / test:pack / test:dev-loop / test:workflows).
- `node scripts/claude/generate-claude-assets.mjs --check` — ok (checked 95).
- `npm run schema:check` — up to date.
- `node scripts/docs/validate-rule-ownership.mjs` — passed (203 rules).

Closes #1681

