### PR TITLE
fix(hook): SubagentStop guard survives >1MB porcelain — 10MB maxBuffer + capped reason (#1686)

### DIFF
--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -423,6 +423,15 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
     .split("\n")
     .map((l) => l.trim())
     .filter(Boolean);
+  // The reason is fed back to the stopping subagent as context, so the path
+  // enumeration is capped: an unbounded list on a very dirty worktree produces a
+  // multi-megabyte reason that consumers truncate or choke on, burying the one
+  // actionable line. The count always reports the full total.
+  const MAX_LISTED_DIRTY_PATHS = 50;
+  const listed = dirty.slice(0, MAX_LISTED_DIRTY_PATHS).map((p) => "  " + p);
+  if (dirty.length > MAX_LISTED_DIRTY_PATHS) {
+    listed.push(`  … and ${dirty.length - MAX_LISTED_DIRTY_PATHS} more (run \`git status --porcelain\` for the full list)`);
+  }
   return {
     decision: "block",
     reason:
@@ -430,6 +439,6 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
       "to prevent silent data loss from post-merge worktree cleanup (cleanup-worktree.mjs runs " +
       "`git worktree remove --force`). Commit your work before stopping. " +
       `Dirty paths (${dirty.length}):\n` +
-      dirty.map((p) => "  " + p).join("\n"),
+      listed.join("\n"),
   };
 }

--- a/.claude/hooks/subagent-stop-uncommitted-guard.mjs
+++ b/.claude/hooks/subagent-stop-uncommitted-guard.mjs
@@ -6,9 +6,10 @@
  * uncommitted changes in a worktree are destroyed with no warning — the only data-loss gap in
  * the enforcement audit. `LOCAL-COMMIT-BEFORE-EXIT` existed only as prose; this hook makes it
  * mechanical: when a subagent stops with a dirty worktree under `tmp/worktrees/`, refuse the
- * stop (exit code 2 + stderr JSON naming `LOCAL-COMMIT-BEFORE-EXIT` and the dirty paths) so the
- * subagent commits before exiting. Post-merge cleanup that force-removes worktrees can no
- * longer destroy uncommitted work silently.
+ * stop (exit code 2 + stderr JSON naming `LOCAL-COMMIT-BEFORE-EXIT` and up to 50 dirty paths,
+ * plus a summary line with the full count when there are more) so the subagent commits before
+ * exiting. Post-merge cleanup that force-removes worktrees can no longer destroy uncommitted
+ * work silently.
  *
  * Interactive sessions awaiting commit authorization set `DEVLOOPS_COMMIT_AUTH_PENDING=1` (an
  * opt-in operator/coordination-path signal, like `DEVLOOPS_MAIN_AGENT_READONLY`) and are
