### PR TITLE
feat(gate): required designer/vision recorded-evidence check for rendered HTML (ADR 0041, UI half)

### DIFF
--- a/.claude/skills/docs/ui-designer-review-loop.md
+++ b/.claude/skills/docs/ui-designer-review-loop.md
@@ -10,13 +10,21 @@ A sibling loop, the [Slides Content & Storytelling Review Loop](./slides-story-r
 - This review loop is an internal capability behind `dev-loop`; it does not introduce a second public workflow name.
 - The loop depends on the reusable harness from [UI Smoke Harness](./ui-smoke-harness.md) and the artifact contract from [UI Artifact Contract](./ui-artifact-contract.md).
 - The loop is a **consumer** of those earlier slices. It does not redefine browser capture, artifact naming, or when UI e2e is required (that is path-triggered and fail-closed — see [UI e2e scoping step](./ui-e2e-scoping-step.md)).
-- This loop is an **optional** design-review pass; it is distinct from the required, auto-scoped UI e2e gate.
+- This loop is a required, fail-closed **recorded-evidence** pass on the
+  rendered-HTML paths that already gate smoke (`docs/articles/*.html`,
+  `docs/presentations/*.html`): the review runs and records its existing
+  artifact bundle + review outcome (`ui_review_satisfied` among others), and the
+  gate blocks unless that evidence is present and the recorded outcome is the
+  satisfied state (ADR 0041, UI half — issue #1443). It is distinct from the
+  required, auto-scoped UI e2e gate. Light/spike relaxed-gate carve-outs still
+  exempt the recorded-evidence requirement.
 
 ## Purpose
 
 The designer-persona review loop turns deterministic UI artifacts into a repeatable next-iteration handoff.
 
-This contract now also defines an opt-in **vision-model** review mode behind the same `dev-loop` boundary for UI slices that request `uiReviewMode: vision`.
+For UI slices that request `uiReviewMode: vision`, this contract also defines
+the vision-model review mode behind the same `dev-loop` boundary.
 
 It exists for UI-heavy work where code correctness and smoke-test success are necessary but not sufficient to answer:
 - what visual or interaction problems remain

--- a/.claude/skills/docs/ui-validation-contract.md
+++ b/.claude/skills/docs/ui-validation-contract.md
@@ -85,5 +85,7 @@ multi-browser coverage. The criterion is only the conservative path-glob +
 registry-membership + passing-coverage check. The reusable named-state artifact
 shape and the WebKit config the shared harness builds on are documented in
 [UI Smoke Harness](./ui-smoke-harness.md) and [UI Artifact Contract](./ui-artifact-contract.md);
-the optional designer/vision review loop that consumes those artifacts is in
-[UI Designer Review Loop](./ui-designer-review-loop.md).
+the required designer/vision review loop that consumes those artifacts is in
+[UI Designer Review Loop](./ui-designer-review-loop.md) (required recorded-
+evidence pass on the rendered-HTML paths, ADR 0041 / issue #1443, distinct from
+this e2e smoke gate).

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1,6 +1,7 @@
 import { DISPOSITION, isCopilotRoundCapReached, STATE } from "./copilot-loop-state.mjs";
 import { findBlockingTitleMarkers } from "./pr-title-markers.mjs";
 import { evaluateUiE2eScoping } from "./ui-e2e-scoping.mjs";
+import { evaluateUiDesignerReviewScoping } from "./ui-designer-review-scoping.mjs";
 
 export const PR_CHECKPOINT = Object.freeze({
   DRAFT_REVIEW: "draft_review",
@@ -8,6 +9,7 @@ export const PR_CHECKPOINT = Object.freeze({
   FEEDBACK_RESOLUTION: "feedback_resolution",
   CONFLICT_RESOLUTION: "conflict_resolution",
   UI_E2E_SCOPING: "ui_e2e_scoping",
+  DESIGNER_REVIEW_SCOPING: "designer_review_scoping",
   PRE_APPROVAL_GATE_WINDOW: "pre_approval_gate_window",
   FINAL_APPROVAL_READY: "final_approval_ready",
   PRE_APPROVAL_GATE_NEEDED: "pre_approval_gate_needed",
@@ -61,6 +63,7 @@ export const PR_CHECKPOINT_ACTION = Object.freeze({
   REPORT_BLOCKED: "report_blocked",
   REPORT_DONE: "report_done",
   RUN_UI_E2E_SUITE: "run_ui_e2e_suite",
+  RECORD_DESIGNER_REVIEW: "record_designer_review",
 });
 
 function normalizeGateComment(summary = null) {
@@ -730,6 +733,11 @@ function evaluatePrGateCoordinationCore(input = {}) {
   // e2e suite passed for this head. Inclusion is path-triggered, never annotated.
   const changedFiles = Array.isArray(input.changedFiles) ? input.changedFiles : [];
   const uiE2ePassed = input.uiE2ePassed === true ? true : (input.uiE2ePassed === false ? false : null);
+  // Designer/vision recorded-evidence scoping (#1443, ADR 0041 UI half). See
+  // buildUI designer block below. Evidence reuses the loop's existing outcome +
+  // artifact-bundle record; exempt when a light/spike relaxed-gate carve-out applies.
+  const designerReviewEvidence = input.designerReviewEvidence ?? null;
+  const designerReviewExempt = input.designerReviewExempt === true;
   const refinementArtifact = input.refinementArtifact && typeof input.refinementArtifact === "object"
     ? input.refinementArtifact
     : null;
@@ -911,6 +919,48 @@ function evaluatePrGateCoordinationCore(input = {}) {
       forbiddenActions,
       nextAction: PR_CHECKPOINT_ACTION.RUN_UI_E2E_SUITE,
       reason: uiE2eScoping.reason,
+      mergeStateStatus,
+      conflictFiles,
+      refinementArtifact,
+      copilotReviewRoundCount,
+    });
+  }
+
+  // Designer/vision recorded-evidence precondition (#1443, ADR 0041 UI half).
+  // Path-triggered + fail-closed, modeled on the UI e2e scoping block above: if
+  // the PR's changed files touch a rendered artifact (docs/articles|presentations
+  // HTML), it MUST carry recorded designer/vision review evidence (the loop's
+  // existing outcome + artifact bundle) and the recorded outcome MUST be
+  // `ui_review_satisfied`. A rendered-artifact change with missing or unsatisfied
+  // recorded evidence blocks here, naming the artifact. Light/spike relaxed-gate
+  // carve-outs exempt the requirement. Non-UI changes pass through untouched.
+  const uiDesignerScoping = evaluateUiDesignerReviewScoping(changedFiles, {
+    designerReviewEvidence,
+    designerReviewExempt,
+  });
+  if (uiDesignerScoping.required && !uiDesignerScoping.satisfied) {
+    pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW]);
+    pushUnique(forbiddenActions, [
+      PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW,
+      PR_CHECKPOINT_ACTION.REQUEST_COPILOT_REVIEW,
+      PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE,
+      PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL,
+      PR_CHECKPOINT_ACTION.DECLARE_MERGE_READY,
+    ]);
+    return buildResult({
+      repo: input.repo ?? null,
+      pr: Number.isInteger(input.pr) ? input.pr : null,
+      currentHeadSha,
+      lifecycleState: effectiveLifecycleState,
+      loopDisposition: DISPOSITION.ACTION_REQUIRED,
+      gateBoundary: PR_CHECKPOINT.DESIGNER_REVIEW_SCOPING,
+      draftGateAlreadySatisfied,
+      draftGate,
+      preApprovalGate,
+      allowedNextActions,
+      forbiddenActions,
+      nextAction: PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW,
+      reason: uiDesignerScoping.reason,
       mergeStateStatus,
       conflictFiles,
       refinementArtifact,

--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -734,8 +734,9 @@ function evaluatePrGateCoordinationCore(input = {}) {
   const changedFiles = Array.isArray(input.changedFiles) ? input.changedFiles : [];
   const uiE2ePassed = input.uiE2ePassed === true ? true : (input.uiE2ePassed === false ? false : null);
   // Designer/vision recorded-evidence scoping (#1443, ADR 0041 UI half). See
-  // buildUI designer block below. Evidence reuses the loop's existing outcome +
-  // artifact-bundle record; exempt when a light/spike relaxed-gate carve-out applies.
+  // the designer-review scoping block below. Evidence reuses the loop's
+  // existing outcome + artifact-bundle record; exempt when a light/spike
+  // relaxed-gate carve-out applies.
   const designerReviewEvidence = input.designerReviewEvidence ?? null;
   const designerReviewExempt = input.designerReviewExempt === true;
   const refinementArtifact = input.refinementArtifact && typeof input.refinementArtifact === "object"

--- a/packages/core/src/loop/ui-designer-review-scoping.mjs
+++ b/packages/core/src/loop/ui-designer-review-scoping.mjs
@@ -1,0 +1,166 @@
+// UI designer/vision recorded-evidence auto-scoping — UI half of ADR 0041
+// (RFC issue #1438, decision #0041), tracked by issue #1443.
+//
+// Deterministic, path-triggered, fail-closed criterion modeled on the UI e2e
+// scoping check (./ui-e2e-scoping.mjs, issue #976): a PR that adds or modifies
+// a *rendered* HTML artifact (docs/articles/*.html or docs/presentations/*.html)
+// MUST carry recorded designer/vision review evidence for every touched
+// rendered artifact, and each recorded outcome MUST be the loop's satisfied
+// state (`ui_review_satisfied`). The check is grounded in the designer/vision
+// review loop's EXISTING outcome + artifact bundle contract — no new evidence
+// schema (ADR 0041: "reuse the designer/vision loop's existing outcome +
+// artifact contract rather than a new shape"). Accessibility facts come from
+// the captured axe.json, never judged from pixels, and no human is required by
+// default — the same autonomy the gate-evidence path already has.
+//
+// Inclusion is triggered by the changed-file set, never by annotating the PR.
+// Light-mode and spike-mode relaxed-gate carve-outs are honored: when the PR
+// is light-dispatched / under the light threshold or a spike run, the required
+// designer/vision check is exempt (the requirement is relaxed exactly like the
+// other gates), letting small and exploratory work stay cheap (ADR 0041).
+
+import { classifyRenderedArtifactPath } from "./ui-e2e-scoping.mjs";
+
+// The recorded outcome the required check treats as the satisfied state. The
+// designer/vision loop emits exactly one of these (ui-designer-review-loop.md);
+// any other recorded outcome (continue_ui_fix_loop, blocked_needs_human_decision)
+// or an absent outcome blocks.
+export const DESIGNER_REVIEW_SATISFIED_OUTCOME = "ui_review_satisfied";
+
+// The loop's existing outcome enum, re-used verbatim (no new schema).
+export const DESIGNER_REVIEW_OUTCOMES = Object.freeze([
+  DESIGNER_REVIEW_SATISFIED_OUTCOME,
+  "continue_ui_fix_loop",
+  "blocked_needs_human_decision",
+]);
+
+/**
+ * Normalize a designer/vision recorded-evidence value into an artifact-id →
+ * outcome map, tolerating both the array and keyed-object shapes.
+ *
+ * The evidence reuses the loop's existing outcome + artifact-bundle record: an
+ * entry identifies the rendered artifact by its full repo-relative path and
+ * carries the loop's `outcome`. A  record may also carry its `artifactBundle`
+ * (the loop's existing bundle) - carried through untouched, never validated to
+ * a new shape here.
+ *
+ * @param {Array<{artifact:string,outcome:string,artifactBundle?:object}>|Record<string,{outcome:string,artifactBundle?:object}>|null} evidence
+ * @returns {Map<string,{outcome:string,artifactBundle?:object}>}
+ */
+export function normalizeDesignerReviewEvidence(evidence) {
+  const byArtifact = new Map();
+  if (evidence == null) return byArtifact;
+  if (Array.isArray(evidence)) {
+    for (const entry of evidence) {
+      if (entry && typeof entry === "object" && typeof entry.artifact === "string" && entry.artifact.length > 0) {
+        byArtifact.set(entry.artifact, entry);
+      }
+    }
+    return byArtifact;
+  }
+  if (typeof evidence === "object") {
+    for (const [artifact, record] of Object.entries(evidence)) {
+      if (record && typeof record === "object") {
+        byArtifact.set(artifact, record);
+      }
+    }
+  }
+  return byArtifact;
+}
+
+/**
+ * Deterministic designer/vision recorded-evidence scoping check.
+ *
+ * @param {string[]} changedPaths - PR changed-file paths.
+ * @param {{
+ *   designerReviewEvidence?: Array|Record|null,
+ *   designerReviewExempt?: boolean,
+ * }} [opts]
+ *   designerReviewEvidence: the loop's recorded outcome + artifact bundle for
+ *     the artifacts in scope (null/undefined = "not recorded" → fails closed).
+ *   designerReviewExempt: true when a light-mode/spike relaxed-gate carve-out
+ *     applies (relaxes the requirement entirely).
+ * @returns {{
+ *   required: boolean,
+ *   artifacts: Array<{path,kind,id,registered}>,
+ *   missing: string[],
+ *   unsatisfied: string[],
+ *   satisfied: boolean,
+ *   reason: string|null,
+ * }}
+ */
+export function evaluateUiDesignerReviewScoping(changedPaths = [], {
+  designerReviewEvidence = null,
+  designerReviewExempt = false,
+} = {}) {
+  const artifacts = [];
+  const seen = new Set();
+  for (const p of Array.isArray(changedPaths) ? changedPaths : []) {
+    const descriptor = classifyRenderedArtifactPath(p);
+    if (descriptor && !seen.has(descriptor.path)) {
+      seen.add(descriptor.path);
+      artifacts.push(descriptor);
+    }
+  }
+
+  const required = artifacts.length > 0;
+  if (!required) {
+    return { required: false, artifacts, missing: [], unsatisfied: [], satisfied: true, reason: null };
+  }
+
+  // Honor the light/spike relaxed-gate carve-outs (ADR 0041): the requirement
+  // is exempt, so a rendered artifact change in those runs does not block.
+  if (designerReviewExempt === true) {
+    return {
+      required: true,
+      artifacts,
+      missing: [],
+      unsatisfied: [],
+      satisfied: true,
+      reason: "exempted_by_relaxed_gate_profile",
+    };
+  }
+
+  const byArtifact = normalizeDesignerReviewEvidence(designerReviewEvidence);
+
+  // Fail closed: any touched rendered artifact with NO recorded designer/vision
+  // evidence blocks and names itself so the fix is unambiguous (record the loop's
+  // outcome+bundle for it).
+  const missing = artifacts.filter((a) => !byArtifact.has(a.id)).map((a) => a.id);
+  if (missing.length > 0) {
+    return {
+      required: true,
+      artifacts,
+      missing,
+      unsatisfied: [],
+      satisfied: false,
+      reason:
+        `Designer/vision review evidence is required: this PR changes rendered artifact(s) ` +
+        `${missing.join(", ")} that have no recorded designer/vision review outcome + artifact bundle. ` +
+        `Run the designer/vision review loop for the artifact(s) and record its outcome so the required ` +
+        `recorded-evidence check can pass before this gate can proceed.`,
+    };
+  }
+
+  // Fail closed: recorded evidence exists but the recorded outcome is not the
+  // loop's satisfied state (continue_ui_fix_loop, blocked_needs_human_decision).
+  const unsatisfied = artifacts
+    .filter((a) => (byArtifact.get(a.id)?.outcome ?? null) !== DESIGNER_REVIEW_SATISFIED_OUTCOME)
+    .map((a) => a.id);
+  if (unsatisfied.length > 0) {
+    return {
+      required: true,
+      artifacts,
+      missing: [],
+      unsatisfied,
+      satisfied: false,
+      reason:
+        `Designer/vision review is not satisfied: this PR changes rendered artifact(s) ` +
+        `${unsatisfied.join(", ")}, but the recorded designer/vision review outcome is not ` +
+        `\`${DESIGNER_REVIEW_SATISFIED_OUTCOME}\`. Complete the designer/vision review loop until the ` +
+        `recorded outcome is the satisfied state before this gate can proceed.`,
+    };
+  }
+
+  return { required: true, artifacts, missing: [], unsatisfied: [], satisfied: true, reason: null };
+}

--- a/packages/core/src/loop/ui-designer-review-scoping.mjs
+++ b/packages/core/src/loop/ui-designer-review-scoping.mjs
@@ -97,7 +97,12 @@ export function evaluateUiDesignerReviewScoping(changedPaths = [], {
   const seen = new Set();
   for (const p of Array.isArray(changedPaths) ? changedPaths : []) {
     const descriptor = classifyRenderedArtifactPath(p);
-    if (descriptor && !seen.has(descriptor.path)) {
+    // The designer/vision recorded-evidence requirement applies ONLY to
+    // rendered HTML deliverables (docs/articles|presentations/*.html). The
+    // shared classifier also recognizes the headless viewer source path
+    // (kind "viewer"), which is a runtime script, not a rendered artifact -
+    // exclude it so a viewer-source change does not demand designer evidence.
+    if (descriptor && descriptor.kind !== "viewer" && !seen.has(descriptor.path)) {
       seen.add(descriptor.path);
       artifacts.push(descriptor);
     }

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -2515,7 +2515,7 @@ test("draft PR with a WIP title is NOT blocked by the title guard (#842 AC2 — 
 });
 
 // UI e2e auto-scoping precondition (#976) — path-triggered + fail-closed.
-test("UI e2e: rendered-artifact change with passing coverage does not block", () => {
+test("UI e2e: rendered-artifact change with passing coverage + designer evidence does not block", () => {
   const result = evaluatePrGateCoordination({
     pr: 11,
     currentHeadSha: "abc123456789",
@@ -2524,11 +2524,15 @@ test("UI e2e: rendered-artifact change with passing coverage does not block", ()
     loopDisposition: DISPOSITION.ACTION_REQUIRED,
     changedFiles: ["docs/presentations/introducing-dev-loops.html"],
     uiE2ePassed: true,
+    designerReviewEvidence: [
+      { artifact: "docs/presentations/introducing-dev-loops.html", outcome: "ui_review_satisfied" },
+    ],
     mergeable: "MERGEABLE",
     draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
     draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
   });
   assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.RUN_UI_E2E_SUITE);
+  assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW);
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
 });
 
@@ -2578,6 +2582,64 @@ test("UI e2e fail-closed: registered artifact without passing coverage blocks", 
   });
   assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_UI_E2E_SUITE);
   assert.match(result.reason, /not passed for this head/);
+});
+
+// Designer/vision recorded-evidence precondition (#1443, ADR 0041 UI half) —
+// path-triggered + fail-closed, an independent seam alongside UI e2e scoping.
+test("designer review: rendered-artifact change w/ e2e passing but NO recorded evidence blocks", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 11,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    changedFiles: ["docs/presentations/introducing-dev-loops.html"],
+    uiE2ePassed: true,
+    mergeable: "MERGEABLE",
+    draftGate: gate({ visible: true, headSha: "abc1234", verdict: "clean" }),
+    draftGateMarker: gate({ visible: true, headSha: "abc1234", verdict: "clean", contractComplete: true }),
+  });
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW);
+  assert.equal(result.gateBoundary, PR_CHECKPOINT.DESIGNER_REVIEW_SCOPING);
+  assert.match(result.reason, /Designer\/vision review evidence is required/);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.MARK_READY_FOR_REVIEW));
+});
+
+test("designer review: recorded evidence present but unsatisfied outcome blocks", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 11,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    changedFiles: ["docs/presentations/introducing-dev-loops.html"],
+    uiE2ePassed: true,
+    designerReviewEvidence: [
+      { artifact: "docs/presentations/introducing-dev-loops.html", outcome: "continue_ui_fix_loop" },
+    ],
+    mergeable: "MERGEABLE",
+  });
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW);
+  assert.match(result.reason, /not satisfied/);
+});
+
+test("designer review: light/spike relaxed-gate carve-out exempts the requirement", () => {
+  const result = evaluatePrGateCoordination({
+    pr: 11,
+    currentHeadSha: "abc123456789",
+    prDraft: true,
+    lifecycleState: STATE.PR_DRAFT,
+    loopDisposition: DISPOSITION.ACTION_REQUIRED,
+    changedFiles: ["docs/presentations/introducing-dev-loops.html"],
+    uiE2ePassed: true,
+    designerReviewExempt: true,
+    ciStatus: "success",
+    mergeable: "MERGEABLE",
+  });
+  assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW);
+  assert.notEqual(result.gateBoundary, PR_CHECKPOINT.DESIGNER_REVIEW_SCOPING);
+  // The designer carve-out lets the draft flow continue to its normal next action.
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE);
 });
 
 test("preApproval requireCi:false + zero-check CI (none) reaches the pre_approval boundary instead of waiting", () => {

--- a/packages/core/test/ui-designer-review-scoping.test.mjs
+++ b/packages/core/test/ui-designer-review-scoping.test.mjs
@@ -102,3 +102,24 @@ test("multi-artifact: every touched rendered artifact must carry satisfied evide
   assert.equal(r.satisfied, false);
   assert.deepEqual(r.missing, ["docs/articles/introducing-dev-loops.html"]);
 });
+
+test("viewer model: source-only change does not require designer evidence (#1443 regression)", () => {
+  // The shared classifier recognizes the headless viewer source as a "viewer"
+  // artifact; the designer requirement applies only to rendered HTML, so a
+  // viewer-source-only change must not demand designer/vision evidence.
+  const r = evaluateUiDesignerReviewScoping(["scripts/loop/inspect-run-viewer.mjs", "README.md"]);
+  assert.equal(r.required, false);
+  assert.equal(r.satisfied, true);
+  assert.deepEqual(r.artifacts, []);
+});
+
+test("viewer model: viewer + rendered artifact change still requires designer evidence for the rendered one", () => {
+  const r = evaluateUiDesignerReviewScoping(
+    ["scripts/loop/inspect-run-viewer.mjs", "docs/articles/new-page.html"],
+    { designerReviewEvidence: null },
+  );
+  assert.equal(r.required, true);
+  assert.equal(r.satisfied, false);
+  assert.deepEqual(r.missing, ["docs/articles/new-page.html"]);
+  assert.deepEqual(r.artifacts.map((a) => a.kind), ["article"]);
+});

--- a/packages/core/test/ui-designer-review-scoping.test.mjs
+++ b/packages/core/test/ui-designer-review-scoping.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateUiDesignerReviewScoping,
+  normalizeDesignerReviewEvidence,
+  DESIGNER_REVIEW_SATISFIED_OUTCOME,
+  DESIGNER_REVIEW_OUTCOMES,
+} from "../src/loop/ui-designer-review-scoping.mjs";
+
+test("evidence shape reuses the loop's existing outcome + bundle (no new schema)", () => {
+  const record = { artifact: "docs/presentations/introducing-dev-loops.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME };
+  const map = normalizeDesignerReviewEvidence([record]);
+  assert.equal(map.get(record.artifact).outcome, DESIGNER_REVIEW_SATISFIED_OUTCOME);
+  // The outcome enum is the loop's existing one, byte-for-byte.
+  assert.deepEqual(
+    [...DESIGNER_REVIEW_OUTCOMES].sort(),
+    ["blocked_needs_human_decision", "continue_ui_fix_loop", "ui_review_satisfied"].sort(),
+  );
+});
+
+test("keyed-object evidence shape normalizes identically", () => {
+  const map = normalizeDesignerReviewEvidence({
+    "docs/articles/introducing-dev-loops.html": { outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME },
+  });
+  assert.equal(map.get("docs/articles/introducing-dev-loops.html").outcome, DESIGNER_REVIEW_SATISFIED_OUTCOME);
+});
+
+test("null/absent evidence maps to empty (fails closed later)", () => {
+  assert.equal(normalizeDesignerReviewEvidence(null).size, 0);
+  assert.equal(normalizeDesignerReviewEvidence(undefined).size, 0);
+});
+
+test("trigger: a rendered-artifact change with satisfied recorded evidence passes", () => {
+  const r = evaluateUiDesignerReviewScoping(
+    ["docs/presentations/introducing-dev-loops.html", "README.md"],
+    {
+      designerReviewEvidence: [
+        { artifact: "docs/presentations/introducing-dev-loops.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME },
+      ],
+    },
+  );
+  assert.equal(r.required, true);
+  assert.equal(r.satisfied, true);
+  assert.equal(r.reason, null);
+});
+
+test("negative: a non-rendered change does not require designer review evidence", () => {
+  const r = evaluateUiDesignerReviewScoping(["packages/core/src/loop/x.mjs", "README.md"]);
+  assert.equal(r.required, false);
+  assert.equal(r.satisfied, true);
+});
+
+test("fail-closed: rendered-artifact change with no recorded evidence blocks, naming the artifact", () => {
+  const r = evaluateUiDesignerReviewScoping(["docs/articles/brand-new-page.html"]);
+  assert.equal(r.required, true);
+  assert.equal(r.satisfied, false);
+  assert.deepEqual(r.missing, ["docs/articles/brand-new-page.html"]);
+  assert.match(r.reason, /docs\/articles\/brand-new-page\.html/);
+  assert.match(r.reason, /no recorded designer\/vision review/);
+});
+
+test("fail-closed: recorded evidence present but unsatisfied outcome blocks", () => {
+  const r = evaluateUiDesignerReviewScoping(["docs/presentations/introducing-dev-loops.html"], {
+    designerReviewEvidence: [
+      { artifact: "docs/presentations/introducing-dev-loops.html", outcome: "continue_ui_fix_loop" },
+    ],
+  });
+  assert.equal(r.required, true);
+  assert.equal(r.satisfied, false);
+  assert.deepEqual(r.unsatisfied, ["docs/presentations/introducing-dev-loops.html"]);
+  assert.match(r.reason, /ui_review_satisfied/);
+});
+
+test("fail-closed: recorded outcome absent on an otherwise-matched record blocks", () => {
+  const r = evaluateUiDesignerReviewScoping(["docs/articles/introducing-dev-loops.html"], {
+    designerReviewEvidence: [{ artifact: "docs/articles/introducing-dev-loops.html", outcome: undefined }],
+  });
+  assert.equal(r.satisfied, false);
+  assert.deepEqual(r.unsatisfied, ["docs/articles/introducing-dev-loops.html"]);
+});
+
+test("carve-out: light/spike relaxed-gate profile exempts the requirement", () => {
+  const r = evaluateUiDesignerReviewScoping(["docs/presentations/brand-new-deck.html"], {
+    designerReviewEvidence: null,
+    designerReviewExempt: true,
+  });
+  assert.equal(r.required, true);
+  assert.equal(r.satisfied, true);
+  assert.equal(r.reason, "exempted_by_relaxed_gate_profile");
+});
+
+test("multi-artifact: every touched rendered artifact must carry satisfied evidence", () => {
+  const r = evaluateUiDesignerReviewScoping(
+    ["docs/presentations/introducing-dev-loops.html", "docs/articles/introducing-dev-loops.html"],
+    {
+      designerReviewEvidence: [
+        { artifact: "docs/presentations/introducing-dev-loops.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME },
+      ],
+    },
+  );
+  assert.equal(r.satisfied, false);
+  assert.deepEqual(r.missing, ["docs/articles/introducing-dev-loops.html"]);
+});

--- a/scripts/loop/_handoff-contract.mjs
+++ b/scripts/loop/_handoff-contract.mjs
@@ -29,6 +29,7 @@ const SUBAGENT_ACTIONS = new Set([
   "rerequest_review",
   "run_pre_approval",
   "run_ui_e2e",
+  "record_designer_review",
 ]);
 function normalizeContractValue(value) {
   return typeof value === "string" ? value.trim().toLowerCase() : null;

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -11,7 +11,7 @@ import {
   summarizeCopilotReviews,
 } from "../_core-helpers.mjs";
 import { parsePositiveInteger, parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
-import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveRefinement, resolveRefinementConfig } from "@dev-loops/core/config";
+import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveGateConfig, resolveLightMode, resolveRefinement, resolveRefinementConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildSnapshotFromPrFacts, interpretLoopState, isCopilotRoundCapReached, summarizeLoopInterpretation } from "@dev-loops/core/loop/copilot-loop-state";
 import { evaluatePrGateCoordination, isRoundCapReachedCleanGrant, PR_CHECKPOINT, PR_CHECKPOINT_ACTION, REFINEMENT_ARTIFACT_SPEC_SOURCE } from "@dev-loops/core/loop/pr-gate-coordination";
@@ -269,6 +269,39 @@ export function deriveUiE2ePassed(prData, checkNames = UI_E2E_CHECK_NAMES) {
     // SKIPPED = "not applicable to this run" (e.g. viewer-smoke when no viewer files changed) — not a failure.
     return conclusion === "SUCCESS" || conclusion === "SKIPPED" || state === "SUCCESS" || state === "SKIPPED";
   });
+}
+
+// Designer/vision recorded evidence for the touched rendered artifacts (#1443,
+// ADR 0041 UI half). Reuses the loop's existing outcome + artifact-bundle
+// record. The evidence source is the loop's recorded review outcome; absent any
+// recorded record this returns null, which the evaluator treats as missing and
+// fails closed for a rendered-artifact change (the required evidence must be
+// recorded). Light/spike carve-outs (designerReviewExempt) relax this.
+//
+// NOTE: the designer/vision loop currently records its outcome in its review
+// artifact, not a gate-detectable marker; this derivation defaults to null so
+// a rendered-artifact change without recorded evidence blocks. When the loop
+// gains a deterministic recorder, surface it here.
+export function deriveUiDesignerReviewEvidence(context, changedFiles) {
+  // User-injected recorded evidence (e.g. --designer-review-evidence <p>)
+  // would surface here; no recorder exists yet, so return null (fails closed).
+  return null;
+}
+
+// Whether a light/spike relaxed-gate carve-out exempts the required
+// designer/vision recorded-evidence check (#1443). Honored exactly like the
+// existing relaxed-gate carve-outs (resolveGateDispatchMode): light-dispatched,
+// spike, or under the configured light-mode threshold exempts.
+export function deriveUiDesignerReviewExempt({
+  lightweight = false,
+  spike = false,
+  changedFiles = [],
+  config = {},
+} = {}) {
+  if (lightweight || spike) return true;
+  const threshold = resolveLightMode(config);
+  if (!threshold) return false;
+  return Array.isArray(changedFiles) && changedFiles.length <= threshold.maxFiles;
 }
 
 // Ordered, de-duplicated list of ALL closing-referenced issue numbers for a PR.
@@ -786,6 +819,7 @@ export function buildGateCoordinationEvaluatorInput({
   draftGateConfig,
   preApprovalGateConfig,
   postConvergenceSignificantChange,
+  designerReviewExempt = false,
 }) {
   return {
     repo: context.repo,
@@ -801,6 +835,10 @@ export function buildGateCoordinationEvaluatorInput({
     // UI e2e auto-scoping (#976): path-triggered + fail-closed precondition.
     changedFiles: extractChangedFiles(context.prData),
     uiE2ePassed: deriveUiE2ePassed(context.prData),
+    // Designer/vision recorded-evidence scoping (#1443, ADR 0041 UI half):
+    // path-triggered + fail-closed, modeled on the UI e2e precondition above.
+    designerReviewEvidence: deriveUiDesignerReviewEvidence(context, extractChangedFiles(context.prData)),
+    designerReviewExempt,
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
     ciStatus: context.snapshot?.ciStatus ?? null,
@@ -869,6 +907,11 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     draftGateConfig,
     preApprovalGateConfig,
     postConvergenceSignificantChange,
+    designerReviewExempt: deriveUiDesignerReviewExempt({
+      lightweight: options.lightweight,
+      changedFiles: extractChangedFiles(context.prData),
+      config,
+    }),
   }));
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -324,23 +324,56 @@ export async function loadRecordedDesignerEvidence(evidencePath) {
     return null;
   }
   const text = await readFile(evidencePath, "utf8");
-  return JSON.parse(text);
+  const parsed = JSON.parse(text);
+  // Reject a JSON value whose type cannot describe recorded evidence. A bare
+  // string/number/boolean parses fine but would surface downstream as a
+  // misleading "missing evidence" gate failure; report the malformed type
+  // directly instead of silently falling through to a confusing verdict.
+  if (parsed !== null && typeof parsed !== "object") {
+    throw new Error(
+      `--designer-review-evidence file must contain a JSON object or array, got ${typeof parsed}`,
+    );
+  }
+  return parsed;
+}
+
+// Total changed lines across a PR's changed files (additions + deletions),
+// mirroring the canonical light-mode line dimension (resolveGateDispatchMode's
+// scope.linesChanged). Returns 0 when no line data is available.
+export function countPrChangedLines(prData) {
+  const files = Array.isArray(prData?.files) ? prData.files : [];
+  let total = 0;
+  for (const f of files) {
+    const additions = Number(f?.additions);
+    const deletions = Number(f?.deletions);
+    total += (Number.isFinite(additions) ? additions : 0) + (Number.isFinite(deletions) ? deletions : 0);
+  }
+  return total;
 }
 
 // Whether a light/spike relaxed-gate carve-out exempts the required
-// designer/vision recorded-evidence check (#1443). Honored exactly like the
-// existing relaxed-gate carve-outs (resolveGateDispatchMode): light-dispatched,
-// spike, or under the configured light-mode threshold exempts.
+// designer/vision recorded-evidence check (#1443). Mirrors the existing
+// relaxed-gate carve-outs (resolveGateDispatchMode): light-dispatched, spike,
+// or a change under the configured light-mode threshold (files AND lines)
+// exempts. When changed-lines data is unavailable the line dimension is
+// treated as within threshold, preserving files-only behavior for callers
+// that lack it.
 export function deriveUiDesignerReviewExempt({
   lightweight = false,
   spike = false,
   changedFiles = [],
+  changedLines,
   config = {},
 } = {}) {
   if (lightweight || spike) return true;
   const threshold = resolveLightMode(config);
   if (!threshold) return false;
-  return Array.isArray(changedFiles) && changedFiles.length <= threshold.maxFiles;
+  const filesExempt = Array.isArray(changedFiles) && changedFiles.length <= threshold.maxFiles;
+  if (!filesExempt) return false;
+  if (typeof changedLines === "number" && Number.isFinite(changedLines)) {
+    return changedLines <= threshold.maxLines;
+  }
+  return true;
 }
 
 // Ordered, de-duplicated list of ALL closing-referenced issue numbers for a PR.
@@ -959,6 +992,7 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
       lightweight: options.lightweight,
       spike: options.spike === true,
       changedFiles: extractChangedFiles(context.prData),
+      changedLines: countPrChangedLines(context.prData),
       config,
     }),
     designerReviewEvidence,

