### PR TITLE
gate-context: treat whitespace-only spec flags as absent, not provided

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -142,10 +142,10 @@ Optional:
   --branch <name>                Source branch name
   --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
   --base <ref>                   Git ref to diff against (git diff <ref>...HEAD); populates scope.diffPath, scope.changedFiles, and adjacentCode (the full build-once bundle). Without it, the CLI emits an explicit thin briefing (scope.diffSource="none") — see skills/docs/gate-review-sub-loop-contract.md.
-  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted it resolves to the PR's closing issue reference.
+  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted it resolves to the PR's closing issue reference. A whitespace-only value is treated as absent (resolves exactly as if the flag were omitted, never recorded as caller-provided).
   --validation-posture <text>    Short description of the validation posture
-  --pr-body <text>               PR description text, inlined into the rendered briefing prefix. OPTIONAL: when omitted the live PR body is fetched from GitHub. An unreadable PR fails closed rather than rendering the PR as description-less.
-  --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label. OPTIONAL: when omitted it is fetched from the PR's closing issue reference, but ONLY when --acceptance-criteria is also omitted — supplying --acceptance-criteria suppresses the issue-body fetch, so pass --issue-body too if the prefix should still carry issue text. Omitted from the prefix entirely when the PR closes no issue.
+  --pr-body <text>               PR description text, inlined into the rendered briefing prefix. OPTIONAL: when omitted the live PR body is fetched from GitHub. An unreadable PR fails closed rather than rendering the PR as description-less. A whitespace-only value is treated as absent (the live body is fetched; a sentinel is rendered only when the resolved source genuinely has no content).
+  --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label. OPTIONAL: when omitted it is fetched from the PR's closing issue reference, but ONLY when --acceptance-criteria is also omitted — supplying --acceptance-criteria suppresses the issue-body fetch, so pass --issue-body too if the prefix should still carry issue text. Omitted from the prefix entirely when the PR closes no issue. A whitespace-only value is treated as absent (resolved/fetched exactly as if the flag were omitted).
   --prefix-file <path>           Record the EXACT BYTES of this file as the briefing-prefix record (<gate>-<headSha>.briefing-prefix.txt) instead of this module's self-rendered prefix — no rendering, no trailing-newline normalization. The emitted prefixHash is the sha256 of those exact bytes and the result/artifact report prefixMode:"file". For an orchestrator that already briefed reviewers with its OWN rendered prefix, this is what lets it record THAT byte sequence so verify-briefing-prefixes.mjs matches. Fails closed (exit 1) if the file is missing, unreadable, or empty. Skips the GitHub spec-of-record resolution (--pr-body/--issue-body/--acceptance-criteria) entirely — the recorded bytes come from this file, so a fetched PR/issue body could never reach them, and the CLI never touches GitHub in this mode at all (--base only runs local git reads). Omit for the default self-rendered prefix (prefixMode inline|pointer).
   --validation-results <path>    Path to the run-gate-validation.mjs artifact (GATE-EXEC-VALIDATION-ARTIFACT) recording this round's validation suites, run once for every reviewer of this gate pass to read instead of re-running. Resolved to an absolute path and recorded at scope.validationResultsPath, and appends a trailing "## Validation results at this head" section to the rendered briefing prefix (self-rendered mode only — ignored under --prefix-file, whose bytes are recorded verbatim). Fails closed (exit 1) if the file is missing or unreadable. Omit for no validation-results section (byte-identical to before this flag existed).
   --full-label                   The PR carries the gate:full label: dynamic angle resolution skips diff-class tier reduction (resolveGateTier returns gate_full_label) and resolves the untriered angle set. Only meaningful when --angles is omitted. When this flag is absent (and --prefix-file is not in use), the label is derived from the live PR via a labels read; a failed read fails closed to the untriered set. Under --prefix-file the CLI never touches GitHub, so the label cannot be derived and an omitted flag likewise fails closed to the untriered set (pass --angles to force a specific set there).
