### PR TITLE
fix(ci-watch): bail zero-allocation stalls when other providers are terminal (#1665)

### DIFF
--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -46,8 +46,9 @@ Statuses:
   changed    Head SHA advanced during the wait; caller must re-baseline
   stuck      Zero-allocation stall bail (#1631): every check-run stayed QUEUED
              with zero jobs allocated (no runner picked up) and no other provider
-             reporting activity for ~5 min; treated as a stuck GitHub Actions
-             queue and bailed early instead of burning the full watch budget
+             actively progressing (commit-status absent or already terminal, i.e.
+             not pending) for ~5 min; treated as a stuck GitHub Actions queue and
+             bailed early instead of burning the full watch budget
 No-checks rule (grace, race-safe):
   Zero check-runs AND zero commit-statuses is NOT settled green on the first
   poll — a provider (CircleCI/Actions) may post its first check a beat after a
@@ -384,10 +385,10 @@ export const NO_CHECKS_GRACE_POLLS = 2;
 
 /** Zero-allocation stall bail budget (#1631): when a CI run is QUEUED with zero
  *  jobs allocated (no runner picked up — every check-run still `queued`, no other
- *  provider reporting activity), the watcher bails after ~5 min instead of burning
- *  the full 30-min watch budget on a stuck GitHub Actions queue. A run that IS
- *  progressing (any check-run in_progress/completed, or another provider pending)
- *  is never bailed early. */
+ *  provider actively progressing: commit-status absent or already terminal), the
+ *  watcher bails after ~5 min instead of burning the full 30-min watch budget on
+ *  a stuck GitHub Actions queue. A run that IS progressing (any check-run
+ *  in_progress/completed, or another provider pending) is never bailed early. */
 export const ZERO_ALLOCATION_STALL_BAIL_MS = 300_000; // ~5 minutes
 
 /**
@@ -427,8 +428,9 @@ export async function watchCiStatus(
   const graceFloor = options.timeoutMs === 0 ? 1 : NO_CHECKS_GRACE_POLLS;
   let consecutiveNoChecks = 0;
   // Zero-allocation stall bail (#1631): track the first poll that observed a
-  // zero-allocation stall (all check-runs queued, no provider activity). The
-  // watcher bails once the stall has persisted for stallBailMs instead of
+  // zero-allocation stall (all check-runs queued, no provider actively
+  // progressing — commit-status absent or already terminal). The watcher
+  // bails once the stall has persisted for stallBailMs instead of
   // burning the full watch budget on a stuck GitHub Actions queue.
   const stallBailMs = options.stallBailMs ?? ZERO_ALLOCATION_STALL_BAIL_MS;
   let stallStartedAtMs = null;

--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -329,7 +329,8 @@ async function fetchHeadCiState({ repo, headSha, prVisibleCheckNames }, { env, g
     !(nonLoopDerivedPrVisibleNames?.length > 0);
   // Zero-allocation stall (#1631): at least one real check-run, ALL of them
   // still `queued` (no runner allocated / no job picked up), and no other
-  // provider actively progressing (commit-status not pending). A commit-status
+  // provider actively progressing — the stall qualifies only when the
+  // commit-status is absent or already terminal (never pending). A commit-status
   // that already reached a terminal state (success/failure) or is absent means
   // nobody is making progress while GitHub Actions sits unallocated, so the
   // watcher bails after ZERO_ALLOCATION_STALL_BAIL_MS of observing this

--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -328,15 +328,17 @@ async function fetchHeadCiState({ repo, headSha, prVisibleCheckNames }, { env, g
     !(nonLoopDerivedPrVisibleNames?.length > 0);
   // Zero-allocation stall (#1631): at least one real check-run, ALL of them
   // still `queued` (no runner allocated / no job picked up), and no other
-  // provider reporting activity (commit-status none). The watcher bails after
-  // ZERO_ALLOCATION_STALL_BAIL_MS of observing this instead of burning its
-  // full budget on a stuck GitHub Actions queue. A run with any job
-  // in_progress/completed, or another provider pending, never qualifies.
+  // provider actively progressing (commit-status not pending). A commit-status
+  // that already reached a terminal state (success/failure) or is absent means
+  // nobody is making progress while GitHub Actions sits unallocated, so the
+  // watcher bails after ZERO_ALLOCATION_STALL_BAIL_MS of observing this
+  // instead of burning its full budget on a stuck queue. A run with any job
+  // in_progress/completed, or another provider still pending, never qualifies.
   const allCheckRunsQueued =
     !fetchError &&
     checkRunsCount > 0 &&
     checkRunsSignal?.allQueued === true &&
-    commitStatus === "none";
+    commitStatus !== "pending";
   return { ciStatus, noChecks, fetchError, failedChecks, excludedFailureDetails, allCheckRunsQueued };
 }
 

--- a/test/github/probe-ci-status.test.mjs
+++ b/test/github/probe-ci-status.test.mjs
@@ -926,6 +926,34 @@ test("watch-ci bails stuck when check-runs are queued and another provider alrea
       );
       assert.equal(result.status, "stuck");
       assert.equal(result.settled, false);
+      assert.equal(result.ciStatus, "pending");
+      // attempt 1 @ t=0 (stall starts), attempt 2 @ t=30, attempt 3 @ t=60 -> bail.
+      assert.equal(result.attempts, 3);
+    },
+  );
+});
+
+test("watch-ci settles failure, not stuck, when check-runs are queued and another provider failed (#1665)", async () => {
+  // Failure variant of the mixed-provider case: a terminal failure commit-status
+  // beside an unallocated queue settles the combined CI status as failure before
+  // the stall branch is ever consulted — the watcher reports the failure rather
+  // than a stall bail.
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build"]) },
+        { match: ["check-runs"], stdout: checkRuns([{ status: "queued", conclusion: null, name: "build" }]) },
+        { match: ["/status"], stdout: statuses([{ state: "failure", context: "ci/circleci: build" }]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 10_000, stallBailMs: 50 },
+        advancingDeps(env),
+      );
+      assert.equal(result.ciStatus, "failure");
+      assert.equal(result.settled, true);
+      assert.notEqual(result.status, "stuck");
     },
   );
 });

--- a/test/github/probe-ci-status.test.mjs
+++ b/test/github/probe-ci-status.test.mjs
@@ -903,6 +903,33 @@ test("watch-ci does NOT bail stuck when another provider is pending (commit-stat
   );
 });
 
+test("watch-ci bails stuck when check-runs are queued and another provider already succeeded (#1665)", async () => {
+  // Mixed-provider stall: every check-run stays queued (zero allocation) while a
+  // commit-status provider (e.g. CircleCI) already reported success — nobody is
+  // actively progressing, so the watcher bails "stuck" after the stall window
+  // instead of burning the full budget waiting on an unallocated queue.
+  await withGhStub(
+    {
+      routes: [
+        { match: ["pr", "view"], stdout: prView("sha-a", ["build", "lint"]) },
+        { match: ["check-runs"], stdout: checkRuns([
+          { status: "queued", conclusion: null, name: "build" },
+          { status: "queued", conclusion: null, name: "lint" },
+        ]) },
+        { match: ["/status"], stdout: statuses([{ state: "success", context: "ci/circleci: build" }]) },
+      ],
+    },
+    async (env) => {
+      const result = await watchCiStatus(
+        { repo: "owner/repo", pr: 7, pollIntervalMs: 30, timeoutMs: 10_000, stallBailMs: 50 },
+        advancingDeps(env),
+      );
+      assert.equal(result.status, "stuck");
+      assert.equal(result.settled, false);
+    },
+  );
+});
+
 test("watch-ci resets the stall when a stuck run starts progressing and settles success (#1631)", async () => {
   // Polls 1-2: all queued (stall accumulates but under the bail window). Poll 3:
   // the run starts progressing and completes success. Must settle success, NOT


### PR DESCRIPTION
## Summary

The zero-allocation stall bail now also fires in the mixed-provider case: all GitHub Actions check-runs stuck `queued` while another commit-status provider already reached a terminal state (e.g. success). Previously the qualifier required a completely absent commit-status, so that case burned the full watch budget.

## Scope and context

Two files: the qualifier in `fetchHeadCiState` (`scripts/github/probe-ci-status.mjs`, `commitStatus === "none"` loosened to `commitStatus !== "pending"`, comments/usage text updated across four sites) and two new watcher tests (mixed-provider success bail; failure-variant settling). The conservative guarantee is unchanged: an actively pending provider, or any check-run in progress, still never bails.

## Acceptance criteria

- [x] All check-runs `queued` plus a non-pending commit-status (e.g. success) bails `stuck` within the stall window instead of burning the full budget.
- [x] A pending commit-status (provider actively progressing) still does NOT bail early (existing test stays green).
- [x] `npm run verify`, `assets:check` (exit 0 at heads 94b4d735 and 176baa80), `schema:check` (exit 0; also inside the recorded validation at this head); zero new failures vs baseline.

## Definition of done

- [x] `node --test test/github/probe-ci-status.test.mjs` green (36 tests, incl. the mixed-provider success and failure-variant cases).
- [x] `npm run verify` green (recorded in the gate validation artifact).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Mixed-provider stall bails stuck within the window | new watcher test (queued runs + success status → stuck) | stall window length unchanged |
| Pending provider never bailed early | existing no-bail test stays green | progressing check-runs never bailed (existing tests) |
| Full verification | npm run verify green, assets:check, schema:check | — |

## Non-goals

- No change to the stall window (ZERO_ALLOCATION_STALL_BAIL_MS) or the stall-reset behavior.
- No change to how loop-derived statuses are excluded (#1531 behavior untouched).

## Open questions

None. A failure commit-status also satisfies the loosened qualifier, but the combined ciStatus settles as failure before the stall bail is consulted, so the qualifier firing there is unreachable in practice.

## Validation

```sh
node --test test/github/probe-ci-status.test.mjs
npm run verify
```

Closes #1665
