### PR TITLE
refine(verify): USAGE + partial-boundary + numbered-list coverage follow-through (#1684)

### DIFF
--- a/scripts/refine/prose-linkage-detector.mjs
+++ b/scripts/refine/prose-linkage-detector.mjs
@@ -12,7 +12,7 @@ import {
 const USAGE = `Usage:
   prose-linkage-detector.mjs --input <path> [--json]
 Fail when issue bodies use prose linkage (` + "`Child of #`, `Parent: #`, `Depends on: #`, `sub-issue of #`" + `)
-instead of GitHub sub-issue API links.${"\n"}${DEFAULT_USAGE_SUFFIX}`;
+instead of GitHub sub-issue API links, or duplicate a child checklist (duplicate_child_checklist).${"\n"}${DEFAULT_USAGE_SUFFIX}`;
 
 function hasDuplicateChildChecklist(issue) {
   const childSet = new Set(issue.children);
@@ -24,7 +24,7 @@ function hasDuplicateChildChecklist(issue) {
   let hasCheckedChildItem = false;
 
   for (const line of issue.body.split(/\r?\n/gu)) {
-    const listItemMatch = /^\s*[-*]\s+(.*)$/u.exec(line);
+    const listItemMatch = /^\s*(?:[-*]|\d+\.)\s+(.*)$/u.exec(line);
     if (!listItemMatch) {
       continue;
     }

--- a/scripts/refine/refinement-completeness-checker.mjs
+++ b/scripts/refine/refinement-completeness-checker.mjs
@@ -11,7 +11,7 @@ import {
 
 const USAGE = `Usage:
   refinement-completeness-checker.mjs --input <path> [--json]
-Validate required refinement sections: Acceptance criteria, Definition of done, Non-goals, and AC / DoD matrix.${"\n"}${DEFAULT_USAGE_SUFFIX}`;
+Validate required refinement sections: Acceptance criteria, Definition of done, Non-goals, AC / DoD matrix, and scope-boundary ownership prose (missing_scope_boundary).${"\n"}${DEFAULT_USAGE_SUFFIX}`;
 
 // ponytail: distance caps ({0,200}? and {0,120}?) bound the gap between
 // "owns"/"does not own"/(#N) so a single match cannot span the whole body.

--- a/test/loop/refine-verify.test.mjs
+++ b/test/loop/refine-verify.test.mjs
@@ -314,6 +314,67 @@ test("each refusal names the rule it upholds (AC5)", () => {
   assert.match(dupChecklist.message, /SUBISSUE-LEAN-BODY-NO-DUPLICATE/);
 });
 
+test("checker USAGE strings mention the new validation categories (AC1)", async () => {
+  const completenessSrc = await readFile("scripts/refine/refinement-completeness-checker.mjs", "utf8");
+  assert.match(completenessSrc, /scope-boundary ownership prose \(missing_scope_boundary\)/);
+
+  const linkageSrc = await readFile("scripts/refine/prose-linkage-detector.mjs", "utf8");
+  assert.match(linkageSrc, /duplicate a child checklist \(duplicate_child_checklist\)/);
+});
+
+test("hasScopeBoundary: partial boundary without issue ref fires missing_scope_boundary (AC2 negative)", () => {
+  // "owns X" + "does NOT own Y" but no "(#NNN)" must NOT satisfy the scope-boundary
+  // requirement: the full sentence regex requires the issue reference to close it.
+  const tree = normalizeTreePayload({
+    root: 1,
+    issues: [
+      { number: 1, children: [], body: buildBody({ scope: "owns orchestration", boundary: "This issue owns orchestration. It does NOT own api." }) },
+    ],
+  });
+  const result = runRefinementCompletenessChecker(tree);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((entry) => entry.code === "missing_scope_boundary"));
+});
+
+test("hasScopeBoundary: complete boundary with issue ref satisfies requirement (AC2 positive control)", () => {
+  const tree = normalizeTreePayload({
+    root: 1,
+    issues: [
+      { number: 1, children: [], body: buildBody({ scope: "owns orchestration", boundary: "This issue owns orchestration. It does NOT own api (#2)." }) },
+    ],
+  });
+  const result = runRefinementCompletenessChecker(tree);
+  assert.ok(!result.errors.some((entry) => entry.code === "missing_scope_boundary"), result.errors.map((e) => e.message).join("\n"));
+});
+
+test("duplicate_child_checklist fires on numbered list child checklist items (AC3)", () => {
+  const body = [
+    "## Scope",
+    "- This issue owns parent. It does NOT own api (#2) or ui (#3).",
+    "",
+    "## Acceptance criteria",
+    "1. implement api (#2)",
+    "2. implement ui (#3)",
+  ].join("\n");
+  const tree = normalizeTreePayload({
+    root: 1,
+    issues: [{ number: 1, children: [2, 3], body }],
+  });
+  const result = runProseLinkageDetector(tree);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((entry) => entry.code === "duplicate_child_checklist"));
+});
+
+test("duplicate_child_checklist does not fire on a numbered boundary bullet (AC3 boundary skip)", () => {
+  const body = [
+    "## Scope",
+    "1. This issue owns parent. It does NOT own api (#2) or ui (#3).",
+  ].join("\n");
+  const tree = normalizeTreePayload({ root: 1, issues: [{ number: 1, children: [2, 3], body }] });
+  const result = runProseLinkageDetector(tree);
+  assert.ok(!result.errors.some((entry) => entry.code === "duplicate_child_checklist"), result.errors.map((e) => e.message).join("\n"));
+});
+
 test("verify FAILS (no vacuous PASS) when ownership prose is absent (DoD regression)", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-refine-vacuous-"));
   try {


### PR DESCRIPTION
## Summary

Low-severity gate follow-through from the #1623 refine-verify gate review. Four deferred polish items resolved; three require product-code/test changes, one was a wording only (no change applied).

Closes #1684

## Changes

1. **USAGE strings updated (contract-surface):** `refinement-completeness-checker.mjs` and `prose-linkage-detector.mjs` `--help` USAGE text now surface the `missing_scope_boundary` and `duplicate_child_checklist` validation categories respectively, so consumers reading the contract surface know the new checks are enforced.
2. **Partial-boundary negative coverage:** added a focused negative test pinning that a body with `owns X` + `does NOT own Y` but no `(#NNN)` reference does NOT satisfy the scope-boundary requirement (fires `missing_scope_boundary`), plus a positive control that a complete boundary with a `(#N)` reference satisfies it.
3. **Numbered-list scope decided — extended:** `hasDuplicateChildChecklist` now matches numbered (`1.`) list items in addition to bullet (`[-*]`) items, so a parent duplicating a child checklist with numbered items is flagged. The boundary-bullet skip still applies to numbered lists (pinned by a negative test).

## Acceptance criteria

- [x] USAGE strings updated for both checker scripts.
- [x] Partial-boundary negative test added.
- [x] Numbered-list scope decided (extend — done).
- [x] `npm run verify` green.

## Definition of done

- [x] All acceptance criteria covered by tests.
- [x] `npm run verify` green.
- [x] `assets:check` green.
- [x] `schema:check` green.
- [x] Cross-harness/non-regression preserved (no harness-specific change).

## Validation

- `node --test test/loop/refine-verify.test.mjs` — 26/26 pass (5 new tests: USAGE categories, partial-boundary negative + positive, numbered-list fires + numbered boundary-skip).
- `npm run verify` — exit 0, all suites green (test:assets/ext/scripts/core/docs/pack/dev-loop/workflows).
- `npm run assets:check` / `schema:check` — both green.

## Non-goals

- No change to the #1623 scope-boundary regex distance caps or other verified behavior.
- #1684 previously reported a PR-Non-goals-word tightening item; that was wording-only on #1683 and required no code change here.
- No `PLAN.md` update needed (no command-surface or product-truth change).
