### PR TITLE
gate: refuse a --verdict contradicting the wrapper overallVerdict (#1641)

### DIFF
--- a/.claude/skills/docs/gate-review-comment-contract.md
+++ b/.claude/skills/docs/gate-review-comment-contract.md
@@ -127,16 +127,19 @@ with the fixed meaning below:
 | `findings_present` | The gate found issues at blocking severities; fixes are required before the gate boundary can be crossed |
 | `blocked` | The gate could not complete or a hard blocker prevented a verdict |
 
-This rule is enforced at post time, not just documented: `upsert-checkpoint-verdict.mjs`
-refuses a `--verdict` that contradicts the consolidated ledger's `overallVerdict`
-for the same head and gate (#1616). The consolidator (`consolidate-fanin.mjs`)
-already computes `overallVerdict` from this rule's definitions; it threads
-through `--ledger-out`'s `{ overallVerdict, findings }` wrapper into the durable
-ledger (`write-gate-findings-log.mjs`), and `upsert-checkpoint-verdict.mjs`
-reads it and derives the verdict by default (passing no `--verdict` is valid),
-accepts a matching explicit value, and refuses a contradiction citing this
-rule. No override flag — a round whose verdict genuinely differs from the
-computed one is a consolidator bug to fix, not an operator decision to override.
+This rule is enforced at write time and at post time, not just documented:
+`write-gate-findings-log.mjs` refuses a `--verdict` that contradicts the
+`--findings`/`--findings-file` wrapper's `overallVerdict` before any ledger is
+written, and `upsert-checkpoint-verdict.mjs` refuses a `--verdict` that
+contradicts the consolidated ledger's `overallVerdict` for the same head and
+gate (#1616). The consolidator (`consolidate-fanin.mjs`) already computes
+`overallVerdict` from this rule's definitions; it threads through
+`--ledger-out`'s `{ overallVerdict, findings }` wrapper into the durable ledger
+(`write-gate-findings-log.mjs`), and `upsert-checkpoint-verdict.mjs` reads it
+and derives the verdict by default (passing no `--verdict` is valid), accepts
+a matching explicit value, and refuses a contradiction citing this rule. No
+override flag — a round whose verdict genuinely differs from the computed one
+is a consolidator bug to fix, not an operator decision to override.
 
 ## Disposition ledger
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1317,6 +1317,11 @@ consolidator's computed verdict) into the durable ledger, so
 `GATE-COMMENT-VERDICT-VALUES`): a `--verdict` that contradicts the ledger's
 `overallVerdict` is refused, and when the ledger carries `overallVerdict` the
 verdict is derived from it by default (passing no `--verdict` is valid).
+`write-gate-findings-log.mjs` itself now fails closed the same way at write
+time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
+a caller-passed `--verdict` that contradicts it is refused before any ledger
+is written, so a contradicting pair never reaches the durable log in the first
+place.
 `post-gate-findings.mjs` unwraps and ignores `overallVerdict`. A finding with severity
 `low` or `nit` (or a legacy spelling, normalized on read) and no
 `disposition` gets `deferred` derived automatically by both tools. A

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1317,7 +1317,7 @@ consolidator's computed verdict) into the durable ledger, so
 `GATE-COMMENT-VERDICT-VALUES`): a `--verdict` that contradicts the ledger's
 `overallVerdict` is refused, and when the ledger carries `overallVerdict` the
 verdict is derived from it by default (passing no `--verdict` is valid).
-`write-gate-findings-log.mjs` itself now fails closed the same way at write
+`write-gate-findings-log.mjs` itself fails closed the same way at write
 time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
 a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -459,10 +459,14 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     normalizedOverallVerdict = verdict;
     // Fail closed on a caller-passed --verdict that contradicts the
     // consolidator's computed verdict, mirroring the consumer-side refusal in
-    // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES). Both
-    // values are already canonical here (--verdict normalized at parse time,
-    // overallVerdict normalized above), so strict string equality is correct.
-    if (options.verdict !== normalizedOverallVerdict) {
+    // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES).
+    // Normalize options.verdict here so the comparison is symmetric for every
+    // caller — a direct programmatic caller passes a non-canonical verdict by
+    // the same normalizeVerdict path the CLI parse normally canonicalizes it
+    // through, so a canonical-value wrapper never false-rejects a
+    // differently-cased/whitespaced but semantically equal caller verdict.
+    const callerVerdict = normalizeVerdict(options.verdict);
+    if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
         `--verdict ${JSON.stringify(options.verdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
       );

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -465,12 +465,25 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     // the same normalizeVerdict path the CLI parse normally canonicalizes it
     // through, so a canonical-value wrapper never false-rejects a
     // differently-cased/whitespaced but semantically equal caller verdict.
-    const callerVerdict = normalizeVerdict(options.verdict);
+    // Validate options.verdict's own domain first (same message the CLI parse
+    // path throws for --verdict) so a null/undefined/non-string/out-of-domain
+    // value is reported as an invalid verdict, not misattributed as a
+    // contradiction with the wrapper. typeof is checked before normalizeVerdict
+    // runs because normalizeVerdict coerces via String(), which would otherwise
+    // let a non-string (e.g. an array) silently pass as its stringified form.
+    const callerVerdict = typeof options.verdict === "string" ? normalizeVerdict(options.verdict) : null;
+    if (!callerVerdict) {
+      throw parseError("--verdict must be clean, findings_present, or blocked");
+    }
     if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
-        `--verdict ${JSON.stringify(options.verdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
+        `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
       );
     }
+    // Persist the canonical (normalized) verdict, not the raw caller value, so
+    // the durable ledger never records a differently-cased/whitespaced verdict
+    // beside the canonical overallVerdict it was just checked against.
+    options.verdict = callerVerdict;
   }
   let provenance;
   if (options.provenance === undefined) {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -457,6 +457,16 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
       );
     }
     normalizedOverallVerdict = verdict;
+    // Fail closed on a caller-passed --verdict that contradicts the
+    // consolidator's computed verdict, mirroring the consumer-side refusal in
+    // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES). Both
+    // values are already canonical here (--verdict normalized at parse time,
+    // overallVerdict normalized above), so strict string equality is correct.
+    if (options.verdict !== normalizedOverallVerdict) {
+      throw parseError(
+        `--verdict ${JSON.stringify(options.verdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
+      );
+    }
   }
   let provenance;
   if (options.provenance === undefined) {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -449,6 +449,7 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // malformed wrapper cannot silently record an invalid verdict as the
   // consolidator's truth (#1616).
   let normalizedOverallVerdict;
+  let persistedVerdict = options.verdict;
   if (overallVerdict !== undefined) {
     const verdict = normalizeVerdict(overallVerdict);
     if (!verdict) {
@@ -482,8 +483,10 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     }
     // Persist the canonical (normalized) verdict, not the raw caller value, so
     // the durable ledger never records a differently-cased/whitespaced verdict
-    // beside the canonical overallVerdict it was just checked against.
-    options.verdict = callerVerdict;
+    // beside the canonical overallVerdict it was just checked against. Kept in
+    // a local instead of mutating the caller-provided options object, which
+    // programmatic callers may reuse across calls.
+    persistedVerdict = callerVerdict;
   }
   let provenance;
   if (options.provenance === undefined) {
@@ -524,7 +527,7 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     pr: options.pr,
     gate: options.gate,
     headSha: options.headSha,
-    verdict: options.verdict,
+    verdict: persistedVerdict,
     loggedAt: new Date().toISOString(),
     findings,
   };

--- a/skills/docs/gate-review-comment-contract.md
+++ b/skills/docs/gate-review-comment-contract.md
@@ -127,16 +127,19 @@ with the fixed meaning below:
 | `findings_present` | The gate found issues at blocking severities; fixes are required before the gate boundary can be crossed |
 | `blocked` | The gate could not complete or a hard blocker prevented a verdict |
 
-This rule is enforced at post time, not just documented: `upsert-checkpoint-verdict.mjs`
-refuses a `--verdict` that contradicts the consolidated ledger's `overallVerdict`
-for the same head and gate (#1616). The consolidator (`consolidate-fanin.mjs`)
-already computes `overallVerdict` from this rule's definitions; it threads
-through `--ledger-out`'s `{ overallVerdict, findings }` wrapper into the durable
-ledger (`write-gate-findings-log.mjs`), and `upsert-checkpoint-verdict.mjs`
-reads it and derives the verdict by default (passing no `--verdict` is valid),
-accepts a matching explicit value, and refuses a contradiction citing this
-rule. No override flag — a round whose verdict genuinely differs from the
-computed one is a consolidator bug to fix, not an operator decision to override.
+This rule is enforced at write time and at post time, not just documented:
+`write-gate-findings-log.mjs` refuses a `--verdict` that contradicts the
+`--findings`/`--findings-file` wrapper's `overallVerdict` before any ledger is
+written, and `upsert-checkpoint-verdict.mjs` refuses a `--verdict` that
+contradicts the consolidated ledger's `overallVerdict` for the same head and
+gate (#1616). The consolidator (`consolidate-fanin.mjs`) already computes
+`overallVerdict` from this rule's definitions; it threads through
+`--ledger-out`'s `{ overallVerdict, findings }` wrapper into the durable ledger
+(`write-gate-findings-log.mjs`), and `upsert-checkpoint-verdict.mjs` reads it
+and derives the verdict by default (passing no `--verdict` is valid), accepts
+a matching explicit value, and refuses a contradiction citing this rule. No
+override flag — a round whose verdict genuinely differs from the computed one
+is a consolidator bug to fix, not an operator decision to override.
 
 ## Disposition ledger
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1317,6 +1317,11 @@ consolidator's computed verdict) into the durable ledger, so
 `GATE-COMMENT-VERDICT-VALUES`): a `--verdict` that contradicts the ledger's
 `overallVerdict` is refused, and when the ledger carries `overallVerdict` the
 verdict is derived from it by default (passing no `--verdict` is valid).
+`write-gate-findings-log.mjs` itself now fails closed the same way at write
+time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
+a caller-passed `--verdict` that contradicts it is refused before any ledger
+is written, so a contradicting pair never reaches the durable log in the first
+place.
 `post-gate-findings.mjs` unwraps and ignores `overallVerdict`. A finding with severity
 `low` or `nit` (or a legacy spelling, normalized on read) and no
 `disposition` gets `deferred` derived automatically by both tools. A

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1317,7 +1317,7 @@ consolidator's computed verdict) into the durable ledger, so
 `GATE-COMMENT-VERDICT-VALUES`): a `--verdict` that contradicts the ledger's
 `overallVerdict` is refused, and when the ledger carries `overallVerdict` the
 verdict is derived from it by default (passing no `--verdict` is valid).
-`write-gate-findings-log.mjs` itself now fails closed the same way at write
+`write-gate-findings-log.mjs` itself fails closed the same way at write
 time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
 a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first

--- a/test/contracts/gate-verdict-consistency-contract.test.mjs
+++ b/test/contracts/gate-verdict-consistency-contract.test.mjs
@@ -58,14 +58,15 @@ test("consolidate-fanin emits overallVerdict (the value the enforcement reads) i
 
 test("write-gate-findings-log rejects a --verdict contradicting the wrapper overallVerdict and cites GATE-COMMENT-VERDICT-VALUES", async () => {
   const src = await readFile(WRITE_GATE_FINDINGS_SCRIPT, "utf8");
-  // Producer-side refusal mirrors the consumer's: it cites the rule ID and the
-  // contract doc path so both sides of the seam point at the same rule.
-  assert.match(src, /GATE-COMMENT-VERDICT-VALUES/);
-  assert.match(src, /skills\/docs\/gate-review-comment-contract\.md/);
-  // The refusal names both the passed --verdict and the wrapper's overallVerdict,
-  // so a contradicting caller can identify the mismatch from the error alone.
-  assert.match(src, /--verdict/);
-  assert.match(src, /"overallVerdict"/);
+  // Distinctive refusal literal (not just the standalone tokens "--verdict" or
+  // "overallVerdict", which also match the CLI usage text and the unrelated
+  // #1616 malformed-wrapper message) — mirrors the upsert-side pin above: the
+  // producer-side refusal phrase must be followed, within a bounded window, by
+  // both the rule ID and the contract doc path, so the citation actually
+  // belongs to this refusal and not to an unrelated mention elsewhere in the
+  // file.
+  assert.match(src, /contradicts the wrapper's "overallVerdict"[\s\S]{0,160}GATE-COMMENT-VERDICT-VALUES/);
+  assert.match(src, /contradicts the wrapper's "overallVerdict"[\s\S]{0,160}skills\/docs\/gate-review-comment-contract\.md/);
 });
 
 test("upsert-checkpoint-verdict derives the verdict from the ledger's overallVerdict by default (#1616 AC: no --verdict is valid)", async () => {

--- a/test/contracts/gate-verdict-consistency-contract.test.mjs
+++ b/test/contracts/gate-verdict-consistency-contract.test.mjs
@@ -24,6 +24,7 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const CONTRACT_DOC = path.join(REPO_ROOT, "skills/docs/gate-review-comment-contract.md");
 const UPSERT_SCRIPT = path.join(REPO_ROOT, "scripts/github/upsert-checkpoint-verdict.mjs");
 const CONSOLIDATE_SCRIPT = path.join(REPO_ROOT, "scripts/loop/consolidate-fanin.mjs");
+const WRITE_GATE_FINDINGS_SCRIPT = path.join(REPO_ROOT, "scripts/github/write-gate-findings-log.mjs");
 
 test("GATE-COMMENT-VERDICT-VALUES states the clean/findings_present meanings the consolidator computes", async () => {
   const doc = await readFile(CONTRACT_DOC, "utf8");
@@ -53,6 +54,18 @@ test("consolidate-fanin emits overallVerdict (the value the enforcement reads) i
   // ...and embeds it in the --ledger-out wrapper that write-gate-findings-log
   // threads into the durable ledger upsert-checkpoint-verdict enforces against.
   assert.match(src, /JSON\.stringify\(\{ overallVerdict: consolidated\.verdict, findings \}/);
+});
+
+test("write-gate-findings-log rejects a --verdict contradicting the wrapper overallVerdict and cites GATE-COMMENT-VERDICT-VALUES", async () => {
+  const src = await readFile(WRITE_GATE_FINDINGS_SCRIPT, "utf8");
+  // Producer-side refusal mirrors the consumer's: it cites the rule ID and the
+  // contract doc path so both sides of the seam point at the same rule.
+  assert.match(src, /GATE-COMMENT-VERDICT-VALUES/);
+  assert.match(src, /skills\/docs\/gate-review-comment-contract\.md/);
+  // The refusal names both the passed --verdict and the wrapper's overallVerdict,
+  // so a contradicting caller can identify the mismatch from the error alone.
+  assert.match(src, /--verdict/);
+  assert.match(src, /"overallVerdict"/);
 });
 
 test("upsert-checkpoint-verdict derives the verdict from the ledger's overallVerdict by default (#1616 AC: no --verdict is valid)", async () => {

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
+  buildLogPath,
   checkProvenanceAngleCoverage,
   parseProvenanceJson,
   parseWriteGateFindingsLogCliArgs,
@@ -1392,9 +1393,15 @@ test("#1641: writeGateFindingsLog rejects a --verdict contradicting the wrapper 
         return true;
       },
     );
-    // No ledger must be written on the rejection.
-    const leaked = (await readdir(tmpDir)).filter((f) => f.endsWith(".json"));
-    assert.equal(leaked.length, 0, "a contradicting pair must not write a ledger before failing");
+    // No ledger must be written on the rejection. A non-recursive readdir of
+    // tmpDir would only ever see the "gate-findings" directory (buildLogPath
+    // nests the ledger three levels below tmpRoot), so it can never observe a
+    // leak; assert the actual write target is absent instead.
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "o/n", pr: 7, gate: "draft_gate", headSha: "a1".repeat(20), tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "a contradicting pair must not write a ledger before failing",
+    );
 
     // Direction 2: --verdict findings_present vs wrapper clean
     await assert.rejects(
@@ -1413,6 +1420,51 @@ test("#1641: writeGateFindingsLog rejects a --verdict contradicting the wrapper 
         return true;
       },
     );
+
+    // Direction 3: --verdict blocked vs wrapper findings_present (issue's
+    // Domain bullet names this pair explicitly).
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 9,
+        gate: "draft_gate",
+        headSha: "c3".repeat(20),
+        verdict: "blocked",
+        findings: JSON.stringify({ overallVerdict: "findings_present", findings: [] }),
+        tmpRoot: tmpDir,
+      }),
+      (err) => {
+        assert.match(err.message, /--verdict "blocked"/);
+        assert.match(err.message, /"overallVerdict" "findings_present"/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("#1641: writeGateFindingsLog rejects an invalid or non-string caller --verdict as a domain error, not a contradiction", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-invalid-"));
+  try {
+    for (const badVerdict of ["bogus", undefined, ["clean"]]) {
+      await assert.rejects(
+        () => writeGateFindingsLog({
+          repo: "o/n",
+          pr: 7,
+          gate: "draft_gate",
+          headSha: "a1".repeat(20),
+          verdict: badVerdict,
+          findings: JSON.stringify({ overallVerdict: "clean", findings: [] }),
+          tmpRoot: tmpDir,
+        }),
+        (err) => {
+          assert.match(err.message, /--verdict must be clean, findings_present, or blocked/);
+          assert.doesNotMatch(err.message, /contradicts/);
+          return true;
+        },
+      );
+    }
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }
@@ -1438,6 +1490,26 @@ test("#1641: writeGateFindingsLog accepts a matching --verdict + wrapper overall
   }
 });
 
+test("#1641: writeGateFindingsLog accepts a non-canonical caller --verdict and persists the canonical value", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-noncanonical-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "o/n",
+      pr: 7,
+      gate: "draft_gate",
+      headSha: "a1".repeat(20),
+      verdict: " Clean ",
+      findings: JSON.stringify({ overallVerdict: "clean", findings: [] }),
+      tmpRoot: tmpDir,
+    });
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(parsed.verdict, "clean", "the ledger must persist the canonical verdict, not the raw caller casing/whitespace");
+    assert.equal(parsed.overallVerdict, "clean");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("#1641: CLI path — a direct write-gate-findings-log.mjs with a contradicting pair exits 1 with {ok:false,error} and writes no ledger", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-cli-conflict-"));
   try {
@@ -1452,14 +1524,19 @@ test("#1641: CLI path — a direct write-gate-findings-log.mjs with a contradict
       "--tmp-root", tmpDir,
     ], { cwd: tmpDir });
 
-    assert.notEqual(result.code, 0, "a contradicting pair must exit non-zero");
+    assert.equal(result.code, 1, "a contradicting pair must exit 1");
     assert.match(result.stderr, /\{"ok":false,"error"/);
     assert.match(result.stderr, /contradicts the wrapper/);
     assert.match(result.stderr, /GATE-COMMENT-VERDICT-VALUES/);
 
-    // No ledger must be written on the rejection.
-    const leaked = (await readdir(tmpDir)).filter((f) => f.endsWith(".json"));
-    assert.equal(leaked.length, 0, "a contradicting CLI pair must not write a ledger before failing");
+    // No ledger must be written on the rejection. Same non-recursive-readdir
+    // caveat as the programmatic-path test above: assert the actual write
+    // target is absent instead of scanning tmpDir's top level.
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "owner/repo", pr: 42, gate: "draft_gate", headSha: "945391c0abcdef1234567890abcdef1234567890", tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "a contradicting CLI pair must not write a ledger before failing",
+    );
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -10,6 +10,9 @@ import {
   parseWriteGateFindingsLogCliArgs,
   writeGateFindingsLog,
 } from "../../scripts/github/write-gate-findings-log.mjs";
+import { runNode as runNodeHelper } from "../_helpers.mjs";
+
+const writeGateFindingsLogScript = path.resolve("scripts/github/write-gate-findings-log.mjs");
 
 // #1592: several fixtures below deliberately keep pre-rename severity
 // spellings ("must-fix"/"worth-fixing-now"/"nice-to-have") as INPUT — this is
@@ -1430,6 +1433,33 @@ test("#1641: writeGateFindingsLog accepts a matching --verdict + wrapper overall
     const parsed = JSON.parse(await readFile(result.path, "utf8"));
     assert.equal(parsed.verdict, "findings_present");
     assert.equal(parsed.overallVerdict, "findings_present");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("#1641: CLI path — a direct write-gate-findings-log.mjs with a contradicting pair exits 1 with {ok:false,error} and writes no ledger", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-cli-conflict-"));
+  try {
+    // Wrapper overallVerdict findings_present contradicts --verdict clean.
+    const result = await runNodeHelper(writeGateFindingsLogScript, [
+      "--repo", "owner/repo",
+      "--pr", "42",
+      "--gate", "draft_gate",
+      "--head-sha", "945391c0abcdef1234567890abcdef1234567890",
+      "--verdict", "clean",
+      "--findings", JSON.stringify({ overallVerdict: "findings_present", findings: [] }),
+      "--tmp-root", tmpDir,
+    ], { cwd: tmpDir });
+
+    assert.notEqual(result.code, 0, "a contradicting pair must exit non-zero");
+    assert.match(result.stderr, /\{"ok":false,"error"/);
+    assert.match(result.stderr, /contradicts the wrapper/);
+    assert.match(result.stderr, /GATE-COMMENT-VERDICT-VALUES/);
+
+    // No ledger must be written on the rejection.
+    const leaked = (await readdir(tmpDir)).filter((f) => f.endsWith(".json"));
+    assert.equal(leaked.length, 0, "a contradicting CLI pair must not write a ledger before failing");
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1362,6 +1362,74 @@ test("#1616: writeGateFindingsLog persists overallVerdict from the {overallVerdi
     assert.equal(parsed.overallVerdict, "findings_present");
     assert.equal(parsed.findings.length, 1);
     assert.equal(parsed.findings[0].severity, "high"); // "must-fix" normalizes to canonical "high"
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("#1641: writeGateFindingsLog rejects a --verdict contradicting the wrapper overallVerdict", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-conflict-"));
+  try {
+    // Direction 1: --verdict clean vs wrapper findings_present
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 7,
+        gate: "draft_gate",
+        headSha: "a1".repeat(20),
+        verdict: "clean",
+        findings: JSON.stringify({ overallVerdict: "findings_present", findings: [] }),
+        tmpRoot: tmpDir,
+      }),
+      (err) => {
+        assert.match(err.message, /--verdict "clean"/);
+        assert.match(err.message, /"overallVerdict" "findings_present"/);
+        assert.match(err.message, /GATE-COMMENT-VERDICT-VALUES/);
+        assert.match(err.message, /skills\/docs\/gate-review-comment-contract\.md/);
+        return true;
+      },
+    );
+    // No ledger must be written on the rejection.
+    const leaked = (await readdir(tmpDir)).filter((f) => f.endsWith(".json"));
+    assert.equal(leaked.length, 0, "a contradicting pair must not write a ledger before failing");
+
+    // Direction 2: --verdict findings_present vs wrapper clean
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 8,
+        gate: "draft_gate",
+        headSha: "b2".repeat(20),
+        verdict: "findings_present",
+        findings: JSON.stringify({ overallVerdict: "clean", findings: [] }),
+        tmpRoot: tmpDir,
+      }),
+      (err) => {
+        assert.match(err.message, /--verdict "findings_present"/);
+        assert.match(err.message, /"overallVerdict" "clean"/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("#1641: writeGateFindingsLog accepts a matching --verdict + wrapper overallVerdict", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-match-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "o/n",
+      pr: 7,
+      gate: "draft_gate",
+      headSha: "a1".repeat(20),
+      verdict: "findings_present",
+      findings: JSON.stringify({ overallVerdict: "findings_present", findings: [] }),
+      tmpRoot: tmpDir,
+    });
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(parsed.verdict, "findings_present");
+    assert.equal(parsed.overallVerdict, "findings_present");
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

`write-gate-findings-log.mjs` now refuses a `--verdict` that contradicts the wrapper's `overallVerdict`, so an ambiguous verdict pair can never be persisted as the round's durable findings ledger. The refusal fires at write time, before any ledger file is created, and cites `GATE-COMMENT-VERDICT-VALUES` plus the owning contract doc.

## Scope and context

Producer-side guard only, inside `writeGateFindingsLog`. The check validates the caller verdict's domain first (a non-string or out-of-domain value gets the parser's own domain error, mirroring the CLI parse path), then compares normalized-vs-normalized, and persists the canonical verdict value. The malformed-wrapper rejection still fires first. Contract docs (`gate-review-sub-loop-contract.md`, `gate-review-comment-contract.md`) state the new write-time enforcement point; their generated mirrors are regenerated in the same change.

## Acceptance criteria

- [x] `writeGateFindingsLog` rejects a wrapper `overallVerdict` that differs from `--verdict`: the call throws before any ledger file is written, and no `<gate>-<headSha>.json` appears under `--tmp-root` (asserted via ENOENT on the exact `buildLogPath` target).
- [x] The rejection error names both values and cites `GATE-COMMENT-VERDICT-VALUES` with the contract doc path `skills/docs/gate-review-comment-contract.md`.
- [x] A matching `--verdict` and wrapper `overallVerdict` writes the ledger with both fields, identical to current behavior (existing test at `test/github/write-gate-findings-log.test.mjs` stays green).
- [x] A bare-array input (no wrapper) is unaffected: ledger writes byte-identically, no `overallVerdict` key.
- [x] The malformed-wrapper rejection (`overallVerdict: "bogus"`) still fires before the contradiction check.
- [x] CLI path: a contradicting pair exits 1 with a `{ ok: false, error }` JSON line on stderr.
- [x] New regression tests cover the contradiction rejection in both directions plus the `blocked` vs `findings_present` pair, and assert the error names both values.
- [x] `test/contracts/gate-verdict-consistency-contract.test.mjs` gains a producer-side pin anchored on the distinctive refusal literal (verified to fail on pre-change main).

## Definition of done

- [x] `npm run verify` green (gate validation artifact recorded at the current head; one known-flaky stdin-idle test in `reply-resolve-review-threads` passed in isolation, tracked by the verify-suite stabilization issue).
- [x] `npm run assets:check` green (95 checked).
- [x] `npm run schema:check` green.
- [x] `node --test test/github/write-gate-findings-log.test.mjs` green (86 tests).
- [x] `node --test test/contracts/gate-verdict-consistency-contract.test.mjs` green.
- [x] Cross-harness non-regression: the change is a harness-neutral producer script plus contract docs; the generated `.claude` mirrors were regenerated byte-identical (`assets:check` 95 checked) and no Pi-only or Claude-only path is touched.
- [x] Scope-bounded; no unrelated changes.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Contradicting verdict pair throws before any ledger write (ENOENT on the buildLogPath target) | write-gate-findings-log test suite green (86 tests) | overallVerdict computation unchanged (consolidate-fanin untouched) |
| Refusal names both values and cites GATE-COMMENT-VERDICT-VALUES plus the contract doc path | producer-side contract pin green (gate-verdict-consistency suite) | no derive-from-wrapper default (stays in upsert-checkpoint-verdict) |
| Matching pair and bare-array inputs write byte-identically to before | existing matching/bare-array tests stay green | verdict field kept in the ledger (backward compat) |
| Malformed-wrapper rejection still fires first | malformed-wrapper ordering test green | post-gate-findings unchanged (unwraps and ignores overallVerdict) |
| CLI contradicting pair exits 1 with the ok-false JSON error shape | CLI-path test asserts exit code equal 1 | judge-verdict interaction contract is a tracked follow-up |
| Both contradiction directions plus the blocked pair covered; error names both values | regression tests green in the producer suite | — |
| Producer-side citation pin fails on pre-change main | contract-test tightening verified against main | — |
| Full verification | npm run verify, assets:check (95), schema:check all green | — |

## Non-goals

- Changing how `overallVerdict` is computed (`consolidate-fanin.mjs` / `@dev-loops/core/loop/gate-fanin` untouched).
- Removing the `verdict` field from the ledger (backward compat for inline/fallback paths).
- Making `--verdict` optional or deriving it from the wrapper; that derive-or-refuse behavior lives in `upsert-checkpoint-verdict.mjs` and stays there.
- Changing `post-gate-findings.mjs`, which unwraps and ignores `overallVerdict` by design.
- Any change to provenance, angle-coverage, or judge-verdict handling in this script (the judge-verdict interaction contract is a tracked follow-up).

## Validation

```sh
node --test test/github/write-gate-findings-log.test.mjs
node --test test/contracts/gate-verdict-consistency-contract.test.mjs
npm run assets:check && npm run schema:check
npm run verify
```

Closes #1641