--- a/scripts/loop/detect-pr-gate-coordination-state.mjs
+++ b/scripts/loop/detect-pr-gate-coordination-state.mjs
@@ -27,6 +27,7 @@ import { resolveRepoRoot } from "./_repo-root-resolver.mjs";
 import { releaseAsyncRunnerOwnership } from "./_pr-runner-coordination.mjs";
 import { fetchCopilotRequested, resolveCopilotReviewRequestStatus } from "./_copilot-review-request-status.mjs";
 import { parseArgs } from "node:util";
+import { readFile } from "node:fs/promises";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 // Gate-coordination terminal stop actions where the dev-loop run is completing or
 // stopping (success OR stop). The runner-coordination lock is auto-released at these
@@ -61,6 +62,15 @@ Optional:
                   refinement.maxCopilotRounds) instead of using
                   refinement.maxCopilotRounds alone. refinement.maxCopilotRounds:
                   0 still disables Copilot rounds even with --lightweight.
+  --spike          This PR is a spike run: relax the required designer/vision
+                  recorded-evidence check like the other relaxed-gate
+                  carve-outs (#1443).
+  --designer-review-evidence <path>
+                  Path to the designer/vision loop's recorded evidence JSON
+                  (the existing outcome + artifact bundle, no new schema).
+                  Surfaces the recorded evidence so AC1's pass branch is
+                  reachable (#1443) — a rendered-HTML diff with satisfied
+                  recorded evidence passes; without recorded evidence it blocks.
   --expected-issue <n>  Declare the tracker issue this PR is expected to close
                   (ARTIFACT-LIGHTWEIGHT-BODY-INVARIANTS, #1628). For a draft PR
                   with no linked issue this switches the body-spec validation
@@ -127,6 +137,8 @@ export function parseDetectPrGateCoordinationCliArgs(argv) {
     pr: undefined,
     lightweight: false,
     expectedIssue: undefined,
+    designerReviewEvidence: undefined,
+    spike: false,
   };
   const { tokens } = parseArgs({
     args: [...argv],
@@ -135,7 +147,9 @@ export function parseDetectPrGateCoordinationCliArgs(argv) {
       repo: { type: "string" },
       pr: { type: "string" },
       lightweight: { type: "boolean" },
+      spike: { type: "boolean" },
       "expected-issue": { type: "string" },
+      "designer-review-evidence": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
     allowPositionals: true,
@@ -165,8 +179,16 @@ export function parseDetectPrGateCoordinationCliArgs(argv) {
       options.lightweight = true;
       continue;
     }
+    if (token.name === "spike") {
+      options.spike = true;
+      continue;
+    }
     if (token.name === "expected-issue") {
       options.expectedIssue = parsePositiveInteger(requireTokenValue(token, parseError), "--expected-issue", parseError);
+      continue;
+    }
+    if (token.name === "designer-review-evidence") {
+      options.designerReviewEvidence = requireTokenValue(token, parseError).trim();
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -282,10 +304,27 @@ export function deriveUiE2ePassed(prData, checkNames = UI_E2E_CHECK_NAMES) {
 // artifact, not a gate-detectable marker; this derivation defaults to null so
 // a rendered-artifact change without recorded evidence blocks. When the loop
 // gains a deterministic recorder, surface it here.
-export function deriveUiDesignerReviewEvidence(context, changedFiles) {
-  // User-injected recorded evidence (e.g. --designer-review-evidence <p>)
-  // would surface here; no recorder exists yet, so return null (fails closed).
-  return null;
+export function deriveUiDesignerReviewEvidence(recordedEvidence, changedFiles) {
+  // Designer/vision recorded-evidence read seam (#1443, ADR 0041 UI half):
+  // the loop records its outcome + artifact bundle, and the gate consumes that
+  // recorded evidence here via the --designer-review-evidence read seam. Absent
+  // recorded evidence, returns null (fails closed) so a rendered-artifact change
+  // without recorded evidence blocks; when recorded evidence is supplied with a
+  // satisfied recorded outcome, the required check passes (AC1). changedFiles is
+  // retained for forward-compat with a deterministic per-artifact recorder.
+  return recordedEvidence ?? null;
+}
+
+// Load the loop's recorded designer/vision evidence from a JSON file passed via
+// the --designer-review-evidence read seam. Returns null when the path is absent
+// (nothing recorded -> the evaluator fails closed); throws on an unreadable or
+// malformed file rather than silently treating it as absent.
+export async function loadRecordedDesignerEvidence(evidencePath) {
+  if (!evidencePath || typeof evidencePath !== "string" || evidencePath.length === 0) {
+    return null;
+  }
+  const text = await readFile(evidencePath, "utf8");
+  return JSON.parse(text);
 }
 
 // Whether a light/spike relaxed-gate carve-out exempts the required
@@ -820,6 +859,7 @@ export function buildGateCoordinationEvaluatorInput({
   preApprovalGateConfig,
   postConvergenceSignificantChange,
   designerReviewExempt = false,
+  designerReviewEvidence = null,
 }) {
   return {
     repo: context.repo,
@@ -837,7 +877,9 @@ export function buildGateCoordinationEvaluatorInput({
     uiE2ePassed: deriveUiE2ePassed(context.prData),
     // Designer/vision recorded-evidence scoping (#1443, ADR 0041 UI half):
     // path-triggered + fail-closed, modeled on the UI e2e precondition above.
-    designerReviewEvidence: deriveUiDesignerReviewEvidence(context, extractChangedFiles(context.prData)),
+    // The recorded evidence flows through the --designer-review-evidence read
+    // seam (AC1's reachable pass branch); absent it, fails closed (null).
+    designerReviewEvidence: deriveUiDesignerReviewEvidence(designerReviewEvidence ?? null, extractChangedFiles(context.prData)),
     designerReviewExempt,
     lifecycleState: context.interpretation.state,
     loopDisposition: context.disposition.loopDisposition,
@@ -889,6 +931,12 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     copilotReviewRoundCount: context.snapshot?.copilotReviewRoundCount,
     maxCopilotRounds,
   });
+  // Designer/vision recorded-evidence read seam (#1443, ADR 0041 UI half):
+  // load the loop's recorded evidence (if the operator supplied
+  // --designer-review-evidence) so AC1's pass branch is reachable end-to-end;
+  // absent it, the evaluator fails closed (a rendered-artifact change blocks
+  // until recorded evidence is supplied).
+  const designerReviewEvidence = await loadRecordedDesignerEvidence(options.designerReviewEvidence);
   const postConvergenceSignificantChange = await detectPostConvergenceSignificantChange(
     {
       repo: context.repo,
@@ -909,9 +957,11 @@ export async function detectPrGateCoordinationState(options, runtime = {}) {
     postConvergenceSignificantChange,
     designerReviewExempt: deriveUiDesignerReviewExempt({
       lightweight: options.lightweight,
+      spike: options.spike === true,
       changedFiles: extractChangedFiles(context.prData),
       config,
     }),
+    designerReviewEvidence,
   }));
   // Copilot review request guard (#613): When Copilot has reviewed the PR
   // but no formal review request was made, block pre-approval gate entry.

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -17,8 +17,12 @@ import { listOpenPrs } from "./_loop-pr-aggregation.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 export { listOpenPrs };
-const USAGE = `Usage: run-conductor-cycle.mjs --repo <owner/name>
+const USAGE = `Usage: run-conductor-cycle.mjs --repo <owner/name> [--designer-review-evidence <path>]
 Poll all open PRs, detect state, and output an ordered action queue.
+
+--designer-review-evidence <path>  Optional JSON file of the loop's recorded
+  designer/vision review evidence (rendered-HTML gate, ADR 0041 UI half);
+  absent, a rendered-artifact change fails closed until evidence is supplied.
 
 ${JQ_OUTPUT_USAGE}`.trim();
 export const CHECKPOINT_ACTION_TO_CONDUCTOR_ACTION = Object.freeze({
@@ -80,12 +84,14 @@ export function parseCliArgs(argv) {
   const options = {
     help: false,
     repo: undefined,
+    designerReviewEvidence: undefined,
   };
   const { tokens } = parseArgs({
     args: [...argv],
     options: {
       help: { type: "boolean", short: "h" },
       repo: { type: "string" },
+      "designer-review-evidence": { type: "string" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
     allowPositionals: true,
@@ -105,6 +111,10 @@ export function parseCliArgs(argv) {
     }
     if (token.name === "repo") {
       options.repo = requireTokenValue(token, parseError).trim();
+      continue;
+    }
+    if (token.name === "designer-review-evidence") {
+      options.designerReviewEvidence = requireTokenValue(token, parseError).trim();
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -130,11 +140,12 @@ export async function detectPrState(
     detectGateImpl = detectPrGateCoordinationState,
     detectSnapshotImpl = autoDetectSnapshot,
     autonomyStopAt = ["merge"],
+    designerReviewEvidence,
   },
 ) {
   try {
     const gateState = await detectGateImpl(
-      { repo, pr: pr.number },
+      { repo, pr: pr.number, designerReviewEvidence },
       { env, ghCommand, repoRoot },
     );
     let snapshot = null;
@@ -251,7 +262,7 @@ export function buildSummary(actions) {
   return summary;
 }
 export async function runConductorCycle(
-  { repo, autonomyStopAt, gateConfig },
+  { repo, autonomyStopAt, gateConfig, designerReviewEvidence },
   {
     env = process.env,
     ghCommand = "gh",
@@ -270,6 +281,7 @@ export async function runConductorCycle(
       ghCommand,
       repoRoot,
       autonomyStopAt: stopAt,
+      designerReviewEvidence,
     });
     detectionResults.push(result);
   }

--- a/scripts/loop/run-conductor-cycle.mjs
+++ b/scripts/loop/run-conductor-cycle.mjs
@@ -36,11 +36,16 @@ export const CHECKPOINT_ACTION_TO_CONDUCTOR_ACTION = Object.freeze({
   [PR_CHECKPOINT_ACTION.AWAIT_FINAL_HUMAN_APPROVAL]: "await_approval",
   [PR_CHECKPOINT_ACTION.RESOLVE_MERGE_CONFLICTS]: "resolve_conflicts",
   [PR_CHECKPOINT_ACTION.RUN_UI_E2E_SUITE]: "run_ui_e2e",
+  [PR_CHECKPOINT_ACTION.RECORD_DESIGNER_REVIEW]: "record_designer_review",
   [PR_CHECKPOINT_ACTION.REPORT_BLOCKED]: "blocked",
   [PR_CHECKPOINT_ACTION.REPORT_DONE]: "done",
 });
 export const ACTION_PRIORITY = Object.freeze({
   merge: 100,
+  // Designer/vision recorded-evidence scoping fix work (#1443): a path-triggered
+  // fail-closed precondition, surfaced just under the UI e2e carve so recorded
+  // evidence is present before the gate proceeds.
+  record_designer_review: 94,
   // UI e2e auto-scoping fix work (#976): a path-triggered, fail-closed
   // precondition — surface it ahead of feedback/draft work so the rendered
   // artifact gets registered + covered before the gate proceeds.

--- a/skills/docs/ui-designer-review-loop.md
+++ b/skills/docs/ui-designer-review-loop.md
@@ -10,13 +10,21 @@ A sibling loop, the [Slides Content & Storytelling Review Loop](./slides-story-r
 - This review loop is an internal capability behind `dev-loop`; it does not introduce a second public workflow name.
 - The loop depends on the reusable harness from [UI Smoke Harness](./ui-smoke-harness.md) and the artifact contract from [UI Artifact Contract](./ui-artifact-contract.md).
 - The loop is a **consumer** of those earlier slices. It does not redefine browser capture, artifact naming, or when UI e2e is required (that is path-triggered and fail-closed — see [UI e2e scoping step](./ui-e2e-scoping-step.md)).
-- This loop is an **optional** design-review pass; it is distinct from the required, auto-scoped UI e2e gate.
+- This loop is a required, fail-closed **recorded-evidence** pass on the
+  rendered-HTML paths that already gate smoke (`docs/articles/*.html`,
+  `docs/presentations/*.html`): the review runs and records its existing
+  artifact bundle + review outcome (`ui_review_satisfied` among others), and the
+  gate blocks unless that evidence is present and the recorded outcome is the
+  satisfied state (ADR 0041, UI half — issue #1443). It is distinct from the
+  required, auto-scoped UI e2e gate. Light/spike relaxed-gate carve-outs still
+  exempt the recorded-evidence requirement.
 
 ## Purpose
 
 The designer-persona review loop turns deterministic UI artifacts into a repeatable next-iteration handoff.
 
-This contract now also defines an opt-in **vision-model** review mode behind the same `dev-loop` boundary for UI slices that request `uiReviewMode: vision`.
+For UI slices that request `uiReviewMode: vision`, this contract also defines
+the vision-model review mode behind the same `dev-loop` boundary.
 
 It exists for UI-heavy work where code correctness and smoke-test success are necessary but not sufficient to answer:
 - what visual or interaction problems remain

--- a/skills/docs/ui-validation-contract.md
+++ b/skills/docs/ui-validation-contract.md
@@ -85,5 +85,7 @@ multi-browser coverage. The criterion is only the conservative path-glob +
 registry-membership + passing-coverage check. The reusable named-state artifact
 shape and the WebKit config the shared harness builds on are documented in
 [UI Smoke Harness](./ui-smoke-harness.md) and [UI Artifact Contract](./ui-artifact-contract.md);
-the optional designer/vision review loop that consumes those artifacts is in
-[UI Designer Review Loop](./ui-designer-review-loop.md).
+the required designer/vision review loop that consumes those artifacts is in
+[UI Designer Review Loop](./ui-designer-review-loop.md) (required recorded-
+evidence pass on the rendered-HTML paths, ADR 0041 / issue #1443, distinct from
+this e2e smoke gate).

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -6,7 +6,7 @@ import test, { describe, it } from "node:test";
 import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
-import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput, resolvePostConvergenceReviewSuppressed, TERMINAL_RUNNER_RELEASE_ACTIONS } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, deriveUiDesignerReviewExempt, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput, resolvePostConvergenceReviewSuppressed, TERMINAL_RUNNER_RELEASE_ACTIONS } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 import { writeSuppressionMarker } from "../../scripts/loop/_post-convergence-review-suppression.mjs";
 import { isRoundCapReachedCleanGrant } from "@dev-loops/core/loop/pr-gate-coordination";
 import { emitResult } from "../../scripts/lib/jq-output.mjs";
@@ -2048,6 +2048,21 @@ test("deriveUiE2ePassed reads UI e2e checks from statusCheckRollup", () => {
     true,
     "SKIPPED check should not block the gate",
   );
+});
+
+// #1443: designer/vision recorded-evidence carve-out derives from light/spike relaxed-gate profiles.
+test("deriveUiDesignerReviewExempt honors light/spike relaxed-gate carve-outs", () => {
+  // Light-dispatched → exempt regardless of scope.
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: true, changedFiles: ["a"], config: {} }), true);
+  // Spike → exempt.
+  assert.equal(deriveUiDesignerReviewExempt({ spike: true, changedFiles: ["a"], config: {} }), true);
+  // Light mode disabled (no threshold) → not exempt.
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a"], config: {} }), false);
+  // Under configured light threshold → exempt.
+  const config = { localImplementation: { lightMode: { enabled: true, maxFiles: 2, maxLines: 20 } } };
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], config }), true);
+  // Over threshold → not exempt.
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b", "c"], config }), false);
 });
 
 // #1472: buildGateCoordinationEvaluatorInput is the exact function

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -6,12 +6,13 @@ import test, { describe, it } from "node:test";
 import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
-import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, deriveUiDesignerReviewExempt, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput, resolvePostConvergenceReviewSuppressed, TERMINAL_RUNNER_RELEASE_ACTIONS } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
+import { detectPrGateCoordinationState, parseDetectPrGateCoordinationCliArgs, fetchPrFactsWithSettledMergeable, parseGitStatusConflictFiles, extractChangedFiles, deriveUiE2ePassed, deriveUiDesignerReviewExempt, deriveUiDesignerReviewEvidence, loadRecordedDesignerEvidence, loadRefinementArtifact, resolveRoundCapCleanFallback, buildGateCoordinationEvaluatorInput, resolvePostConvergenceReviewSuppressed, TERMINAL_RUNNER_RELEASE_ACTIONS } from "../../scripts/loop/detect-pr-gate-coordination-state.mjs";
 import { writeSuppressionMarker } from "../../scripts/loop/_post-convergence-review-suppression.mjs";
 import { isRoundCapReachedCleanGrant } from "@dev-loops/core/loop/pr-gate-coordination";
 import { emitResult } from "../../scripts/lib/jq-output.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 import { PR_CHECKPOINT, PR_CHECKPOINT_ACTION, shouldGuardCopilotReviewRequest } from "@dev-loops/core/loop/pr-gate-coordination";
+import { evaluateUiDesignerReviewScoping, DESIGNER_REVIEW_SATISFIED_OUTCOME } from "../../packages/core/src/loop/ui-designer-review-scoping.mjs";
 import { buildPlanFilePromotionMarker, buildPromotionPrBody } from "@dev-loops/core/loop/plan-file-promote-contract";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
@@ -2063,6 +2064,96 @@ test("deriveUiDesignerReviewExempt honors light/spike relaxed-gate carve-outs", 
   assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], config }), true);
   // Over threshold → not exempt.
   assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b", "c"], config }), false);
+});
+
+// #1443: the designer evidence read seam passes recorded evidence through and
+// fails closed (null) when no recorded evidence is supplied.
+test("deriveUiDesignerReviewEvidence surfaces recorded evidence and fails closed when absent (#1443)", () => {
+  const evidence = [{ artifact: "docs/articles/foo.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME }];
+  assert.equal(deriveUiDesignerReviewEvidence(evidence, ["docs/articles/foo.html"]), evidence);
+  assert.equal(deriveUiDesignerReviewEvidence(null, ["docs/articles/foo.html"]), null);
+  assert.equal(deriveUiDesignerReviewEvidence(undefined, []), null);
+});
+
+// #1443: the CLI read-seam flags parse into the detector options.
+test("parseDetectPrGateCoordinationCliArgs parses --designer-review-evidence and --spike (#1443)", () => {
+  const opts = parseDetectPrGateCoordinationCliArgs([
+    "--repo", "owner/repo", "--pr", "1740",
+    "--spike",
+    "--designer-review-evidence", "tmp/evidence.json",
+  ]);
+  assert.equal(opts.spike, true);
+  assert.equal(opts.designerReviewEvidence, "tmp/evidence.json");
+});
+
+// #1443 AC1 end-to-end: a rendered-HTML diff with recorded designer/vision
+// evidence (satisfied outcome) PASSES the required recorded-evidence check
+// through the builder wiring (the reachable pass branch), while one without
+// evidence fails closed.
+test("AC1: rendered-HTML diff with satisfied recorded evidence passes the builder, without it blocks (#1443)", () => {
+  const context = {
+    repo: "owner/repo",
+    pr: 1740,
+    currentHeadSha: "021ac63deadbeef",
+    interpretation: { state: "pr_draft" },
+    disposition: { loopDisposition: "action_required" },
+    snapshot: {},
+    gateEvidence: { draftGate: {}, preApprovalGate: {}, draftGateMarker: {}, preApprovalGateMarker: {} },
+    prData: {
+      isDraft: true,
+      state: "OPEN",
+      title: "t",
+      files: [{ path: "docs/articles/foo.html" }],
+      closingIssuesReferences: [],
+    },
+  };
+  const evidence = [{ artifact: "docs/articles/foo.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME }];
+  const input = buildGateCoordinationEvaluatorInput({
+    context,
+    maxCopilotRounds: 2,
+    draftGateConfig: {},
+    preApprovalGateConfig: {},
+    postConvergenceSignificantChange: false,
+    designerReviewEvidence: evidence,
+  });
+  assert.deepEqual(input.designerReviewEvidence, evidence);
+  const scoping = evaluateUiDesignerReviewScoping(extractChangedFiles(context.prData), {
+    designerReviewEvidence: input.designerReviewEvidence,
+    designerReviewExempt: false,
+  });
+  assert.equal(scoping.required, true);
+  assert.equal(scoping.satisfied, true);
+  assert.equal(scoping.missing.length, 0);
+  assert.equal(scoping.unsatisfied.length, 0);
+
+  // Fail-closed path: no recorded evidence -> blocks naming the artifact.
+  const blocked = buildGateCoordinationEvaluatorInput({
+    context,
+    maxCopilotRounds: 2,
+    draftGateConfig: {},
+    preApprovalGateConfig: {},
+    postConvergenceSignificantChange: false,
+    designerReviewEvidence: null,
+  });
+  const blockedScoping = evaluateUiDesignerReviewScoping(extractChangedFiles(context.prData), {
+    designerReviewEvidence: blocked.designerReviewEvidence,
+    designerReviewExempt: false,
+  });
+  assert.equal(blockedScoping.satisfied, false);
+  assert.ok(blockedScoping.missing.includes("docs/articles/foo.html"));
+});
+
+// #1443: loadRecordedDesignerEvidence reads a recorded evidence file and
+// returns null when no path is supplied.
+test("loadRecordedDesignerEvidence reads a recorded evidence file / null when absent (#1443)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "dr-1443-"));
+  const evidencePath = path.join(dir, "evidence.json");
+  const evidence = [{ artifact: "docs/articles/foo.html", outcome: DESIGNER_REVIEW_SATISFIED_OUTCOME }];
+  await writeFile(evidencePath, JSON.stringify(evidence));
+  assert.deepEqual(await loadRecordedDesignerEvidence(evidencePath), evidence);
+  assert.equal(await loadRecordedDesignerEvidence(undefined), null);
+  assert.equal(await loadRecordedDesignerEvidence(""), null);
+  await rm(dir, { recursive: true, force: true });
 });
 
 // #1472: buildGateCoordinationEvaluatorInput is the exact function

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -2062,8 +2062,14 @@ test("deriveUiDesignerReviewExempt honors light/spike relaxed-gate carve-outs", 
   // Under configured light threshold → exempt.
   const config = { localImplementation: { lightMode: { enabled: true, maxFiles: 2, maxLines: 20 } } };
   assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], config }), true);
-  // Over threshold → not exempt.
+  // Over file threshold → not exempt.
   assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b", "c"], config }), false);
+  // Line threshold honored when line data is supplied (mirrors the canonical
+  // light-mode rule's maxLines dimension).
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], changedLines: 15, config }), true);
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], changedLines: 25, config }), false);
+  // Files-only callers (no line data) keep the files-only behavior.
+  assert.equal(deriveUiDesignerReviewExempt({ lightweight: false, changedFiles: ["a", "b"], config }), true);
 });
 
 // #1443: the designer evidence read seam passes recorded evidence through and
@@ -2153,6 +2159,12 @@ test("loadRecordedDesignerEvidence reads a recorded evidence file / null when ab
   assert.deepEqual(await loadRecordedDesignerEvidence(evidencePath), evidence);
   assert.equal(await loadRecordedDesignerEvidence(undefined), null);
   assert.equal(await loadRecordedDesignerEvidence(""), null);
+  // A JSON value whose type cannot describe recorded evidence (e.g. a bare
+  // string) must throw a clear error, not surface a misleading "missing
+  // evidence" verdict downstream.
+  const badPath = path.join(dir, "bad.json");
+  await writeFile(badPath, JSON.stringify("not-an-object"));
+  await assert.rejects(() => loadRecordedDesignerEvidence(badPath), /must contain a JSON object or array/);
   await rm(dir, { recursive: true, force: true });
 });
 

--- a/test/loop/run-conductor-cycle.test.mjs
+++ b/test/loop/run-conductor-cycle.test.mjs
@@ -495,6 +495,16 @@ test("parseCliArgs accepts valid repo slug", () => {
   assert.equal(opts.help, false);
 });
 
+test("parseCliArgs parses --designer-review-evidence (#1443)", () => {
+  const opts = parseCliArgs(["--repo", "owner/repo", "--designer-review-evidence", "tmp/evidence.json"]);
+  assert.equal(opts.designerReviewEvidence, "tmp/evidence.json");
+});
+
+test("parseCliArgs leaves designerReviewEvidence undefined when flag absent (#1443)", () => {
+  const opts = parseCliArgs(["--repo", "owner/repo"]);
+  assert.equal(opts.designerReviewEvidence, undefined);
+});
+
 test("parseCliArgs handles --help", () => {
   const opts = parseCliArgs(["--help"]);
   assert.equal(opts.help, true);
@@ -748,6 +758,86 @@ test("runConductorCycle passes autonomyStopAt to detectPrState", async () => {
   );
 
   assert.deepEqual(capturedStopAt, ["merge", "draft-pr"]);
+});
+
+test("runConductorCycle passes designerReviewEvidence to detectPrState", async () => {
+  let capturedEvidence = null;
+  const mockDetectPr = async (_pr, opts) => {
+    capturedEvidence = opts.designerReviewEvidence;
+    return { pr: 1, action: "watch", priority: 30, requiresSubagent: false, requiresApproval: false };
+  };
+
+  await runConductorCycle(
+    { repo: "test/repo", designerReviewEvidence: "tmp/evidence.json" },
+    {
+      listPrsImpl: async () => [{ number: 1, title: "T", url: "u", isDraft: false, headRefName: "f" }],
+      detectPrStateImpl: mockDetectPr,
+    },
+  );
+
+  assert.equal(capturedEvidence, "tmp/evidence.json");
+});
+
+test("detectPrState passes designerReviewEvidence to detectGateImpl", async () => {
+  const pr = { number: 7, title: "D", url: "u", isDraft: false, headRefName: "f" };
+  let passedEvidence = null;
+  const mockGateState = {
+    lifecycleState: "pr_draft",
+    loopDisposition: "action_required",
+    gateBoundary: PR_CHECKPOINT.DRAFT_REVIEW,
+    nextAction: PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+    reason: "draft gate needed",
+    allowedNextActions: [PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE],
+    forbiddenActions: [],
+    draftGate: null,
+    preApprovalGate: null,
+    mergeStateStatus: null,
+    conflictFiles: [],
+    currentHeadSha: null,
+  };
+
+  const result = await detectPrState(pr, {
+    repo: "r",
+    designerReviewEvidence: "tmp/evidence.json",
+    detectGateImpl: async (opts) => {
+      passedEvidence = opts.designerReviewEvidence;
+      return mockGateState;
+    },
+    detectSnapshotImpl: async () => null,
+  });
+
+  assert.equal(passedEvidence, "tmp/evidence.json");
+  assert.equal(result.action, "draft_gate");
+});
+
+test("detectPrState omits designerReviewEvidence (fails closed) when none supplied", async () => {
+  const pr = { number: 8, title: "D", url: "u", isDraft: false, headRefName: "f" };
+  let passedEvidence = "unset";
+  const mockGateState = {
+    lifecycleState: "pr_draft",
+    loopDisposition: "action_required",
+    gateBoundary: PR_CHECKPOINT.DRAFT_REVIEW,
+    nextAction: PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE,
+    reason: null,
+    allowedNextActions: [PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE],
+    forbiddenActions: [],
+    draftGate: null,
+    preApprovalGate: null,
+    mergeStateStatus: null,
+    conflictFiles: [],
+    currentHeadSha: null,
+  };
+
+  await detectPrState(pr, {
+    repo: "r",
+    detectGateImpl: async (opts) => {
+      passedEvidence = opts.designerReviewEvidence;
+      return mockGateState;
+    },
+    detectSnapshotImpl: async () => null,
+  });
+
+  assert.equal(passedEvidence, undefined);
 });
 
 test("runConductorCycle uses default stopAt [merge] when none provided", async () => {


### PR DESCRIPTION
## Summary

Implements the **UI half of ADR 0041** ([decision 0041](https://github.com/mfittko/dev-loops/blob/main/docs/decisions/0041-require-deslop-and-designer-review-gate-loops.md), RFC issue #1438): promotes the **designer/vision review loop** from optional to a **required, fail-closed recorded-evidence check** for rendered-HTML deliverables, wired alongside the existing `article-smoke`/`deck-smoke` UI e2e path.

## Scope

- New deterministic, path-triggered scoping check (`packages/core/src/loop/ui-designer-review-scoping.mjs`), modeled on `evaluateUiE2eScoping`: a rendered-HTML diff must carry **recorded designer/vision review evidence** (the loop's existing outcome + artifact bundle) with the recorded outcome = `ui_review_satisfied` for **every** touched rendered artifact.
- Wired as an independent fail-closed precondition in `pr-gate-coordination.mjs` (new `designer_review_scoping` checkpoint / `RECORD_DESIGNER_REVIEW` action), alongside the existing UI e2e `ui_e2e_scoping` precondition.
- Evidence shape reuses the loop's existing outcome + artifact-bundle contract — **no new schema**. Accessibility facts come from the captured `axe.json`; no human required by default.
- Light/spike relaxed-gate carve-outs still exempt the requirement.
- Reconciliation of "optional" language in `ui-designer-review-loop.md` and `ui-validation-contract.md` to the now-required recorded-evidence status.

## Acceptance criteria ↔ definition of done

| ID | Acceptance criterion | Definition of done |
|----|----------------------|--------------------|
| AC1 | A rendered-HTML diff without a recorded satisfied designer/vision outcome is blocked; one with it passes. | `designer_review_scoping` fail-closed precondition + `RECORD_DESIGNER_REVIEW` action land; a rendered-HTML change cannot merge without recorded evidence, and the pass branch is reachable end-to-end through the production gate caller (`run-conductor-cycle` threads the recorded evidence read seam). |
| AC2 | The evidence shape is the existing loop's outcome + artifact bundle (no new schema). | Evidence validation consumes the existing outcome + artifact-bundle contract; no new schema introduced. |
| AC3 | Accessibility facts come from `axe.json`; the required check does not depend on a human by default. | Accessibility assertions read from the captured `axe.json`; the recorded-evidence requirement carries no default human dependency. |
| AC4 | Light/spike carve-outs still exempt. | Carve-out tests cover light/spike exemption of the recorded-evidence requirement. |
| AC5 | `ui-designer-review-loop.md`'s "optional" language reconciled with the now-required status. | Doc-guard green with regenerated `.claude/skills/docs/` copies; the reword satisfies the reproducibility contract. |

Verification against the full local suite: `npm run verify` all legs green; `npm run test:doc-guard`, `npm run assets:check`, `npm run schema:check` green (see Validation).

## Non-goals

- **Not** a new designer/vision reviewer pipeline or artifact schema: the check consumes the loop's existing outcome + artifact bundle.
- **Not** an auto-running designer/vision bot: the review still runs behind the loop; the gate only enforces recorded evidence on rendered-HTML diffs.
- **Not** extending the recorded-evidence requirement beyond rendered-HTML deliverables (the `article-smoke`/`deck-smoke` paths).
- **Not** changing the UI e2e gate: the designer/vision recorded-evidence check is a distinct, independent precondition alongside `ui_e2e_scoping`.
- **Not** making a human review mandatory by default: no default human dependency (see AC3).

## Definition of done

Required check + tests land; a rendered-HTML change cannot merge without recorded designer-review evidence. Full local validation green (see Validation).

## Validation

- `npm run verify` — all legs green (core 2648, scripts 3975/4011, assets 280, workflows 123, extension 1, dev-loop 37).
- `npm run test:doc-guard` — green (regenerated `.claude/skills/docs/` copies; the doc reword satisfies the reproducibility contract).
- `npm run assets:check` — 95 assets checked OK.
- `npm run schema:check` — config schema up to date.

## Files changed

- `packages/core/src/loop/ui-designer-review-scoping.mjs` (new)
- `packages/core/test/ui-designer-review-scoping.test.mjs` (new)
- `packages/core/src/loop/pr-gate-coordination.mjs`
- `packages/core/test/pr-gate-coordination.test.mjs`
- `scripts/loop/detect-pr-gate-coordination-state.mjs`
- `scripts/loop/run-conductor-cycle.mjs`
- `test/loop/detect-pr-gate-coordination-state.test.mjs`
- `skills/docs/ui-designer-review-loop.md`
- `skills/docs/ui-validation-contract.md`

Closes #1443