@@ -35,10 +36,13 @@ try {
   // Bounded: a stalled `git status` (slow/networked FS, held index lock) must not hang the
   // subagent stop. On timeout git is killed and execFileSync throws → caught → porcelain=""
   // → fail-safe allow (better than blocking the exit with no message).
-  // maxBuffer is raised to 10MB: the Node default (1MB) makes execFileSync throw on a
-  // dirty worktree with ~4000+ status lines, which the catch would turn into a fail-safe
-  // allow — defeating the guard exactly when the most work is at risk. Beyond 10MB
-  // (~40k+ dirty paths) the fail-safe allow is the documented ceiling.
+  // maxBuffer is raised to 10MB: the Node default (1MB) makes execFileSync throw once
+  // `git status --porcelain` output crosses that size, which the catch would turn into a
+  // fail-safe allow — defeating the guard exactly when the most work is at risk. The e2e
+  // fixture (test/contracts/claude-hooks-settings.test.mjs) trips the 1MB default at
+  // ~4300+ dirty paths using its long (~245-byte) porcelain lines; real paths are much
+  // shorter, so a real worktree needs far more entries to hit either bound. Beyond 10MB
+  // (~43k+ such long-line paths) the fail-safe allow is the documented ceiling.
   porcelain = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", timeout: 5000, maxBuffer: 10 * 1024 * 1024 });
 } catch {
   // Not a git repo / git unavailable / status timed out — nothing to guard, allow the stop.

--- a/.claude/hooks/subagent-stop-uncommitted-guard.mjs
+++ b/.claude/hooks/subagent-stop-uncommitted-guard.mjs
@@ -34,8 +34,12 @@ let porcelain = "";
 try {
   // Bounded: a stalled `git status` (slow/networked FS, held index lock) must not hang the
   // subagent stop. On timeout git is killed and execFileSync throws → caught → porcelain=""
-  // → fail-safe allow (better than blocking the exit with no message). #1619 review finding.
-  porcelain = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", timeout: 5000 });
+  // → fail-safe allow (better than blocking the exit with no message).
+  // maxBuffer is raised to 10MB: the Node default (1MB) makes execFileSync throw on a
+  // dirty worktree with ~4000+ status lines, which the catch would turn into a fail-safe
+  // allow — defeating the guard exactly when the most work is at risk. Beyond 10MB
+  // (~40k+ dirty paths) the fail-safe allow is the documented ceiling.
+  porcelain = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", timeout: 5000, maxBuffer: 10 * 1024 * 1024 });
 } catch {
   // Not a git repo / git unavailable / status timed out — nothing to guard, allow the stop.
   porcelain = "";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **SubagentStop guard's `maxBuffer` raised to 10MB; block reason's dirty-path enumeration capped at 50 (#1686).** `.claude/hooks/subagent-stop-uncommitted-guard.mjs`'s `git status --porcelain` capture used Node's default 1MB `maxBuffer`, so a heavily dirty worktree could overflow it, throw, and fail-safe allow the stop — defeating the guard exactly when the most work is at risk. `execFileSync` now allows up to 10MB. The block reason from `decideSubagentStopGuard` (`@dev-loops/core/claude/hook-decisions`) now lists at most 50 dirty paths plus a summary line naming the remaining count (the reported total is always the full count), so a very dirty worktree still produces a bounded, consumable reason instead of an unbounded one. Tests in `packages/core/test/claude-hook-decisions.test.mjs` (cap boundary at 50/51, order preservation) and `test/contracts/claude-hooks-settings.test.mjs` (e2e >1MB fixture).
+
 ## 1.0.0-rc.6 - 2026-08-16
 
 ### Added

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -422,6 +422,15 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
     .split("\n")
     .map((l) => l.trim())
     .filter(Boolean);
+  // The reason is fed back to the stopping subagent as context, so the path
+  // enumeration is capped: an unbounded list on a very dirty worktree produces a
+  // multi-megabyte reason that consumers truncate or choke on, burying the one
+  // actionable line. The count always reports the full total.
+  const MAX_LISTED_DIRTY_PATHS = 50;
+  const listed = dirty.slice(0, MAX_LISTED_DIRTY_PATHS).map((p) => "  " + p);
+  if (dirty.length > MAX_LISTED_DIRTY_PATHS) {
+    listed.push(`  … and ${dirty.length - MAX_LISTED_DIRTY_PATHS} more (run \`git status --porcelain\` for the full list)`);
+  }
   return {
     decision: "block",
     reason:
@@ -429,6 +438,6 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
       "to prevent silent data loss from post-merge worktree cleanup (cleanup-worktree.mjs runs " +
       "`git worktree remove --force`). Commit your work before stopping. " +
       `Dirty paths (${dirty.length}):\n` +
-      dirty.map((p) => "  " + p).join("\n"),
+      listed.join("\n"),
   };
 }

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -541,6 +541,16 @@ test("decideSubagentStopGuard treats a non-string cwd as out-of-scope (allow)", 
   assert.equal(decideSubagentStopGuard({ cwd: undefined, porcelain: " M x" }).decision, "allow");
 });
 
+test("decideSubagentStopGuard caps the enumerated dirty paths at 50 and reports the full count", () => {
+  const lines = Array.from({ length: 120 }, (_, i) => `?? file-${String(i).padStart(3, "0")}.txt`);
+  const d = decideSubagentStopGuard({ cwd: WT, porcelain: lines.join("\n") });
+  assert.equal(d.decision, "block");
+  assert.match(d.reason, /Dirty paths \(120\):/);
+  assert.match(d.reason, /file-049\.txt/);
+  assert.doesNotMatch(d.reason, /file-050\.txt/);
+  assert.match(d.reason, /… and 70 more/);
+});
+
 // ---------------------------------------------------------------------------
 // decideBashGate — the six guard rules enforced at one seam (#1622)
 // ---------------------------------------------------------------------------

--- a/packages/core/test/claude-hook-decisions.test.mjs
+++ b/packages/core/test/claude-hook-decisions.test.mjs
@@ -541,14 +541,40 @@ test("decideSubagentStopGuard treats a non-string cwd as out-of-scope (allow)", 
   assert.equal(decideSubagentStopGuard({ cwd: undefined, porcelain: " M x" }).decision, "allow");
 });
 
