### PR TITLE
config: agent merges on full gate pass — humanMergeOnly override (#1746)

### DIFF
--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -185,9 +185,23 @@ A marker is allowed only while the PR is still in draft; it must be removed befo
 
 ## Merge authorization
 
-- Merge authorization MUST be explicit for the active issue/PR scope
+- Merge authorization MUST be explicit for the active issue/PR scope, OR supplied by a recorded standing authorization (below)
 - `"Merge authorized if gates green"` is valid explicit authorization
-- Implied approval from prior turns MUST NOT be treated as sufficient
+- Implied approval from prior turns MUST NOT be treated as sufficient; only a recorded standing authorization carries across scopes
+
+### Recorded standing authorization (ADR 0050)
+
+An operator MAY record a standing merge authorization that applies to every PR whose
+full gate pipeline passes: clean `draft_gate` and `pre_approval_gate` verdicts at the
+current head, zero unresolved review threads, a green gate-evidence audit, and green CI.
+A standing authorization is valid only when all of the following hold:
+
+- the repo config sets `autonomy.humanMergeOnly: false` (the config alone authorizes nothing)
+- the authorization is recorded in a durable artifact (an accepted decision record naming
+  the condition), not only in a chat turn
+- the gate pass is complete at the current head; a gate-incomplete PR stays unauthorized
+
+Absent a recorded standing authorization, the per-scope explicit rule above governs.
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 

--- a/.claude/skills/docs/merge-preconditions.md
+++ b/.claude/skills/docs/merge-preconditions.md
@@ -50,7 +50,7 @@ Before merge, ALL of the following MUST hold:
 3. ✅ Draft gate satisfied — clean `draft_gate` verdict per `GATE-COMMENT-VERDICT-VALUES` ([Checkpoint Verdict Comment Contract](./gate-review-comment-contract.md))
 4. ✅ Pre-approval gate satisfied — clean `pre_approval_gate` verdict on the current head, same rule
 5. ✅ All review threads resolved
-6. ✅ Explicit merge authorization from operator
+6. ✅ Merge authorization from the operator — explicit for the active scope, or a recorded standing authorization (see [Merge authorization](#merge-authorization))
 7. ✅ Closing-reference state matches artifact backing, each arm owned by a different contract: tracker-backed work — PR body contains `Closes #N` or `Fixes #N` (owned by the PR description contract in [copilot-loop-operations.md](copilot-loop-operations.md)); issue-less lightweight (PR-body-as-spec, no backing issue) — the closing reference is absent by design and `node scripts/loop/validate-pr-body-spec.mjs --repo <owner/name> --pr <number> --no-issue` passes clean (owned by `ARTIFACT-LIGHTWEIGHT-BODY-INVARIANTS` in [Artifact Authority Contract](artifact-authority-contract.md)); plan-file promotion (P4) — the PR body carries the committed plan-doc path as the spec-of-record and, being issue-less by design (`buildPromotionPrBody` neutralizes closing keywords), the closing reference MUST NOT be present
 8. ✅ PR **title** free of merge-blocking markers — see [Title markers](#title-markers) for the exact constructions that count
 
@@ -202,6 +202,11 @@ A standing authorization is valid only when all of the following hold:
 - the gate pass is complete at the current head; a gate-incomplete PR stays unauthorized
 
 Absent a recorded standing authorization, the per-scope explicit rule above governs.
+
+A standing authorization is surfaced through the same per-run authorization signal the
+rest of the loop already consumes (`resolveEffectiveMergeAuthorized`); sibling contracts
+that require "explicit merge authorization for the active scope" are satisfied by that
+signal and need no separate carve-out.
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 

--- a/.devloops
+++ b/.devloops
@@ -161,9 +161,11 @@ queue:
   reDispatchMaxRetries: 1
   archiveOlderThanDays: 7
 
-# Operator override (mfittko, 2026-08-18): merges are agent-executed once the full
+# Operator override (mfittko, 2026-08-18, ADR 0050): lifts the repo-level bar on
+# agent-executed merges so the per-run authorization signal is honored again. The
+# operator's standing instruction supplies that authorization for PRs whose full
 # gate pipeline passes (draft_gate + pre_approval_gate clean at current head, zero
-# unresolved threads, evidence audit green). Supersedes the shipped human-merge-only
-# default; the human approval checkpoint remains the standing authorization itself.
+# unresolved threads, evidence audit green); stopAt and the resolver chain are
+# unchanged, so the config alone clears nothing.
 autonomy:
   humanMergeOnly: false

--- a/.devloops
+++ b/.devloops
@@ -160,3 +160,10 @@ queue:
   maxAutoFiledIssues: 10
   reDispatchMaxRetries: 1
   archiveOlderThanDays: 7
+
+# Operator override (mfittko, 2026-08-18): merges are agent-executed once the full
+# gate pipeline passes (draft_gate + pre_approval_gate clean at current head, zero
+# unresolved threads, evidence audit green). Supersedes the shipped human-merge-only
+# default; the human approval checkpoint remains the standing authorization itself.
+autonomy:
+  humanMergeOnly: false

--- a/docs/decisions/0050-agent-merge-on-full-gate-pass.md
+++ b/docs/decisions/0050-agent-merge-on-full-gate-pass.md
@@ -1,0 +1,17 @@
+# 0050. Run this repo with humanMergeOnly off: the agent merges on a full gate pass
+
+## Status
+
+Accepted — 2026-08-18 ([PR 1747](https://github.com/mfittko/dev-loops/pull/1747))
+
+## Context
+
+[ADR 0007](./0007-human-only-merge-authority.md) hardened `autonomy.humanMergeOnly` as a repo-level invariant: when set, the agent never runs `gh pr merge`, and every merge is a human click. The shipped extension default enables it. Its Consequences section describes that posture as "the final merge is always a human action". By August 2026 the gate pipeline had grown a stronger standing check than the click it guarded: draft and pre-approval verdicts posted per head by fan-out review with judge disposition, fail-closed evidence audits over both verdict surfaces, thread-resolution enforcement, and CI gating. During the rc.7 drive the operator concluded the per-merge click added latency without adding safety and directed the change in-session (operator instruction, 2026-08-18, recorded in the PR that carries this record).
+
+## Decision
+
+We run this repository with `autonomy.humanMergeOnly: false`: the agent executes `gh pr merge` itself once the full gate pipeline passes — clean `draft_gate` and `pre_approval_gate` verdicts at the current head, zero unresolved review threads, a green two-surface gate-evidence audit, and green CI. The standing authorization is the gate contract, not a per-PR message. ADR 0007's mechanism is unchanged and not superseded: the knob, the single authoritative resolver, and its fail-closed behavior (a broken config denies merge) remain the enforcement path; this record changes only the value this repo sets. We rejected removing the knob (other repos legitimately want the invariant) and rejected a per-PR chat authorization (it reintroduces the latency without strengthening the check).
+
+## Consequences
+
+Merge latency drops to the gate pipeline's own wall time; unattended queue drives can complete a cycle end to end. The gate pipeline is now the last line before main: weakening any gate precondition weakens merge safety directly, so gate-contract changes deserve the scrutiny previously reserved for merge authorization. The mandatory post-merge duties become load-bearing rather than advisory: main push workflows verified green at every merge commit, and the substantive post-merge retrospective. A repo that wants the old posture back flips the one config value; the fail-closed machinery of ADR 0007 is still there to enforce it.

--- a/docs/decisions/0050-agent-merge-on-full-gate-pass.md
+++ b/docs/decisions/0050-agent-merge-on-full-gate-pass.md
@@ -4,13 +4,15 @@
 
 Accepted — 2026-08-18 ([PR 1747](https://github.com/mfittko/dev-loops/pull/1747))
 
+Changes only the value this repository configures for the knob [ADR 0007](./0007-human-only-merge-authority.md) hardened; ADR 0007's mechanism (the knob, the authoritative resolver, fail-closed config handling) is unchanged and not superseded.
+
 ## Context
 
 [ADR 0007](./0007-human-only-merge-authority.md) hardened `autonomy.humanMergeOnly` as a repo-level invariant: when set, the agent never runs `gh pr merge`, and every merge is a human click. The shipped extension default enables it. Its Consequences section describes that posture as "the final merge is always a human action". By August 2026 the gate pipeline had grown a stronger standing check than the click it guarded: draft and pre-approval verdicts posted per head by fan-out review with judge disposition, fail-closed evidence audits over both verdict surfaces, thread-resolution enforcement, and CI gating. During the rc.7 drive the operator concluded the per-merge click added latency without adding safety and directed the change in-session (operator instruction, 2026-08-18, recorded in the PR that carries this record).
 
 ## Decision
 
-We run this repository with `autonomy.humanMergeOnly: false`: the agent executes `gh pr merge` itself once the full gate pipeline passes — clean `draft_gate` and `pre_approval_gate` verdicts at the current head, zero unresolved review threads, a green two-surface gate-evidence audit, and green CI. The standing authorization is the gate contract, not a per-PR message. ADR 0007's mechanism is unchanged and not superseded: the knob, the single authoritative resolver, and its fail-closed behavior (a broken config denies merge) remain the enforcement path; this record changes only the value this repo sets. We rejected removing the knob (other repos legitimately want the invariant) and rejected a per-PR chat authorization (it reintroduces the latency without strengthening the check).
+We run this repository with `autonomy.humanMergeOnly: false`, which removes the repo-level bar on agent-executed merges: `resolveEffectiveMergeAuthorized` again honors the per-run authorization signal, and the operator's standing instruction (recorded here and in session memory) supplies that authorization for every PR whose full gate pipeline passes — clean `draft_gate` and `pre_approval_gate` verdicts at the current head, zero unresolved review threads, a green two-surface gate-evidence audit, and green CI. A gate-incomplete PR remains unauthorized: `autonomy.stopAt` and the resolver chain are untouched, so the config alone clears nothing. We rejected removing the knob (other repos legitimately want the invariant) and rejected per-PR chat authorization (it reintroduces the latency without strengthening the check).
 
 ## Consequences
 

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -185,9 +185,23 @@ A marker is allowed only while the PR is still in draft; it must be removed befo
 
 ## Merge authorization
 
-- Merge authorization MUST be explicit for the active issue/PR scope
+- Merge authorization MUST be explicit for the active issue/PR scope, OR supplied by a recorded standing authorization (below)
 - `"Merge authorized if gates green"` is valid explicit authorization
-- Implied approval from prior turns MUST NOT be treated as sufficient
+- Implied approval from prior turns MUST NOT be treated as sufficient; only a recorded standing authorization carries across scopes
+
+### Recorded standing authorization (ADR 0050)
+
+An operator MAY record a standing merge authorization that applies to every PR whose
+full gate pipeline passes: clean `draft_gate` and `pre_approval_gate` verdicts at the
+current head, zero unresolved review threads, a green gate-evidence audit, and green CI.
+A standing authorization is valid only when all of the following hold:
+
+- the repo config sets `autonomy.humanMergeOnly: false` (the config alone authorizes nothing)
+- the authorization is recorded in a durable artifact (an accepted decision record naming
+  the condition), not only in a chat turn
+- the gate pass is complete at the current head; a gate-incomplete PR stays unauthorized
+
+Absent a recorded standing authorization, the per-scope explicit rule above governs.
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 

--- a/skills/docs/merge-preconditions.md
+++ b/skills/docs/merge-preconditions.md
@@ -50,7 +50,7 @@ Before merge, ALL of the following MUST hold:
 3. ✅ Draft gate satisfied — clean `draft_gate` verdict per `GATE-COMMENT-VERDICT-VALUES` ([Checkpoint Verdict Comment Contract](./gate-review-comment-contract.md))
 4. ✅ Pre-approval gate satisfied — clean `pre_approval_gate` verdict on the current head, same rule
 5. ✅ All review threads resolved
-6. ✅ Explicit merge authorization from operator
+6. ✅ Merge authorization from the operator — explicit for the active scope, or a recorded standing authorization (see [Merge authorization](#merge-authorization))
 7. ✅ Closing-reference state matches artifact backing, each arm owned by a different contract: tracker-backed work — PR body contains `Closes #N` or `Fixes #N` (owned by the PR description contract in [copilot-loop-operations.md](copilot-loop-operations.md)); issue-less lightweight (PR-body-as-spec, no backing issue) — the closing reference is absent by design and `node scripts/loop/validate-pr-body-spec.mjs --repo <owner/name> --pr <number> --no-issue` passes clean (owned by `ARTIFACT-LIGHTWEIGHT-BODY-INVARIANTS` in [Artifact Authority Contract](artifact-authority-contract.md)); plan-file promotion (P4) — the PR body carries the committed plan-doc path as the spec-of-record and, being issue-less by design (`buildPromotionPrBody` neutralizes closing keywords), the closing reference MUST NOT be present
 8. ✅ PR **title** free of merge-blocking markers — see [Title markers](#title-markers) for the exact constructions that count
 
@@ -202,6 +202,11 @@ A standing authorization is valid only when all of the following hold:
 - the gate pass is complete at the current head; a gate-incomplete PR stays unauthorized
 
 Absent a recorded standing authorization, the per-scope explicit rule above governs.
+
+A standing authorization is surfaced through the same per-run authorization signal the
+rest of the loop already consumes (`resolveEffectiveMergeAuthorized`); sibling contracts
+that require "explicit merge authorization for the active scope" are satisfied by that
+signal and need no separate carve-out.
 
 ### `autonomy.humanMergeOnly` — fixed human-only merge (non-overridable)
 


### PR DESCRIPTION
## Summary

Commits the operator-directed autonomy override: `autonomy.humanMergeOnly: false` in `.devloops`, so the agent executes merges once the full gate pipeline passes. The override existed as an uncommitted operator edit; this PR makes it durable.

## Scope and context

Four files (three source, one regenerated mirror): the `.devloops` override (comment block plus the `autonomy.humanMergeOnly: false` key), ADR 0050 recording the decision (ADR-WORTHY-PERSIST: policy reversal carried by the implementing PR), and the merge-preconditions contract amendment admitting a recorded standing authorization (rule-block item six, the standing-authorization subsection, and the sibling per-run-signal clause) with its regenerated `.claude` mirror. ADR 0007's mechanism is unchanged; only this repo's configured value flips. The Bash-gate hook resolves the value through `scripts/loop/resolve-human-merge-only.mjs`, which now prints `false` at the repo root.

## Acceptance criteria

- [x] `.devloops` sets `autonomy.humanMergeOnly: false` with an operator-override comment naming the condition (full gate pass) and date.
- [x] `node scripts/loop/resolve-human-merge-only.mjs` prints `false` at the repo root.
- [x] Config loads with zero errors.

## Definition of done

- [x] `npm run verify` green.
- [x] `npm run schema:check` green (key already in the schema; no drift).
- [x] `npm run test:doc-guard` green (276 contract tests at the current head, covering the merge-preconditions amendment).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Override present with operator comment | npm run verify (config-loading suites) | stopAt semantics unchanged |
| Decision recorded as ADR 0050 | npm run test:docs (decision-record validator, 51 records) | ADR 0007 mechanism untouched |
| Merge-preconditions contract admits recorded standing authorization | npm run test:doc-guard (276 contract tests green at head) | public-dev-loop-contract unchanged (per-run-signal clause) |
| Resolver prints false | npm run verify | hook/resolver scripts unchanged |
| Config loads with zero errors | npm run verify, schema:check | — |

## Non-goals

- No change to `autonomy.stopAt` semantics or any other autonomy knob.
- No changes to the hook or resolver scripts.

## Validation

```sh
node scripts/loop/resolve-human-merge-only.mjs
npm run schema:check
npm run verify
```

Closes #1746