@@ -361,7 +361,12 @@ export function parseWriteGateContextCliArgs(argv) {
       continue;
     }
     if (token.name === "acceptance-criteria") {
-      options.acceptanceCriteria = requireTokenValue(token, parseError).trim();
+      // Whitespace-only counts as absent (same as omitting the flag): a caller-
+      // provided pointer that carries no content must not suppress the GitHub
+      // spec-of-record resolution, or the artifact would record a false spec
+      // claim ("provided") with an empty pointer that still names the issue.
+      const trimmed = requireTokenValue(token, parseError).trim();
+      options.acceptanceCriteria = trimmed.length > 0 ? trimmed : null;
       continue;
     }
     if (token.name === "validation-posture") {
@@ -369,11 +374,21 @@ export function parseWriteGateContextCliArgs(argv) {
       continue;
     }
     if (token.name === "pr-body") {
-      options.prBody = requireTokenValue(token, parseError);
+      // Whitespace-only counts as absent: a whitespace value must not trigger
+      // the PR_BODY_ABSENT_SENTINEL render while short-circuiting the live-body
+      // read — the sentinel may only appear when the resolved source genuinely
+      // has no content.
+      const raw = requireTokenValue(token, parseError);
+      options.prBody = raw.trim().length > 0 ? raw : null;
       continue;
     }
     if (token.name === "issue-body") {
-      options.issueBody = requireTokenValue(token, parseError);
+      // Whitespace-only counts as absent: it must not drop the linked-issue
+      // section while the acceptance-criteria pointer still names the issue
+      // (the exact indistinguishability ISSUE_BODY_ABSENT_SENTINEL exists to
+      // prevent). Treating it as omitted lets resolution fetch the real body.
+      const raw = requireTokenValue(token, parseError);
+      options.issueBody = raw.trim().length > 0 ? raw : null;
       continue;
     }
     if (token.name === "prefix-file") {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -480,6 +480,31 @@ test("parseWriteGateContextCliArgs rejects a whitespace-only --prefix-file (fail
   ]), /--prefix-file must not be empty/);
 });
 
+test("parseWriteGateContextCliArgs treats whitespace-only spec flags as absent, not provided (#1540)", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "abc1234",
+    "--angles", "[]",
+    "--pr-body", "   ",
+    "--issue-body", "  ",
+    "--acceptance-criteria", "   ",
+  ]);
+  assert.equal(result.prBody, null, "whitespace-only --pr-body is treated as absent");
+  assert.equal(result.issueBody, null, "whitespace-only --issue-body is treated as absent");
+  assert.equal(result.acceptanceCriteria, null, "whitespace-only --acceptance-criteria is treated as absent");
+});
+
+test("parseWriteGateContextCliArgs keeps real-content spec flags verbatim (#1540)", () => {
+  const result = parseWriteGateContextCliArgs([
+    "--repo", "a/b", "--pr", "1", "--gate", "draft_gate", "--head-sha", "abc1234", "--angles", "[]",
+    "--pr-body", " Fixes the thing ",
+    "--issue-body", " Has real content ",
+    "--acceptance-criteria", " #900 ",
+  ]);
+  assert.equal(result.prBody, " Fixes the thing ", "real content is kept untrimmed (body text is not modified)");
+  assert.equal(result.issueBody, " Has real content ", "real content is kept untrimmed");
+  assert.equal(result.acceptanceCriteria, "#900", "pointer is trimmed to its content");
+});
+
 // ---------------------------------------------------------------------------
 // Artifact shape
 // ---------------------------------------------------------------------------
