### PR TITLE
feat(gate): required fail-closed deslop angle for prose (ADR 0041, #1442)

### DIFF
--- a/.claude/skills/docs/ab-contrast-deslop-step.md
+++ b/.claude/skills/docs/ab-contrast-deslop-step.md
@@ -1,6 +1,6 @@
 # A/B contrast removal — a standard deslop step
 
-A repeatable editorial step for written deliverables (articles, decks, docs, READMEs). It targets one antipattern: the **binary-contrast / negation-by-contrast** construction, the strongest single AI tell in generated prose. Run it as part of the deslop pass before any approval gate. This is the first documented sub-step of the broader deslop step tracked in #936.
+A repeatable editorial step for written deliverables (articles, decks, docs, READMEs). It targets one antipattern: the **binary-contrast / negation-by-contrast** construction, the strongest single AI tell in generated prose. Since **ADR 0041** this step is a **required, fail-closed gate angle**: a prose diff (`docs/articles/**`, `docs/presentations/**`, `README*`, narrative `docs/*.md`) arms the `deslop` gate angle, which runs this step per document (one reviewer per document; the existing fan-out mechanism already does that) and blocks on any surviving binary-contrast construction. Normative contracts under `skills/docs/**` are exempt — they are governed by the contract style guide and contradiction lens, and deslop's contrast-cutting must not fight required RFC-2119 modality. The existing light-mode and spike-mode relaxed gate carve-outs apply to this angle as they do to other gates. This is the first documented sub-step of the broader deslop step tracked in [#936](https://github.com/mfittko/dev-loops/issues/936).
 
 ## The antipattern (both orderings)
 

--- a/.devloops
+++ b/.devloops
@@ -38,10 +38,10 @@ gates:
     tiers:
       - name: docs-only
         match: { kinds: [docs], maxLines: 300 }
-        angles: [link-check, contract-surface, gate-evidence]
+        angles: [link-check, contract-surface, gate-evidence, deslop] # #1442: prose must run the required deslop angle
       - name: small-non-code
         match: { kinds: [docs, test, config], maxLines: 50 }
-        angles: [correctness, gate-evidence, link-check]
+        angles: [correctness, gate-evidence, link-check, deslop]
     # Only per-layer DELTAS live here — angles that merely restate an
     # extension-defaults.yaml draft-pool entry byte-for-byte are a no-op under
     # merge-by-name (D3) and have been trimmed. This repo's draft gate keeps

--- a/packages/core/src/analysis/change-classifier.mjs
+++ b/packages/core/src/analysis/change-classifier.mjs
@@ -22,6 +22,10 @@ export const ChangeCategory = Object.freeze({
   // child_process/shell exec, untrusted network fetch, destructive filesystem
   // ops / local-file upload). Triggers an up-front adversarial threat-model angle.
   SECURITY_SENSITIVE_SEAM: "SECURITY_SENSITIVE_SEAM",
+  // #1442: a changed file is on the prose surface (docs/articles/**,
+  // docs/presentations/**, README*, narrative docs/*.md) — ADR 0041 prose half.
+  // Triggers the required fail-closed `deslop` gate angle.
+  PROSE_PRESENT: "PROSE_PRESENT",
 });
 
 // ---------------------------------------------------------------------------
@@ -68,6 +72,12 @@ export const CATEGORY_ANGLE_MAP = {
   // never dropped for such a diff (a seam is dangerous regardless of size).
   [ChangeCategory.SECURITY_SENSITIVE_SEAM]: [
     "threat-model", "input-validation", "scope", "correctness",
+  ],
+  // #1442 (ADR 0041 prose half): a prose-surface path is present → run the
+  // required `deslop` gate angle. skills/docs/** is deliberately NOT prose, so
+  // a normative-contract-only docs diff never triggers deslop.
+  [ChangeCategory.PROSE_PRESENT]: [
+    "deslop",
   ],
 };
 

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -21,6 +21,31 @@
 // fails closed toward a full re-review, which is what a version bump needs.
 const DOTFILE_CONFIG_BASENAMES = new Set([".devloops"]);
 
+// #1442 (ADR 0041 prose half): the prose surface that triggers the required
+// `deslop` gate angle. skills/docs/** is deliberately excluded — those are
+// normative contracts (owned by the contract style guide + contradiction
+// lens), not prose, and deslop's contrast-cutting must not fight RFC-2119
+// modality.
+const PROSE_PATH_RE = /^docs\/(articles|presentations)\//;
+const NARRATIVE_DOC_RE = /^docs\/[^/]+\.(md|markdown)$/;
+
+/**
+ * Whether a file path is on the prose surface (#1442): docs/articles/**,
+ * docs/presentations/**, README*, or a narrative direct-child docs/*.md.
+ * skills/docs/** is exempt (normative contracts, not prose).
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isProsePath(filePath) {
+  const fp = normalizeSep(filePath);
+  if (PROSE_PATH_RE.test(fp)) return true;
+  if (NARRATIVE_DOC_RE.test(fp)) return true;
+  const base = fp.split("/").pop() ?? "";
+  if (base.startsWith("README")) return true;
+  return false;
+}
+
 /**
  * @typedef {object} T0Result
  * @property {string[]} files — flat file paths
@@ -76,6 +101,9 @@ export function analyzeT0(nameStatusOutput) {
   }
 
   const renameOnly = lines.length > 0 && renameCount === lines.length;
+  // #1442: any changed file on the prose surface arms the PROSE_PRESENT
+  // category, driving the required `deslop` gate angle.
+  const prosePresent = files.some(isProsePath);
   // Derive from the shared classifier so this predicate can't drift from it: a
   // code/config/test file hosted under docs/ is not prose, so a mixed diff that
   // includes one is not docs-only (it still gets the code-review surface).
@@ -87,6 +115,7 @@ export function analyzeT0(nameStatusOutput) {
     directories: [...directories].sort(),
     renameOnly,
     allDocs,
+    prosePresent,
   };
 }
 
@@ -372,6 +401,7 @@ function t0FileCategories(t0) {
   const categories = [];
   if (t0.renameOnly) categories.push("RENAME_ONLY");
   if (t0.allDocs) categories.push("DOCS_ONLY");
+  if (t0.prosePresent) categories.push("PROSE_PRESENT");
   if (t0.files.every((f) => classifyFile(f) === "config")) categories.push("CONFIG_ONLY");
   if (t0.files.every((f) => classifyFile(f) === "test")) categories.push("TEST_ONLY");
   if (t0.files.every((f) => classifyFile(f) === "ci")) categories.push("CI_ONLY");
@@ -392,6 +422,7 @@ function t0PresentSurfaceCategories(t0) {
   const categories = [];
   const cats = new Set(t0.files.map(classifyFile));
   if (cats.has("docs")) categories.push("DOCS_ONLY");
+  if (t0.prosePresent) categories.push("PROSE_PRESENT");
   if (cats.has("config")) categories.push("CONFIG_ONLY");
   if (cats.has("test")) categories.push("TEST_ONLY");
   if (cats.has("ci")) categories.push("CI_ONLY");

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -503,8 +503,17 @@ export function analyzeDiff({ nameStatusOutput, diffOutput }) {
   // When t1 is null (unambiguous diff), infer categories from t0
   // so dynamic angle resolution can narrow for config-only / test-only etc.
   if (!t1) {
+    // #1442 Copilot finding: a genuinely MIXED diff whose T1 never ran (no
+    // diffOutput) must NOT get a T0-only PROSE_PRESENT category. Non-empty
+    // categories set ambiguous=false, so a mixed code+prose diff would
+    // under-select to just deslop + always-include and drop the code-review
+    // core. T0-only inference is only safe for unambiguous diffs (docs-only /
+    // single surface); a mixed diff without hunk content is unclassifiable, so
+    // return empty categories and let resolveDynamicAngles fall back to the
+    // full angle set (fail closed).
+    const changeCategories = t0Ambiguous ? [] : inferCategoriesFromT0(t0);
     t1 = {
-      changeCategories: inferCategoriesFromT0(t0),
+      changeCategories,
       hunkCount: 0,
       lineStats: { added: 0, deleted: 0 },
     };

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -28,17 +28,26 @@ const DOTFILE_CONFIG_BASENAMES = new Set([".devloops"]);
 // modality.
 const PROSE_PATH_RE = /^docs\/(articles|presentations)\//;
 const NARRATIVE_DOC_RE = /^docs\/[^/]+\.(md|markdown)$/;
+// #1442 review finding: the skills/docs/** exemption must hold for the README
+// rule too. PROSE_PATH_RE / NARRATIVE_DOC_RE are anchored to `docs/` so
+// skills/docs files never match them; the README basename rule is the ONLY
+// path by which a skills/docs file could be classified prose (e.g. a future
+// `skills/docs/README-*.md`). Carve the normative-contract subtree out
+// explicitly so a README-named contract never arms deslop.
+const SKILLS_DOCS_EXEMPT_RE = /^(skills\/docs|\x2eclaude\/skills\/docs)\//;
 
 /**
  * Whether a file path is on the prose surface (#1442): docs/articles/**,
  * docs/presentations/**, README*, or a narrative direct-child docs/*.md.
- * skills/docs/** is exempt (normative contracts, not prose).
+ * skills/docs/** (and .claude/skills/docs/**) is exempt (normative
+ * contracts, not prose) across ALL rules, including the README basename rule.
  *
  * @param {string} filePath
  * @returns {boolean}
  */
 export function isProsePath(filePath) {
   const fp = normalizeSep(filePath);
+  if (SKILLS_DOCS_EXEMPT_RE.test(fp)) return false;
   if (PROSE_PATH_RE.test(fp)) return true;
   if (NARRATIVE_DOC_RE.test(fp)) return true;
   const base = fp.split("/").pop() ?? "";
@@ -81,6 +90,13 @@ export function analyzeT0(nameStatusOutput) {
   const extensions = new Set();
   const directories = new Set();
   let renameCount = 0;
+  // #1442 review finding: prose arming must be scoped to content-carrying
+  // rows. A pure deletion (`D` name-status row) has no prose content for the
+  // deslop reviewer to strip — arming deslop on it over-selects and re-runs
+  // the fan-out over a content-free delta. Added/modified/renamed-dest rows
+  // (A / M / M? / R-dest) carry content and still arm prose. Rename rows emit
+  // `R<score>\told\tnew` (rawPath = parts[2], the new content-bearing path).
+  let prosePresent = false;
 
   for (const line of lines) {
     const parts = line.split("\t");
@@ -98,12 +114,14 @@ export function analyzeT0(nameStatusOutput) {
     if (dir) directories.add(dir);
 
     if (status.startsWith("R")) renameCount++;
+    // #1442: a content-carrying prose file arms PROSE_PRESENT → deslop. Pure
+    // deletions (`D`) are excluded (no prose content to strip, avoids noise).
+    if (prosePresent) continue;
+    if (status === "D" || status.startsWith("D")) continue;
+    if (isProsePath(path)) prosePresent = true;
   }
 
   const renameOnly = lines.length > 0 && renameCount === lines.length;
-  // #1442: any changed file on the prose surface arms the PROSE_PRESENT
-  // category, driving the required `deslop` gate angle.
-  const prosePresent = files.some(isProsePath);
   // Derive from the shared classifier so this predicate can't drift from it: a
   // code/config/test file hosted under docs/ is not prose, so a mixed diff that
   // includes one is not docs-only (it still gets the code-review surface).

--- a/packages/core/src/analysis/diff-analyzer.mjs
+++ b/packages/core/src/analysis/diff-analyzer.mjs
@@ -46,6 +46,10 @@ const SKILLS_DOCS_EXEMPT_RE = /^(skills\/docs|\x2eclaude\/skills\/docs)\//;
  * @returns {boolean}
  */
 export function isProsePath(filePath) {
+  // #1442 review finding (input-validation): exported trust-boundary guard.
+  // Fail closed (false) on a non-string/empty argument rather than crashing in
+  // normalizeSep(filePath).replaceAll(...).
+  if (typeof filePath !== "string" || filePath.length === 0) return false;
   const fp = normalizeSep(filePath);
   if (SKILLS_DOCS_EXEMPT_RE.test(fp)) return false;
   if (PROSE_PATH_RE.test(fp)) return true;
@@ -115,9 +119,14 @@ export function analyzeT0(nameStatusOutput) {
 
     if (status.startsWith("R")) renameCount++;
     // #1442: a content-carrying prose file arms PROSE_PRESENT → deslop. Pure
-    // deletions (`D`) are excluded (no prose content to strip, avoids noise).
+    // deletions (`D`) are excluded (no prose content to strip, avoids noise);
+    // a pure `R100` rename (git's 100% similarity score — no content changed)
+    // is likewise content-free and must not arm deslop. Renames with a score
+    // below 100 (`R<score>\told\tnew`, rawPath = the new content-bearing path)
+    // carry content and still arm prose.
     if (prosePresent) continue;
     if (status === "D" || status.startsWith("D")) continue;
+    if (status.startsWith("R") && status === "R100") continue;
     if (isProsePath(path)) prosePresent = true;
   }
 

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -901,6 +901,7 @@ const BUILTIN_PERSONAS = Object.freeze({
   determinism:          { persona: "review", defaultModel: null },
   "acceptance-criteria": { persona: "review", defaultModel: null },
   "ac-dod":              { persona: "review", defaultModel: null },
+  deslop:                { persona: "review", defaultModel: null },
 });
 
 const DEFAULT_REVIEWER_PERSONA = "default-reviewer";
@@ -2448,11 +2449,13 @@ export async function resolveGateAnglesDynamic(config, gate, { diff, hasFullLabe
   let changedFiles;
   let filesChanged;
   let linesChanged;
+  let prosePresent = false;
   if (diff) {
     const { analyzeT0, analyzeT1 } = await import("../analysis/diff-analyzer.mjs");
     const t0 = analyzeT0(diff.nameStatusOutput);
     changedFiles = t0.files;
     filesChanged = changedFiles.length;
+    prosePresent = t0.prosePresent; // #1442: gate deslop on the prose surface
     if (diff.diffOutput) {
       const lineStats = analyzeT1(diff.diffOutput, t0).lineStats;
       linesChanged = lineStats.added + lineStats.deleted;
@@ -2461,10 +2464,18 @@ export async function resolveGateAnglesDynamic(config, gate, { diff, hasFullLabe
   const tierResult = resolveGateTier(config, gate, { changedFiles, filesChanged, linesChanged, hasFullLabel });
   if (tierResult.tier) {
     const configuredAngles = resolveGateAngles(config, gate) ?? [];
-    const tierAngleSet = new Set(tierResult.angles);
-    const skippedAngles = configuredAngles.filter((a) => !tierAngleSet.has(a));
+    let recommendedAngles = tierResult.angles;
+    // #1442 (ADR 0041 prose half): deslop is a prose-only angle. A docs-kind
+    // tier (e.g. this repo's docs-only/small-non-code) names it so prose diffs
+    // keep it, but that same kind matches exempt normative contracts
+    // (skills/docs/**). Strip deslop when the diff touches no prose surface so
+    // exemption holds even through the tier path.
+    if (recommendedAngles.includes("deslop") && prosePresent === false) {
+      recommendedAngles = recommendedAngles.filter((a) => a !== "deslop");
+    }
+    const skippedAngles = configuredAngles.filter((a) => !recommendedAngles.includes(a));
     return {
-      recommendedAngles: tierResult.angles,
+      recommendedAngles,
       skippedAngles,
       reasons: Object.fromEntries(skippedAngles.map((a) => [a, `tier:${tierResult.tier}`])),
       fallbackToAll: false,

--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -133,6 +133,28 @@ gates:
         mandatory: true
         persona: review
         prompt: 'Review the PR description for completeness, contract fitness, and checkbox formatting before this PR is marked ready for review. The PR body is the implementation contract — it must have: - A Summary section explaining what changed and why - A Scope and context section defining the boundary of the change - An Acceptance criteria section with the linked issue acceptance criteria - A Definition of done section - A Non-goals section - A Validation command section describing exactly how to verify the change - The "Closes #N" line must match the linked issue; flag changes that alter or remove the operator-intended close target Checkboxes (`- [ ]` / `- [x]`, or `* [ ]` / `* [x]`) must appear inside genuine Markdown list items. Flag any checkbox marker used outside a list item (including table cells) as a medium finding. Flag any checkbox marker wrapped in backticks (e.g. `` `[x]` ``) as a medium finding. Flag PRs where the body is a single sentence or lacks any of these sections. Do not block on formatting preferences other than checkbox correctness.'
+    # #1442 (ADR 0041 prose half): required fail-closed deslop angle for prose
+    # deliverables. Runs the A/B-contrast-removal deslop step (ab-contrast-
+    # deslop-step.md) — flag surviving binary-contrast constructions so the gate
+    # fails closed on them. One reviewer per document (the existing fan-out
+    # mechanism already does this). Only armed when the diff touches the prose
+    # surface (PROSE_PRESENT); skills/docs/** is exempt.
+      - name: deslop
+        persona: review
+        prompt: >-
+          Run the required deslop step (ab-contrast-deslop-step.md) on every
+          changed prose document in the diff (docs/articles/**, docs/presentations/**,
+          README*, narrative docs/*.md). Flag every surviving binary-contrast /
+          negation-by-contrast construction — "not X but Y", "X, not Y",
+          "rather than A, B", "it isn't A, it's B", dramatic antithesis pairs and
+          fragments ("where X, Y", "less A, more B", "not just A but B") — in
+          either ordering (A-then-B or B-then-A). For each instance report a line
+          ref, the exact quote, the pattern name, and a proposed rewrite that cuts
+          the scaffolding while keeping any load-bearing factual distinction stated
+          plainly. Do NOT flag genuine conditionals, real either/or behavior, or
+          RFC-2119 modality (MUST/SHOULD) in normative contracts; and do NOT touch
+          skills/docs/** (exempt). Be exhaustive — a missed instance is the failure
+          mode, and fail closed when any survives.
     required: true
     requireCi: true
     # Diff-class angle tiers (opt-in, ordered, first match wins). A matching tier

--- a/packages/core/src/loop/gate-carry-forward.mjs
+++ b/packages/core/src/loop/gate-carry-forward.mjs
@@ -57,7 +57,10 @@ import { ALWAYS_INCLUDE, CATEGORY_ANGLE_MAP } from "../analysis/change-classifie
  * @type {Record<string, string[]>}
  */
 const KIND_TO_CATEGORIES = {
-  docs: ["DOCS_ONLY"],
+  // #1442: a docs file is PROSE_PRESENT when it lands on the prose surface, so
+  // deslop's carry-forward surface is the `docs` kind (a non-docs delta never
+  // re-runs a clean deslop verdict).
+  docs: ["DOCS_ONLY", "PROSE_PRESENT"],
   config: ["CONFIG_ONLY"],
   test: ["TEST_ONLY"],
   ci: ["CI_ONLY"],

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1899,6 +1899,14 @@ describe("role resolution", () => {
     assert.equal(result.fallback, false);
   });
 
+  // #1442: the required deslop gate angle resolves to the review persona.
+  test("R11d: deslop angle resolves to review persona (ADR 0041 prose half)", () => {
+    const result = resolveReviewerRole({}, "deslop");
+    assert.equal(result.persona, "review");
+    assert.equal(result.model, null);
+    assert.equal(result.fallback, false);
+  });
+
   test("R12: all 20 known angles resolve without fallback", () => {
     const expectedPersonas = {
       scope: "review",
@@ -2848,7 +2856,7 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
       "input-validation", "determinism", "no-op", "link-check",
       "packaging-runtime", "state-concurrency", "config-drift", "gate-evidence",
       "pr-description", "pr-comments", "contradiction-lens", "code-conformance",
-      "semantic-drift",
+      "semantic-drift", "deslop", // #1442 (ADR 0041 prose half)
     ],
     preApproval: [
       "dry", "kiss", "yagni", "srp", "soc", "deep", "docs", "ocp", "lsp", "isp",
@@ -4561,7 +4569,7 @@ describe("resolveGateAnglesDynamic", () => {
       gates: { draft: { angles: ["scope", "coverage", "docs", "deep", "kiss"] } },
     };
     const result = await resolveGateAnglesDynamic(config, "draft", {
-      diff: { nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md" },
+      diff: { nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/specs/bar.md" },
     });
     assert.equal(result.dynamicAnglesActive, true);
     assert.equal(result.fallbackToAll, true);
@@ -4756,6 +4764,34 @@ describe("resolveGateTier (issue #1550 — diff-class angle tiers)", () => {
       gates: { draft: { tiers: [{ name: "docs-only", match: {}, angles: ["docs"] }] } },
     });
     assert.equal(result.success, false);
+  });
+
+  // #1442: the prose-only deslop angle is gated on the prose surface even when
+  // a docs-kind tier names it — a prose docs diff keeps it, an exempt
+  // skills/docs contract diff drops it.
+  test("tier with deslop: prose diff keeps deslop, skills/docs contract drops it", async () => {
+    const { resolveGateAnglesDynamic } = await import("../src/config/config.mjs");
+    const config = {
+      version: 1,
+      gates: {
+        draft: {
+          dynamicAngles: true,
+          angles: ["link-check", "contract-surface", "gate-evidence", "deslop"],
+          tiers: [{ name: "docs-only", match: { kinds: ["docs"], maxLines: 300 }, angles: ["link-check", "contract-surface", "gate-evidence", "deslop"] }],
+        },
+      },
+    };
+    // Prose docs-only diff (< 300 lines) matches the docs-only tier and keeps deslop.
+    const prose = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "M\tdocs/articles/foo.md", diffOutput: "@@ -1,1 +1,1 @@\n+not X. Y." },
+    });
+    assert.ok(prose.recommendedAngles.includes("deslop"), "prose diff must keep deslop through the docs tier");
+    // Exempt normative contract (skills/docs) matches the same docs tier but is
+    // NOT prose → deslop is stripped.
+    const contract = await resolveGateAnglesDynamic(config, "draft", {
+      diff: { nameStatusOutput: "M\tskills/docs/worktree-guidance.md", diffOutput: "@@ -1,1 +1,1 @@\n+M" },
+    });
+    assert.ok(!contract.recommendedAngles.includes("deslop"), "skills/docs contract diff must drop deslop");
   });
 });
 

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -1907,7 +1907,7 @@ describe("role resolution", () => {
     assert.equal(result.fallback, false);
   });
 
-  test("R12: all 20 known angles resolve without fallback", () => {
+  test("R12: all 21 known angles resolve without fallback (deslop added in #1442)", () => {
     const expectedPersonas = {
       scope: "review",
       coverage: "review",
@@ -1929,6 +1929,7 @@ describe("role resolution", () => {
       "state-concurrency": "review",
       "renderer-security": "review",
       determinism: "review",
+      deslop: "review", // #1442 (ADR 0041 prose half)
     };
 
     for (const [angle, expectedPersona] of Object.entries(expectedPersonas)) {
@@ -1936,6 +1937,33 @@ describe("role resolution", () => {
       assert.equal(result.persona, expectedPersona, `angle ${angle}`);
       assert.equal(result.fallback, false, `angle ${angle}`);
     }
+  });
+
+  // #1442 review finding (coverage, AC2): AC2 — "a prose diff with a planted
+  // binary-contrast construction is BLOCKED; a clean prose diff passes" — is
+  // enforced entirely by the fail-closed deslop persona prompt. No test bound
+  // the shipped prompt to that directive, so a regression that softens or drops
+  // fail-closed would pass the whole suite. This binds it so it cannot silently
+  // regress (the fail-closed blocking behavior itself runs as an LLM over this
+  // exact prompt).
+  test("R11e: shipped deslop prompt retains the fail-closed directive (AC2 binding)", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+    const sourceDefaults = await readFile(
+      path.join(repoRoot, "packages", "core", "src", "config", "extension-defaults.yaml"),
+      "utf8",
+    );
+    const deslopBlock = sourceDefaults.match(
+      /- name: deslop[\s\S]*?prompt: >-[\s\S]*?fail closed when any survives/,
+    );
+    assert.ok(deslopBlock, "deslop persona prompt must exist in shipped extension-defaults.yaml");
+    const prompt = deslopBlock[0];
+    // Every surviving binary-contrast construction must block (`fail closed when
+    // any survives`), a missed instance is the failure mode (`Be exhaustive`),
+    // and skills/docs on the diff still respected.
+    assert.match(prompt, /fail closed when any survives/);
+    assert.match(prompt, /Be exhaustive/);
+    assert.match(prompt, /skills\/docs/);
   });
 
   test("R13: known angle with model override applies override", () => {
@@ -2856,7 +2884,7 @@ describe("shipped .devloops + extension-defaults.yaml resolve byte-identically t
       "input-validation", "determinism", "no-op", "link-check",
       "packaging-runtime", "state-concurrency", "config-drift", "gate-evidence",
       "pr-description", "pr-comments", "contradiction-lens", "code-conformance",
-      "semantic-drift", "deslop", // #1442 (ADR 0041 prose half)
+      "semantic-drift", "deslop", // #1442 (ADR 0041 prose half) — deliberate addition atop the pre-#1404 pinned baseline
     ],
     preApproval: [
       "dry", "kiss", "yagni", "srp", "soc", "deep", "docs", "ocp", "lsp", "isp",

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -82,6 +82,12 @@ test("isProsePath: prose surface — articles, presentations, README*, narrative
 test("isProsePath: NOT prose — skills/docs contracts, nested docs, code, config, other docs", () => {
   assert.equal(isProsePath("skills/docs/ab-contrast-deslop-step.md"), false);
   assert.equal(isProsePath("skills/docs/worktree-guidance.md"), false);
+  // #1442 review finding: the skills/docs/** exemption must hold for README-named
+  // contracts too (the README basename rule is the only path that could classify
+  // a skills/docs file as prose).
+  assert.equal(isProsePath("skills/docs/README.md"), false);
+  assert.equal(isProsePath("skills/docs/README-styleguide.md"), false);
+  assert.equal(isProsePath(".claude/skills/docs/README.md"), false);
   // Nested under docs/ (not a direct-child narrative doc, not articles/presentations)
   assert.equal(isProsePath("docs/specs/foo.md"), false);
   assert.equal(isProsePath("docs/decisions/0001.md"), false);
@@ -115,6 +121,24 @@ test("analyzeDiff: non-prose docs diff (skills/docs) does NOT get PROSE_PRESENT"
   const r = analyzeDiff({ nameStatusOutput: "M\tskills/docs/worktree-guidance.md" });
   assert.ok(r.t1.changeCategories.includes("DOCS_ONLY"));
   assert.ok(!r.t1.changeCategories.includes("PROSE_PRESENT"), "skills/docs is exempt from deslop");
+});
+
+// #1442 review finding: a pure deletion (`D` row) has no prose content for the
+// deslop reviewer to strip — it must NOT arm PROSE_PRESENT / deslop.
+test("analyzeDiff: a pure deletion of a prose file does NOT arm PROSE_PRESENT", () => {
+  const r = analyzeDiff({ nameStatusOutput: "D\tdocs/articles/retired-article.md" });
+  assert.ok(!r.t1.changeCategories.includes("PROSE_PRESENT"), "deletion-only prose diff must not select deslop");
+  assert.ok(r.t1.changeCategories.includes("DOCS_ONLY"), "a deleted docs file is still a docs change");
+});
+
+test("analyzeDiff: a modified prose file still arms PROSE_PRESENT", () => {
+  const r = analyzeDiff({ nameStatusOutput: "M\tdocs/articles/foo.md" });
+  assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"));
+});
+
+test("analyzeDiff: a deleted prose file among added/modified files does not block prose arming from the live ones", () => {
+  const r = analyzeDiff({ nameStatusOutput: "D\tdocs/articles/old.md\nM\tdocs/articles/new.md" });
+  assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"), "live modified prose file still arms deslop");
 });
 
 test("classifyFile: config for allowlisted extensionless dotfiles", () => {

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -131,6 +131,23 @@ test("analyzeDiff: a pure deletion of a prose file does NOT arm PROSE_PRESENT", 
   assert.ok(r.t1.changeCategories.includes("DOCS_ONLY"), "a deleted docs file is still a docs change");
 });
 
+test("isProsePath: NOT prose — non-string / empty argument fails closed", () => {
+  assert.equal(isProsePath(null), false);
+  assert.equal(isProsePath(undefined), false);
+  assert.equal(isProsePath(""), false);
+  assert.equal(isProsePath(42), false);
+});
+
+test("analyzeDiff: a pure R100 rename of a prose file does NOT arm PROSE_PRESENT", () => {
+  const r = analyzeDiff({ nameStatusOutput: "R100\tdocs/articles/old.md\tdocs/articles/new.md" });
+  assert.ok(!r.t1.changeCategories.includes("PROSE_PRESENT"), "pure R100 rename (no content change) must not select deslop");
+});
+
+test("analyzeDiff: a content-carrying rename (R<100) of a prose file arms PROSE_PRESENT", () => {
+  const r = analyzeDiff({ nameStatusOutput: "R090\tdocs/articles/old.md\tdocs/articles/new.md" });
+  assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"), "a below-100 rename carries content and must arm deslop");
+});
+
 test("analyzeDiff: a modified prose file still arms PROSE_PRESENT", () => {
   const r = analyzeDiff({ nameStatusOutput: "M\tdocs/articles/foo.md" });
   assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"));

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -7,6 +7,7 @@ import {
   analyzeT1,
   analyzeDiff,
   diffHasSecuritySeam,
+  isProsePath,
 } from "../src/analysis/diff-analyzer.mjs";
 import { resolveDynamicAngles } from "../src/analysis/change-classifier.mjs";
 
@@ -63,6 +64,57 @@ test("classifyFile: unknown for unrecognized", () => {
 test("classifyFile: docs for .markdown files", () => {
   assert.equal(classifyFile("docs/guide.markdown"), "docs");
   assert.equal(classifyFile("CHANGELOG.markdown"), "docs");
+});
+
+// #1442 (ADR 0041 prose half): prose-surface detection for the deslop angle.
+// ---------------------------------------------------------------------------
+
+test("isProsePath: prose surface — articles, presentations, README*, narrative docs/*.md", () => {
+  assert.equal(isProsePath("docs/articles/introducing-dev-loops.md"), true);
+  assert.equal(isProsePath("docs/articles/how-dev-loops-decided-itself.html"), true);
+  assert.equal(isProsePath("docs/presentations/process-observability-presentation.md"), true);
+  assert.equal(isProsePath("README.md"), true);
+  assert.equal(isProsePath("README-hi.md"), true);
+  assert.equal(isProsePath("docs/index.md"), true);
+  assert.equal(isProsePath("docs/migrating-to-dev-loops.md"), true);
+});
+
+test("isProsePath: NOT prose — skills/docs contracts, nested docs, code, config, other docs", () => {
+  assert.equal(isProsePath("skills/docs/ab-contrast-deslop-step.md"), false);
+  assert.equal(isProsePath("skills/docs/worktree-guidance.md"), false);
+  // Nested under docs/ (not a direct-child narrative doc, not articles/presentations)
+  assert.equal(isProsePath("docs/specs/foo.md"), false);
+  assert.equal(isProsePath("docs/decisions/0001.md"), false);
+  // Top-level non-README docs are NOT prose (root-level changelog)
+  assert.equal(isProsePath("CHANGELOG.md"), false);
+  assert.equal(isProsePath("CHANGELOG.markdown"), false);
+  // Unclassifiable / non-docs
+  assert.equal(isProsePath("src/foo.mjs"), false);
+  assert.equal(isProsePath(".devloops"), false);
+  assert.equal(isProsePath("assets/logo.png"), false);
+});
+
+// #1442: prose diffs arm PROSE_PRESENT → deslop; non-prose diffs do not.
+test("analyzeDiff: prose diff → PROSE_PRESENT category", () => {
+  const r = analyzeDiff({ nameStatusOutput: "M\tdocs/articles/foo.md" });
+  assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"));
+  const r2 = analyzeDiff({ nameStatusOutput: "M\tREADME.md" });
+  assert.ok(r2.t1.changeCategories.includes("PROSE_PRESENT"));
+});
+
+test("analyzeDiff: mixed code+prose diff keeps PROSE_PRESENT alongside LOGIC_CHANGE", () => {
+  const r = analyzeDiff({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/articles/foo.md",
+    diffOutput: "@@ -1,1 +1,1 @@\n+export const x = 1;\n",
+  });
+  assert.ok(r.t1.changeCategories.includes("LOGIC_CHANGE"));
+  assert.ok(r.t1.changeCategories.includes("PROSE_PRESENT"));
+});
+
+test("analyzeDiff: non-prose docs diff (skills/docs) does NOT get PROSE_PRESENT", () => {
+  const r = analyzeDiff({ nameStatusOutput: "M\tskills/docs/worktree-guidance.md" });
+  assert.ok(r.t1.changeCategories.includes("DOCS_ONLY"));
+  assert.ok(!r.t1.changeCategories.includes("PROSE_PRESENT"), "skills/docs is exempt from deslop");
 });
 
 test("classifyFile: config for allowlisted extensionless dotfiles", () => {
@@ -301,7 +353,8 @@ test("analyzeT1: detects COMMENT_ONLY from comment-only diff", () => {
 test("analyzeDiff: T0 unambiguous → no T1, not ambiguous", () => {
   const result = analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md\nM\tREADME.md" });
   assert.ok(result.t0.allDocs);
-  assert.deepEqual(result.t1.changeCategories, ["DOCS_ONLY"]);
+  // #1442: both paths are on the prose surface, so PROSE_PRESENT arms the deslop angle.
+  assert.deepEqual(result.t1.changeCategories, ["DOCS_ONLY", "PROSE_PRESENT"]);
   assert.equal(result.ambiguous, false);
 });
 
@@ -338,7 +391,7 @@ test("analyzeDiff: T0 ambiguous with diff + no classifiable change → ambiguous
 });
 
 test("analyzeDiff: T0 ambiguous without diff → no T1, ambiguous", () => {
-  const result = analyzeDiff({ nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/bar.md" });
+  const result = analyzeDiff({ nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/specs/bar.md" });
   assert.deepEqual(result.t1.changeCategories, []);
   assert.equal(result.ambiguous, true);
 });
@@ -457,7 +510,7 @@ test("analyzeDiff: pure single-surface diffs keep exclusive semantics (no over-u
   );
   assert.deepEqual(
     analyzeDiff({ nameStatusOutput: "M\tdocs/guide.md" }).t1.changeCategories,
-    ["DOCS_ONLY"],
+    ["DOCS_ONLY", "PROSE_PRESENT"], // #1442: narrative docs/*.md is prose
   );
 });
 

--- a/packages/core/test/diff-analyzer.test.mjs
+++ b/packages/core/test/diff-analyzer.test.mjs
@@ -437,6 +437,17 @@ test("analyzeDiff: T0 ambiguous without diff → no T1, ambiguous", () => {
   assert.equal(result.ambiguous, true);
 });
 
+test("analyzeDiff: mixed code+prose WITHOUT diff stays ambiguous (fail-closed, #1442)", () => {
+  // A prose file must not let a mixed code+prose diff under-select. With no
+  // diffOutput the hunk-level T1 never runs, and a T0-only PROSE_PRESENT would
+  // mark it "classified" -> ambiguous=false -> deslop + always-include only,
+  // dropping the code surface. It must instead stay ambiguous and fall back to
+  // the full angle set (deslop still runs there).
+  const r = analyzeDiff({ nameStatusOutput: "M\tsrc/foo.mjs\nM\tdocs/articles/bar.md" });
+  assert.equal(r.t1.changeCategories.length, 0, "mixed no-diffOutput must not be PROSE_PRESENT-only");
+  assert.equal(r.ambiguous, true);
+});
+
 test("analyzeDiff: rename-only → unambiguous", () => {
   const result = analyzeDiff({ nameStatusOutput: "R100\told.mjs\tnew.mjs" });
   assert.ok(result.t0.renameOnly);

--- a/packages/core/test/dynamic-angles.test.mjs
+++ b/packages/core/test/dynamic-angles.test.mjs
@@ -151,6 +151,52 @@ test("resolveDynamicAngles: mixed logic + CI unions ci-guard into the core subse
 });
 
 // ---------------------------------------------------------------------------
+// #1442: PROSE_PRESENT → deslop angle selection
+// ---------------------------------------------------------------------------
+
+const PROSE_DRAFT_ANGLES = [...new Set([...DRAFT_ANGLES, ...PREAPPROVAL_ANGLES, "deslop"])];
+
+test("resolveDynamicAngles: PROSE_PRESENT selects deslop (configured)", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: PROSE_DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.DOCS_ONLY, ChangeCategory.PROSE_PRESENT],
+  });
+  assert.equal(result.fallbackToAll, false);
+  assert.ok(result.recommendedAngles.includes("deslop"), "prose diff must run deslop");
+  assert.ok(!result.skippedAngles.includes("deslop"));
+});
+
+test("resolveDynamicAngles: PROSE_PRESENT adds deslop from the pool (additive mode)", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: DRAFT_ANGLES.filter((a) => a !== "deslop"),
+    changeCategories: [ChangeCategory.PROSE_PRESENT],
+    anglePool: PROSE_DRAFT_ANGLES,
+  });
+  assert.ok(result.addedAngles.includes("deslop"), "deslop pulled from the pool for a prose diff");
+  assert.match(result.addedReasons["deslop"], /PROSE_PRESENT/);
+});
+
+test("resolveDynamicAngles: a non-prose docs diff does NOT select deslop", () => {
+  // skills/docs/** (normative contracts) is exempt — DOCS_ONLY alone must not
+  // arm deslop.
+  const result = resolveDynamicAngles({
+    configuredAngles: PROSE_DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.DOCS_ONLY],
+  });
+  assert.ok(result.skippedAngles.includes("deslop"), "non-prose docs diff must skip deslop");
+  assert.ok(!result.recommendedAngles.includes("deslop"));
+});
+
+test("resolveDynamicAngles: a logic change does NOT select deslop (non-prose angle set unchanged)", () => {
+  const result = resolveDynamicAngles({
+    configuredAngles: PROSE_DRAFT_ANGLES,
+    changeCategories: [ChangeCategory.LOGIC_CHANGE],
+  });
+  assert.ok(!result.recommendedAngles.includes("deslop"));
+  assert.ok(result.skippedAngles.includes("deslop"));
+});
+
+// ---------------------------------------------------------------------------
 // Always-include
 // ---------------------------------------------------------------------------
 

--- a/packages/core/test/gate-carry-forward.test.mjs
+++ b/packages/core/test/gate-carry-forward.test.mjs
@@ -54,6 +54,16 @@ describe("angleReviewSurface — the pure angle -> surface mapping", () => {
     assert.equal(surface.kind, "kinds");
     assert.deepEqual([...surface.kinds], ["docs"]);
   });
+
+  // #1442: deslop's review surface is the `docs` kind — a clean deslop verdict
+  // carries forward across a delta with no docs file, and re-runs on any doc
+  // change (prose or not; non-prose docs never vote clean on deslop in the
+  // first place because PROSE_PRESENT is not armed).
+  test("deslop angle surface is docs (fail-closed carry-forward)", () => {
+    const surface = angleReviewSurface("deslop");
+    assert.equal(surface.kind, "kinds");
+    assert.deepEqual([...surface.kinds], ["docs"]);
+  });
 });
 
 describe("resolveAngleCarryForward — fail-closed decision", () => {

--- a/skills/docs/ab-contrast-deslop-step.md
+++ b/skills/docs/ab-contrast-deslop-step.md
@@ -1,6 +1,6 @@
 # A/B contrast removal — a standard deslop step
 
-A repeatable editorial step for written deliverables (articles, decks, docs, READMEs). It targets one antipattern: the **binary-contrast / negation-by-contrast** construction, the strongest single AI tell in generated prose. Run it as part of the deslop pass before any approval gate. This is the first documented sub-step of the broader deslop step tracked in #936.
+A repeatable editorial step for written deliverables (articles, decks, docs, READMEs). It targets one antipattern: the **binary-contrast / negation-by-contrast** construction, the strongest single AI tell in generated prose. Since **ADR 0041** this step is a **required, fail-closed gate angle**: a prose diff (`docs/articles/**`, `docs/presentations/**`, `README*`, narrative `docs/*.md`) arms the `deslop` gate angle, which runs this step per document (one reviewer per document; the existing fan-out mechanism already does that) and blocks on any surviving binary-contrast construction. Normative contracts under `skills/docs/**` are exempt — they are governed by the contract style guide and contradiction lens, and deslop's contrast-cutting must not fight required RFC-2119 modality. The existing light-mode and spike-mode relaxed gate carve-outs apply to this angle as they do to other gates. This is the first documented sub-step of the broader deslop step tracked in [#936](https://github.com/mfittko/dev-loops/issues/936).
 
 ## The antipattern (both orderings)
 


### PR DESCRIPTION
## Summary

Implements the **prose half** of ADR 0041: promotes the **deslop** loop from an advisory editorial step to a **required, fail-closed gate angle** for prose deliverables. A diff that touches the prose surface now arms a `deslop` review angle which runs the A/B-contrast-removal step per changed document and blocks on any surviving binary-contrast construction.

## Scope and context

- Adds a `PROSE_PRESENT` change category and routes `deslop` through `CATEGORY_ANGLE_MAP`.
- Adds `isProsePath()` detecting the prose surface: `docs/articles/**`, `docs/presentations/**`, `README*`, and narrative direct-child `docs/*.md`.
- `skills/docs/**` is deliberately **exempt** — those are normative contracts governed by the contract style guide + contradiction lens, and deslop's contrast-cutting must not fight required RFC-2119 modality.
- Wires `prosePresent` through `analyzeT0` / `t0PresentSurfaceCategories` and `resolveGateAnglesDynamic`, and strips `deslop` even when a docs-kind tier names it, if the diff touches no prose surface (exemption holds through the tier path).
- Registers `deslop` in `BUILTIN_PERSONAS` (review persona), ships the required fail-closed deslop prompt in `extension-defaults.yaml`, and adds the angle to this repo's draft gate tier pools.
- Reconciles the advisory language in `ab-contrast-deslop-step.md` to the now-required status.

## Acceptance criteria

- `deslop` angle exists in the catalog and is path-triggered on the prose surface above, with `skills/docs/**` exempt.
- A prose diff with a planted binary-contrast construction is blocked by the gate; a clean prose diff passes.
- Light/spike carve-outs still exempt as they do for other gates.
- Contract docs updated; the advisory language in `ab-contrast-deslop-step.md` is reconciled with the now-required status.

## Definition of done

- Angle + tests land through the full gate. No change to non-prose diffs' angle set.

## Non-goals

- The designer/vision recorded-evidence check (ADR 0041 UI half) is the sibling issue, not this one.
- No change to non-prose angle sets (code/config/test/CI diffs do not gain `deslop`).

## Validation

- `npm run verify` — all touched suites green (`diff-analyzer`, `dynamic-angles`, `config`, `gate-carry-forward`).
- One unrelated local-only flake observed: `reply-resolve-review-threads` "open stdin pipe no-data hang" test (known #1639 environmental family) passes in isolation; not a regression from this change.

Closes #1442
