### PR TITLE
test(hook): cover SubagentStop fail-safe-allow on non-git dir (#1685)

### DIFF
--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -339,3 +339,27 @@ test("SubagentStop hook exempts an interactive session awaiting commit authoriza
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("SubagentStop hook fail-safe-allows a mkdir-only (non-git) dir under tmp/worktrees/ (#1685)", () => {
+  // Every makeWorktree() fixture calls `git init`, so the hook always sees a valid git repo and
+  // the fail-safe-allow catch path (`execFileSync("git", ["status","--porcelain"], { timeout:
+  // 5000 })` throws → porcelain="" → allow the stop) is never exercised e2e. This test creates
+  // the dir with `mkdir` only (no `git init`) OUTSIDE any git repo — so `git status --porcelain`
+  // throws and the catch allows the stop: exit 0 + no block output. A dir under the repo's own
+  // tmp/worktrees/ is nested inside the surrounding git repo, so git status would succeed there
+  // and report the untracked dir as dirty instead of throwing; hosting the non-git dir under
+  // os.tmpdir() (outside every repo, like the existing outside-path test) makes git genuinely
+  // fail while the path still carries a tmp/worktrees/ segment so isUnderWorktreePath stays real.
+  // Non-goal: the fail-safe allow on git error/timeout is the correct behavior — this test pins
+  // it, it does not change it.
+  const dir = path.join(os.tmpdir(), "tmp", "worktrees", `subagent-stop-test-nongit-${process.pid}`);
+  // mkdir only — deliberately NO `git init` (and outside any git repo)
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    const { code, stderrJson } = runHook("subagent-stop-uncommitted-guard.mjs", { cwd: dir });
+    assert.equal(code, 0, "non-git dir under tmp/worktrees/ must fail-safe allow the stop (exit 0)");
+    assert.equal(stderrJson, null, "fail-safe-allow path must not emit block output");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the missing e2e coverage for the SubagentStop uncommitted-guard hook's git-error/timeout fail-safe-allow path (#1685 follow-up from #1619 draft_gate review, coverage angle, low severity).

Every existing `makeWorktree()` test fixture calls `git init`, so the hook always observes a valid git repo and the non-git / git-failure catch branch (`execFileSync("git", ["status","--porcelain"], { timeout: 5000 })` throws → `porcelain=""` → allow the stop) was never exercised end to end. This change pins that behavior with a dedicated e2e test.

## Acceptance criteria

- [x] An e2e test creates a dir under a `tmp/worktrees/`-segmented path with `mkdir` only (no `git init`), runs the SubagentStop hook, and asserts exit 0 + no block output (the fail-safe-allow path).
- [ ] (Optional, not implemented) A test that stubs a git-status timeout and asserts the fail-safe allow.

AC2 (timeout stub) is explicitly optional in the issue. The git-error fail-safe-allow catch is the same code path (`execFileSync` throws → `porcelain=""`); AC1 covers it deterministically and without a slow ~5s timeout stub. Keeping scope to the mandatory AC per "do not widen scope."

## Definition of done

- New e2e test present and passing locally.
- Full `npm run verify` green (all legs fail 0).
- No production source change; test-only addition.
- Cross-harness non-regression preserved (test runs under both harnesses' plain `node --test`; no harness-specific constructs).

## Non-goals

- Changing the fail-safe behavior (allow on git failure/timeout is correct — unchanged).
- No production source change; test-only addition.

## Validation

Recorded gate validation: `npm run verify` (all legs fail 0).

Closes #1685