-test("decideSubagentStopGuard caps the enumerated dirty paths at 50 and reports the full count", () => {
-  const lines = Array.from({ length: 120 }, (_, i) => `?? file-${String(i).padStart(3, "0")}.txt`);
+test("decideSubagentStopGuard caps the enumerated dirty paths at 50, reports the full count, and preserves porcelain order", () => {
+  // Descending index order (not ascending/sorted) so the assertions can tell "preserves
+  // porcelain order" apart from "sorts the paths" — git porcelain lists tracked
+  // staged/modified paths before untracked ones, and a sort creeping into the decider would
+  // displace the higher-data-loss-risk entries out of the first 50 shown.
+  const lines = Array.from({ length: 120 }, (_, i) => `?? file-${String(119 - i).padStart(3, "0")}.txt`);
   const d = decideSubagentStopGuard({ cwd: WT, porcelain: lines.join("\n") });
   assert.equal(d.decision, "block");
   assert.match(d.reason, /Dirty paths \(120\):/);
+  assert.match(d.reason, /file-119\.txt/);
+  assert.match(d.reason, /file-070\.txt/);
+  assert.doesNotMatch(d.reason, /file-069\.txt/);
+  assert.match(d.reason, /… and 70 more/);
+  const firstListedPath = d.reason.split("\n")[1].trim();
+  assert.equal(firstListedPath, lines[0], "first listed path must be the first porcelain line verbatim (order preserved, not sorted)");
+});
+
+test("decideSubagentStopGuard lists all paths with no truncation summary at exactly the 50-path cap", () => {
+  const lines = Array.from({ length: 50 }, (_, i) => `?? file-${String(i).padStart(3, "0")}.txt`);
+  const d = decideSubagentStopGuard({ cwd: WT, porcelain: lines.join("\n") });
+  assert.equal(d.decision, "block");
+  assert.match(d.reason, /Dirty paths \(50\):/);
+  assert.match(d.reason, /file-049\.txt/);
+  assert.doesNotMatch(d.reason, /… and/);
+});
+
+test("decideSubagentStopGuard adds a one-more truncation summary at 51 dirty paths (smallest over-cap input)", () => {
+  const lines = Array.from({ length: 51 }, (_, i) => `?? file-${String(i).padStart(3, "0")}.txt`);
+  const d = decideSubagentStopGuard({ cwd: WT, porcelain: lines.join("\n") });
+  assert.equal(d.decision, "block");
+  assert.match(d.reason, /Dirty paths \(51\):/);
   assert.match(d.reason, /file-049\.txt/);
   assert.doesNotMatch(d.reason, /file-050\.txt/);
-  assert.match(d.reason, /… and 70 more/);
+  assert.match(d.reason, /… and 1 more/);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -363,3 +363,29 @@ test("SubagentStop hook fail-safe-allows a mkdir-only (non-git) dir under tmp/wo
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node default maxBuffer (#1686)", () => {
+  // With Node's default execFileSync maxBuffer (1MB), ~4000+ dirty paths make
+  // `git status --porcelain` throw ERR_CHILD_PROCESS_STDIO_MAXBUFFER, and the catch
+  // turns that into a fail-safe allow — defeating the guard on exactly the worktrees
+  // with the most uncommitted work. The hook raises maxBuffer to 10MB; this test
+  // creates enough long-named untracked files to push porcelain past 1MB and asserts
+  // the guard still blocks. Beyond 10MB the fail-safe allow is the documented ceiling.
+  const dir = makeWorktree("maxbuffer", false);
+  try {
+    const name = (i) => `f${String(i).padStart(5, "0")}-${"x".repeat(230)}.txt`;
+    // ~4600 files x ~240-byte porcelain lines ≈ 1.1MB of status output.
+    for (let i = 0; i < 4600; i++) {
+      fs.writeFileSync(path.join(dir, name(i)), "", "utf8");
+    }
+    const porcelainBytes = spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }).stdout.length;
+    assert.ok(porcelainBytes > 1024 * 1024, `fixture must exceed the 1MB default maxBuffer (got ${porcelainBytes} bytes)`);
+    const { code, stderrJson } = runHook("subagent-stop-uncommitted-guard.mjs", { cwd: dir });
+    assert.equal(code, 2, "a >1MB-porcelain dirty worktree must still be refused (exit 2)");
+    assert.ok(stderrJson, "block reason JSON on stderr");
+    assert.equal(stderrJson.decision, "block");
+    assert.match(stderrJson.reason, /LOCAL-COMMIT-BEFORE-EXIT/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -380,7 +380,7 @@ test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node 
     for (let i = 0; i < 4600; i++) {
       fs.writeFileSync(path.join(dir, name(i)), "", "utf8");
     }
-    const porcelainBytes = spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }).stdout.length;
+    const porcelainBytes = Buffer.byteLength(spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }).stdout, "utf8");
     assert.ok(porcelainBytes > 1024 * 1024, `fixture must exceed the 1MB default maxBuffer (got ${porcelainBytes} bytes)`);
     const { code, stderrJson } = runHook("subagent-stop-uncommitted-guard.mjs", { cwd: dir });
     assert.equal(code, 2, "a >1MB-porcelain dirty worktree must still be refused (exit 2)");

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -365,12 +365,14 @@ test("SubagentStop hook fail-safe-allows a mkdir-only (non-git) dir under tmp/wo
 });
 
 test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node default maxBuffer (#1686)", () => {
-  // With Node's default execFileSync maxBuffer (1MB), ~4000+ dirty paths make
-  // `git status --porcelain` throw ERR_CHILD_PROCESS_STDIO_MAXBUFFER, and the catch
+  // With Node's default execFileSync maxBuffer (1MB), `git status --porcelain` throws
+  // ERR_CHILD_PROCESS_STDIO_MAXBUFFER once the output crosses that size, and the catch
   // turns that into a fail-safe allow — defeating the guard on exactly the worktrees
   // with the most uncommitted work. The hook raises maxBuffer to 10MB; this test
   // creates enough long-named untracked files to push porcelain past 1MB and asserts
-  // the guard still blocks. Beyond 10MB the fail-safe allow is the documented ceiling.
+  // the guard still blocks. Using this fixture's long (~245-byte) porcelain lines, that
+  // takes ~4300+ files; real (much shorter) paths need far more to hit the same bound.
+  // Beyond 10MB (~43k+ such long-line paths) the fail-safe allow is the documented ceiling.
   const dir = makeWorktree("maxbuffer", false);
   try {
     const name = (i) => `f${String(i).padStart(5, "0")}-${"x".repeat(230)}.txt`;
@@ -385,6 +387,10 @@ test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node 
     assert.ok(stderrJson, "block reason JSON on stderr");
     assert.equal(stderrJson.decision, "block");
     assert.match(stderrJson.reason, /LOCAL-COMMIT-BEFORE-EXIT/);
+    // The reason itself stays bounded (the 50-path cap), not merely parseable off stderr —
+    // pins the cap end to end rather than relying on runHook's own maxBuffer as an incidental
+    // proxy for it.
+    assert.match(stderrJson.reason, /… and 4550 more/);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

The SubagentStop uncommitted-work guard's `git status --porcelain` call could exceed Node's default 1MB `execFileSync` maxBuffer, throw, and fall into the fail-safe-allow catch — defeating the guard on exactly the worktrees with the most uncommitted work. The call now runs with a 10MB maxBuffer, and the block reason caps its dirty-path enumeration at 50 paths plus a full-count summary so the output stays consumable by the harness and the stopping subagent.

## Scope and context

Six files: the hook (`.claude/hooks/subagent-stop-uncommitted-guard.mjs`, hand-written), the shared decision function in core (`packages/core/src/claude/hook-decisions.mjs`) with its regenerated vendored copy (`.claude/hooks/_hook-decisions.mjs`), one test file per layer, and a CHANGELOG entry. The reason-cap is a companion fix discovered by the new e2e test: an unbounded path list on a 4600-file worktree produced a >1MB stderr reason that consumers truncate or choke on.

## Acceptance criteria

- [x] The `git status --porcelain` call in the SubagentStop guard runs with a 10MB maxBuffer; a large-but-realistic dirty worktree no longer trips the default limit into fail-safe allow.
- [x] A test exercises porcelain output exceeding the 1MB default and asserts the guard still blocks; the 10MB ceiling is documented in the hook comment.
- [x] The block reason lists at most 50 dirty paths plus a full-count summary line, pinned by unit tests at the 50/51 boundary (order-preserving) and by the e2e truncation-summary assertion.

## Definition of done

- [x] `node --test test/contracts/claude-hooks-settings.test.mjs` green (24 tests, incl. the new >1MB e2e case).
- [x] `node --test packages/core/test/claude-hook-decisions.test.mjs` green (73 tests, incl. the path-cap unit case and the 50/51 boundary cases).
- [x] `npm run assets:check` green (vendored hook copy regenerated).
- [x] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| 10MB maxBuffer on the porcelain call | claude-hooks-settings e2e suite green | fail-safe allow on genuine git errors unchanged |
| >1MB porcelain still blocks, ceiling documented | new e2e test (4600-file fixture, >1MB verified) plus the hook comment | no behavior change beyond the buffer and the reason cap |
| Reason stays consumable (path list capped at 50 + full count) | new unit test in claude-hook-decisions suite | — |

## Non-goals

- Changing the fail-safe-allow behavior on genuine git errors / timeouts (correct as-is; pinned by the existing non-git e2e test).

## Open questions

None. The one open design point surfaced in review — whether the reason should also carry a byte-level cap in addition to the 50-path cap — was judged a follow-up, not a blocker (the 50-path cap bounds the realistic case; a byte cap would only matter for pathological single-path lengths).

## Validation

```sh
node --test test/contracts/claude-hooks-settings.test.mjs
node --test packages/core/test/claude-hook-decisions.test.mjs
npm run assets:check && npm run verify
```

Closes #1686
