### PR TITLE
gate-context: align --help, JSDoc, and absent-PR sentinel with shipped resolution (#1541)

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -142,10 +142,10 @@ Optional:
   --branch <name>                Source branch name
   --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
   --base <ref>                   Git ref to diff against (git diff <ref>...HEAD); populates scope.diffPath, scope.changedFiles, and adjacentCode (the full build-once bundle). Without it, the CLI emits an explicit thin briefing (scope.diffSource="none") — see skills/docs/gate-review-sub-loop-contract.md.
-  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted it resolves to the PR's closing issue reference. A whitespace-only value is treated as absent (resolves exactly as if the flag were omitted, never recorded as caller-provided).
+  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted, EVERY of the PR's closing issue references is resolved and each linked issue's body is fetched — an umbrella PR resolves all of them, comma-joined and cross-repo-qualified (e.g. #1496, #1511 or owner/other#12). An unreadable PR or linked issue FAILS CLOSED (exit 1, no artifact written) rather than rendering absence. A whitespace-only value is treated as absent (resolves exactly as if the flag were omitted, never recorded as caller-provided).
   --validation-posture <text>    Short description of the validation posture
   --pr-body <text>               PR description text, inlined into the rendered briefing prefix. OPTIONAL: when omitted the live PR body is fetched from GitHub. An unreadable PR fails closed rather than rendering the PR as description-less. A whitespace-only value is treated as absent (the live body is fetched; a sentinel is rendered only when the resolved source genuinely has no content).
-  --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label. OPTIONAL: when omitted it is fetched from the PR's closing issue reference, but ONLY when --acceptance-criteria is also omitted — supplying --acceptance-criteria suppresses the issue-body fetch, so pass --issue-body too if the prefix should still carry issue text. Omitted from the prefix entirely when the PR closes no issue. A whitespace-only value is treated as absent (resolved/fetched exactly as if the flag were omitted).
+  --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label. OPTIONAL: when omitted it is fetched from every of the PR's closing issue references (an umbrella PR closes several), but ONLY when --acceptance-criteria is also omitted — supplying --acceptance-criteria suppresses the issue-body fetch, so pass --issue-body too if the prefix should still carry issue text. An unreadable linked issue FAILS CLOSED (exit 1, no artifact written) rather than rendering the section as absent; the bodies are omitted from the prefix entirely when the PR closes no issue. A whitespace-only value is treated as absent (resolved/fetched exactly as if the flag were omitted).
   --prefix-file <path>           Record the EXACT BYTES of this file as the briefing-prefix record (<gate>-<headSha>.briefing-prefix.txt) instead of this module's self-rendered prefix — no rendering, no trailing-newline normalization. The emitted prefixHash is the sha256 of those exact bytes and the result/artifact report prefixMode:"file". For an orchestrator that already briefed reviewers with its OWN rendered prefix, this is what lets it record THAT byte sequence so verify-briefing-prefixes.mjs matches. Fails closed (exit 1) if the file is missing, unreadable, or empty. Skips the GitHub spec-of-record resolution (--pr-body/--issue-body/--acceptance-criteria) entirely — the recorded bytes come from this file, so a fetched PR/issue body could never reach them, and the CLI never touches GitHub in this mode at all (--base only runs local git reads). Omit for the default self-rendered prefix (prefixMode inline|pointer).
   --validation-results <path>    Path to the run-gate-validation.mjs artifact (GATE-EXEC-VALIDATION-ARTIFACT) recording this round's validation suites, run once for every reviewer of this gate pass to read instead of re-running. Resolved to an absolute path and recorded at scope.validationResultsPath, and appends a trailing "## Validation results at this head" section to the rendered briefing prefix (self-rendered mode only — ignored under --prefix-file, whose bytes are recorded verbatim). Fails closed (exit 1) if the file is missing or unreadable. Omit for no validation-results section (byte-identical to before this flag existed).
   --full-label                   The PR carries the gate:full label: dynamic angle resolution skips diff-class tier reduction (resolveGateTier returns gate_full_label) and resolves the untriered angle set. Only meaningful when --angles is omitted. When this flag is absent (and --prefix-file is not in use), the label is derived from the live PR via a labels read; a failed read fails closed to the untriered set. Under --prefix-file the CLI never touches GitHub, so the label cannot be derived and an omitted flag likewise fails closed to the untriered set (pass --angles to force a specific set there).
@@ -687,15 +687,20 @@ export function buildValidationResultsPath({ repo, pr, gate, headSha, tmpRoot = 
 export const BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES = 200 * 1024;
 
 /**
- * Rendered when no PR body text reaches the prefix. The CLI resolves the live
- * body itself (resolvePrSpecContext) and fails closed when it cannot, so from
- * the CLI path this wording is reached only for a PR whose description is
- * genuinely empty on GitHub — it is a truthful statement, not the old
- * "(no PR body provided)" which described the CALLER's arguments and read as a
- * claim about the PR. Programmatic callers that pass no `prBody` still land
- * here; that is their explicit choice of a thin briefing.
+ * Rendered when no PR body text reaches the prefix. Deliberately SOURCE-NEUTRAL:
+ * it asserts only that no PR description is shown, never a GitHub-specific fact
+ * ("empty on GitHub") — because it is also rendered by the exported
+ * renderBriefingPrefix / writeGateContext programmatic path, which never
+ * contacts GitHub and therefore cannot truthfully claim anything about the
+ * live PR state. It is distinguishable from the old "(no PR body provided)",
+ * which described the CALLER's arguments and could read as a claim about the
+ * PR: the sentinel reads as an absence statement, not an argument audit. On
+ * the CLI path the live body is resolved (resolvePrSpecContext) and an
+ * unreadable PR fails closed, so the sentinel appears there only when a
+ * resolved source is genuinely empty; programmatic callers that pass no
+ * `prBody` land here by their explicit choice of a thin briefing.
  */
-export const PR_BODY_ABSENT_SENTINEL = "(this PR has an empty description on GitHub)";
+export const PR_BODY_ABSENT_SENTINEL = "(no PR description is shown)";
 
 /**
  * Rendered in place of an individual linked issue's body when that issue was
@@ -1160,9 +1165,13 @@ function renderValidationResultsSection(validationResultsPath, headSha) {
  * present), the full diff at the reviewed head (inlined up to `capBytes`, else
  * a pointer to `diffPath`), and a changed-files/adjacent-code summary — in that
  * fixed order. Pure and
- * deterministic: identical input always renders identical bytes, so two builds
- * at the same head produce a byte-identical prefix (the fan-out's shared-prefix
- * requirement).
+ * deterministic: identical input always renders identical bytes — the pure
+ * function's guarantee. The CLI path resolves the live PR body and linked-issue
+ * bodies from GitHub and passes them in as input, so a same-head rebuild after
+ * a live description edit resolves DIFFERENT input and yields DIFFERENT prefix
+ * bytes; a conductor MUST NOT rebuild the context while reviewers for that head
+ * are still running (GATE-EXEC-BRIEFING-PREFIX in the gate-review sub-loop
+ * contract). Only byte-identity for identical input holds unconditionally.
  *
  * prBody/issueBody/issueSections/diffOutput are untrusted GitHub text (PR
  * author or linked-issue author controlled) and are each wrapped in their own

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -142,7 +142,7 @@ Optional:
   --branch <name>                Source branch name
   --touched-files <json>         JSON array of changed file path strings (separate from the diff-derived scope.changedFiles)
   --base <ref>                   Git ref to diff against (git diff <ref>...HEAD); populates scope.diffPath, scope.changedFiles, and adjacentCode (the full build-once bundle). Without it, the CLI emits an explicit thin briefing (scope.diffSource="none") — see skills/docs/gate-review-sub-loop-contract.md.
-  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted, EVERY of the PR's closing issue references is resolved and each linked issue's body is fetched — an umbrella PR resolves all of them, comma-joined and cross-repo-qualified (e.g. #1496, #1511 or owner/other#12). An unreadable PR or linked issue FAILS CLOSED (exit 1, no artifact written) rather than rendering absence. A whitespace-only value is treated as absent (resolves exactly as if the flag were omitted, never recorded as caller-provided).
+  --acceptance-criteria <ptr>    Pointer to acceptance criteria (issue ref, doc path, URL); also used as the linked-issue label in the rendered briefing prefix. OPTIONAL: when omitted, every of the PR's closing issue references is resolved, comma-joined and cross-repo-qualified (e.g. #1496, #1511 or owner/other#12) — an umbrella PR resolves all of them. The linked issues' bodies are fetched only when --issue-body is also omitted (see below). An unreadable PR or linked issue FAILS CLOSED (exit 1, no artifact written) rather than rendering absence. A whitespace-only value is treated as absent (resolves exactly as if the flag were omitted, never recorded as caller-provided).
   --validation-posture <text>    Short description of the validation posture
   --pr-body <text>               PR description text, inlined into the rendered briefing prefix. OPTIONAL: when omitted the live PR body is fetched from GitHub. An unreadable PR fails closed rather than rendering the PR as description-less. A whitespace-only value is treated as absent (the live body is fetched; a sentinel is rendered only when the resolved source genuinely has no content).
   --issue-body <text>            Linked-issue body text, inlined into the briefing prefix under --acceptance-criteria's label. OPTIONAL: when omitted it is fetched from every of the PR's closing issue references (an umbrella PR closes several), but ONLY when --acceptance-criteria is also omitted — supplying --acceptance-criteria suppresses the issue-body fetch, so pass --issue-body too if the prefix should still carry issue text. An unreadable linked issue FAILS CLOSED (exit 1, no artifact written) rather than rendering the section as absent; the bodies are omitted from the prefix entirely when the PR closes no issue. A whitespace-only value is treated as absent (resolved/fetched exactly as if the flag were omitted).
@@ -703,14 +703,18 @@ export const BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES = 200 * 1024;
 export const PR_BODY_ABSENT_SENTINEL = "(no PR description is shown)";
 
 /**
- * Rendered in place of an individual linked issue's body when that issue was
- * resolved (it has a closing reference) but its body is genuinely empty on
- * GitHub. Mirrors PR_BODY_ABSENT_SENTINEL: a resolved-but-empty body must read
- * as a truthful, distinguishable statement rather than silently collapsing the
- * `## Linked issue` section (which would then read identically to "the PR
- * closes no issue" — the exact indistinguishability #1511 targets).
+ * Rendered in place of an individual linked issue's body when that issue's
+ * body text is absent. Deliberately SOURCE-NEUTRAL like PR_BODY_ABSENT_SENTINEL:
+ * it asserts only that no issue body is shown, never a GitHub-specific fact
+ * ("empty on GitHub") — because it is also rendered by the exported
+ * renderBriefingPrefix / writeGateContext programmatic path, which never
+ * contacts GitHub and therefore cannot truthfully claim anything about the
+ * live issue state. A resolved-but-empty body must read as a truthful,
+ * distinguishable statement rather than silently collapsing the `## Linked
+ * issue` section (which would then read identically to "the PR closes no
+ * issue" — the exact indistinguishability #1511 targets).
  */
-export const ISSUE_BODY_ABSENT_SENTINEL = "(this issue has an empty body on GitHub)";
+export const ISSUE_BODY_ABSENT_SENTINEL = "(no issue body is shown)";
 
 /**
  * Pick a fenced-code-block delimiter that cannot be prematurely closed by the

--- a/test/contracts/gate-context-doc-surfaces-contract.test.mjs
+++ b/test/contracts/gate-context-doc-surfaces-contract.test.mjs
@@ -13,6 +13,8 @@
 //   3. PR_BODY_ABSENT_SENTINEL must be source-neutral (no GitHub-specific fact),
 //      because it is also rendered by the programmatic renderBriefingPrefix /
 //      writeGateContext path that never contacts GitHub.
+//   4. ISSUE_BODY_ABSENT_SENTINEL must be source-neutral for the same reason (it
+//      is also rendered by the programmatic path).
 //
 // These are doc/comment claims, so the pins are source reads of the module
 // (plus the exported sentinel value) rather than behavioral assertions.
@@ -21,7 +23,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { PR_BODY_ABSENT_SENTINEL } from "../../scripts/github/write-gate-context.mjs";
+import {
+  ISSUE_BODY_ABSENT_SENTINEL,
+  PR_BODY_ABSENT_SENTINEL,
+} from "../../scripts/github/write-gate-context.mjs";
 
 const srcUrl = new URL("../../scripts/github/write-gate-context.mjs", import.meta.url);
 
@@ -67,4 +72,12 @@ test("write-gate-context: PR_BODY_ABSENT_SENTINEL is source-neutral (no GitHub-s
   // must not assert a fact only a GitHub reader could know.
   assert.ok(!/GitHub/i.test(PR_BODY_ABSENT_SENTINEL), "sentinel must not assert a GitHub-specific fact");
   assert.match(PR_BODY_ABSENT_SENTINEL, /no PR description/i, "sentinel reads as a source-neutral absence statement");
+});
+
+test("write-gate-context: ISSUE_BODY_ABSENT_SENTINEL is source-neutral (no GitHub-specific fact) (#1541)", () => {
+  // ISSUE_BODY is rendered by the same exported programmatic path (lines 1279,
+  // 1434) whenever an issue-section body is absent, so it must not assert a
+  // fact only a GitHub reader could know — mirroring PR_BODY_ABSENT_SENTINEL.
+  assert.ok(!/GitHub/i.test(ISSUE_BODY_ABSENT_SENTINEL), "issue sentinel must not assert a GitHub-specific fact");
+  assert.match(ISSUE_BODY_ABSENT_SENTINEL, /no issue body/i, "issue sentinel reads as a source-neutral absence statement");
 });

--- a/test/contracts/gate-context-doc-surfaces-contract.test.mjs
+++ b/test/contracts/gate-context-doc-surfaces-contract.test.mjs
@@ -1,0 +1,70 @@
+// Enforcement guard for issue #1541 (gate-context doc surfaces contradict the
+// shipped resolution behavior). Three documentation surfaces in
+// scripts/github/write-gate-context.mjs must stay aligned with the shipped
+// behavior so a future behavior change fails these pins rather than silently
+// re-diverging:
+//
+//   1. --help for --acceptance-criteria / --issue-body must describe multi-issue
+//      resolution (every closing reference, comma-joined, cross-repo-qualified)
+//      and the unreadable-linked-issue fail-closed, matching the contract doc.
+//   2. renderBriefingPrefix's JSDoc must NOT claim same-head byte-identical
+//      output; it states what the CLI path actually guarantees (a same-head
+//      rebuild after a live description edit yields different prefix bytes).
+//   3. PR_BODY_ABSENT_SENTINEL must be source-neutral (no GitHub-specific fact),
+//      because it is also rendered by the programmatic renderBriefingPrefix /
+//      writeGateContext path that never contacts GitHub.
+//
+// These are doc/comment claims, so the pins are source reads of the module
+// (plus the exported sentinel value) rather than behavioral assertions.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { PR_BODY_ABSENT_SENTINEL } from "../../scripts/github/write-gate-context.mjs";
+
+const srcUrl = new URL("../../scripts/github/write-gate-context.mjs", import.meta.url);
+
+test("write-gate-context --help: --acceptance-criteria and --issue-body describe multi-issue resolution and fail-closed (#1541)", async () => {
+  const src = await readFile(srcUrl, "utf8");
+  const acLine = src.split("\n").find((l) => l.startsWith("  --acceptance-criteria <ptr>"));
+  const ibLine = src.split("\n").find((l) => l.startsWith("  --issue-body <text>"));
+  assert.ok(acLine, "the --acceptance-criteria help line exists");
+  assert.ok(ibLine, "the --issue-body help line exists");
+
+  // Multi-issue: every closing reference is resolved (plural), umbrella PRs
+  // resolve all of them, cross-repo-qualified references resolve in their own repo.
+  assert.match(acLine, /closing issue references/i, "acceptance-criteria help describes resolving EVERY closing reference (multi-issue)");
+  assert.match(acLine, /cross-repo|umbrella/i, "acceptance-criteria help names the multi-issue/cross-repo shape");
+  assert.match(ibLine, /closing issue references/i, "issue-body help describes fetching from EVERY closing reference (multi-issue)");
+
+  // Fail-closed on an unreadable linked issue, matching the contract doc.
+  assert.match(acLine, /FAILS CLOSED|fail closed/i, "acceptance-criteria help names the unreadable-linked-issue fail-closed");
+  assert.match(acLine, /no artifact written/i, "acceptance-criteria help names the no-artifact-written failure mode");
+  assert.ok(ibLine.includes("FAILS CLOSED"), "issue-body help names the unreadable-linked-issue fail-closed");
+
+  // The OLD single-issue phrasing must be gone (the divergence the issue filed).
+  assert.ok(!acLine.includes("resolves to the PR's closing issue reference"), "old single-issue acceptance-criteria phrasing is gone");
+  assert.ok(!ibLine.includes("fetched from the PR's closing issue reference"), "old single-issue issue-body phrasing is gone");
+});
+
+test("write-gate-context: renderBriefingPrefix JSDoc no longer claims same-head byte-identical output and states the CLI guarantee (#1541)", async () => {
+  const src = await readFile(srcUrl, "utf8");
+  // The disqualifying shared-prefix claim must be gone.
+  assert.ok(
+    !/two builds\s*\n?\s*at the same head produce a byte-identical prefix/.test(src),
+    "renderBriefingPrefix JSDoc must not claim same-head byte-identical output",
+  );
+  // It states the CLI path's actual guarantee: a same-head rebuild after a live
+  // description edit yields different prefix bytes.
+  assert.match(src, /live description edit/i, "JSDoc states the same-head rebuild-after-edit scenario");
+  assert.match(src, /DIFFERENT prefix bytes/i, "JSDoc states the rebuild-differs consequence");
+});
+
+test("write-gate-context: PR_BODY_ABSENT_SENTINEL is source-neutral (no GitHub-specific fact) (#1541)", () => {
+  // The sentinel is also rendered by the exported renderBriefingPrefix /
+  // writeGateContext programmatic path, which never contacts GitHub — so it
+  // must not assert a fact only a GitHub reader could know.
+  assert.ok(!/GitHub/i.test(PR_BODY_ABSENT_SENTINEL), "sentinel must not assert a GitHub-specific fact");
+  assert.match(PR_BODY_ABSENT_SENTINEL, /no PR description/i, "sentinel reads as a source-neutral absence statement");
+});


### PR DESCRIPTION
## Problem

Three documentation surfaces in `scripts/github/write-gate-context.mjs` describe behavior the shipped code no longer has:

1. `--help` text for `--acceptance-criteria` and `--issue-body` describes single-issue resolution and omits the unreadable-linked-issue fail-closed. The code resolves EVERY closing reference (comma-joined, cross-repo-qualified) and exits 1 without writing an artifact when any linked-issue read fails.
2. `renderBriefingPrefix`'s JSDoc asserts "two builds at the same head produce a byte-identical prefix". For the CLI path that is false: a same-head rebuild after a live description edit yields different prefix bytes.
3. `PR_BODY_ABSENT_SENTINEL` asserts a fact about GitHub ("this PR has an empty description on GitHub") but is also rendered by the exported programmatic path that never contacts GitHub — on that surface it asserts something the emitting path cannot know.

## Changes

- `--help` for `--acceptance-criteria` and `--issue-body` now describe multi-issue resolution (every closing reference, comma-joined, cross-repo-qualified) and the unreadable-linked-issue fail-closed, matching `skills/docs/gate-review-sub-loop-contract.md`.
- `renderBriefingPrefix`'s JSDoc no longer claims same-head byte-identical output; it states the CLI path's actual guarantee (a same-head rebuild after a live description edit yields different prefix bytes).
- `PR_BODY_ABSENT_SENTINEL` is now source-neutral — `(no PR description is shown)` — asserting only absence, not a GitHub-specific fact.
- `ISSUE_BODY_ABSENT_SENTINEL` is now source-neutral too — `(no issue body is shown)` — for the same reason: it is also rendered by the exported programming path that never contacts GitHub.
- The `--acceptance-criteria` help line no longer implies linked-issue bodies are always fetched and fixes a grammar issue (`EVERY of` → `every`).
- Added `test/contracts/gate-context-doc-surfaces-contract.test.mjs` pinning the corrected claims so a future behavior change fails rather than silently re-diverging.

No resolution or rendering behavior changed.

## Acceptance criteria

- [x] `--help` for `--acceptance-criteria` and `--issue-body` describes multi-issue resolution and the fail-closed on an unreadable linked issue, matching the contract doc.
- [x] `renderBriefingPrefix`'s JSDoc no longer claims same-head byte-identical output, and states what the CLI path actually guarantees.
- [x] The absent-body sentinel does not assert a GitHub-specific fact on a path that never reads GitHub.
- [x] A test or contract check pins each corrected claim.

## Definition of done

- `npm run verify` green.
- `assets:check` and `schema:check` green.
- No remaining statement in `scripts/github/write-gate-context.mjs` contradicts `skills/docs/gate-review-sub-loop-contract.md`.
- No remaining sentinel in `scripts/github/write-gate-context.mjs` asserts a GitHub-specific fact on the programmatic rendering path.

## Non-goals

No resolution or rendering behavior changes; no change to how gate contexts are resolved or rendered. The `ISSUE_BODY_ABSENT_SENTINEL` and help-text wording fixes stay within the doc-surface accuracy scope of issue #1541.

## AC / DoD / non-goals matrix

| Acceptance criterion | Definition-of-done item(s) | Non-goal |
| --- | --- | --- |
| AC1: `--help` for `--acceptance-criteria`/`--issue-body` describes multi-issue resolution + unreadable-linked-issue fail-closed | DoD: no statement in `write-gate-context.mjs` contradicts the contract doc; `npm run verify` green | No resolution/rendering behavior change |
| AC2: `renderBriefingPrefix` JSDoc no longer claims same-head byte-identical output; states the CLI guarantee | DoD: contract test asserts the JSDoc states `live description edit` / `DIFFERENT prefix bytes`; `npm run verify` green | No resolution/rendering behavior change |
| AC3: absent-body sentinel does not assert a GitHub-specific fact on a path that never reads GitHub | DoD: contract test asserts `PR_BODY_ABSENT_SENTINEL` and `ISSUE_BODY_ABSENT_SENTINEL` carry no `GitHub` fact; `npm run verify` green | No resolution/rendering behavior change |
| AC4: a test or contract check pins each corrected claim | DoD: `test/contracts/gate-context-doc-surfaces-contract.test.mjs` (4 tests) passes | No resolution/rendering behavior change |

## Validation

- `npm run verify` (full suite) — exit 0, 0 failures.
- `npm run assets:check` — ok (95 checked).
- `npm run schema:check` — up to date.
- New contract test `test/contracts/gate-context-doc-surfaces-contract.test.mjs` (4 tests) passes.

Closes #1541