@@ -3034,6 +3059,36 @@ test("resolvePrSpecContext: all three spec flags provided short-circuits before 
   assert.equal(options.issueBody, "flag issue");
   assert.equal(options.acceptanceCriteria, "docs/plan.md");
   assert.equal(options.acceptanceCriteriaSource, "provided");
+});
+
+test("main: whitespace-only spec flags resolve as if omitted — live body fetched, issue resolved, prefix rendered, never 'provided' (#1540)", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-ws-"));
+  try {
+    await mkdir(path.join(repoRoot, "tmp"), { recursive: true });
+    // No --base: the diff-capture path is skipped, so no git fixture is needed.
+    await main([
+      "--repo", "owner/repo", "--pr", "61", "--gate", "draft_gate",
+      "--head-sha", "abc1234567890", "--angles", '["scope"]',
+      "--pr-body", "   ",
+      "--issue-body", "  ",
+      "--acceptance-criteria", "   ",
+    ], { repoRoot, run: specStubRun({ closing: [{ number: 42 }] }) });
+
+    const artifact = await readGateContext({ repo: "owner/repo", pr: 61, gate: "draft_gate", headSha: "abc1234567890" }, { repoRoot });
+    assert.ok(artifact, "artifact written");
+    assert.equal(artifact.scope.acceptanceCriteria, "#42", "pointer resolves from the closing issue, not a whitespace '' stamp");
+    assert.notEqual(artifact.scope.acceptanceCriteriaSource, "provided", "whitespace is never recorded as caller-provided");
+    assert.equal(artifact.scope.acceptanceCriteriaSource, "linked-issue-unrefined");
+
+    const prefixPath = buildGateBriefingPrefixPath({ repo: "owner/repo", pr: 61, gate: "draft_gate", headSha: "abc1234567890" });
+    const prefix = await readFile(path.resolve(repoRoot, prefixPath), "utf8");
+    assert.ok(prefix.includes("live PR body"), "live PR body is rendered, not PR_BODY_ABSENT_SENTINEL");
+    assert.ok(!prefix.includes(PR_BODY_ABSENT_SENTINEL), "absent sentinel must not render when live body is fetched");
+    assert.ok(prefix.includes("## Linked issue #42"), "linked-issue section rendered with resolved pointer");
+    assert.ok(prefix.includes("live issue body"), "resolved issue body is rendered, not dropped by whitespace");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
 });
 
 test("resolvePrSpecContext: --acceptance-criteria provided without --issue-body never fetches an issue body and keeps source=provided", async () => {


### PR DESCRIPTION
## Why

`scripts/github/write-gate-context.mjs` accepted whitespace-only values for the three spec-of-record flags. `requireTokenValue` rejects only the empty string, so a whitespace value counted as caller-provided and suppressed the GitHub resolution that exists to prevent a false spec claim.

Three concrete outcomes, all previously verified:

- `--acceptance-criteria "   "` trimmed to `""`, which `acceptanceCriteria != null` read as provided — closing-issue resolution was skipped and `acceptanceCriteriaSource` recorded `"provided"` for a PR that really closes an issue.
- `--pr-body "   "` made the prefix render `PR_BODY_ABSENT_SENTINEL` without ever reading the live body.
- `--issue-body "  "` dropped the `## Linked issue` section while the acceptance-criteria pointer still named the issue.

## Chosen behavior

A whitespace-only value for `--pr-body`, `--issue-body`, or `--acceptance-criteria` is **treated as absent** — resolution proceeds exactly as if the flag were omitted (the live PR body and/or closing-issue body are resolved; the pointer resolves from the closing issue; `acceptanceCriteriaSource` never records `"provided"` for a value that carries no content). Real-content values are unchanged (`--pr-body`/`--issue-body` kept untrimmed as body text; `--acceptance-criteria` trimmed to its pointer).

## Acceptance criteria

- [x] A whitespace-only value for `--pr-body`, `--issue-body`, or `--acceptance-criteria` is treated as absent, not as provided: resolution proceeds exactly as if the flag were omitted.
- [x] `scope.acceptanceCriteriaSource` never records `provided` for a value that carries no content.
- [x] A sentinel is rendered only when the resolved source genuinely has no content, never as a consequence of a whitespace argument short-circuiting the read.
- [x] Rejecting outright is an acceptable alternative; the chosen behavior (absent) is stated in each flag's `--help` text.
- [x] Tests cover all three flags with a whitespace value, asserting both the resolved fields and the rendered prefix.

## Definition of done

- [x] `npm run verify` green (4010 tests, 0 fail).
- [x] `npm run schema:check` — up to date.
- [x] `npm run assets:check` — 95 checked, ok.
- [x] The chosen behavior (treated as absent) is stated in the flag's `--help` text.

## Non-goals (respected)

- Changing how genuinely empty upstream content renders.
- Trimming values that carry real content.

## Validation

- Test-first: added parse-level tests (whitespace-only flags normalize to absent; real-content flags kept verbatim) and an end-to-end `main()` test driving whitespace flags through the parser asserting resolved `scope` fields and the rendered briefing prefix.
- Full `npm run verify` + `schema:check` + `assets:check` green on this head.

Closes #1540
