### PR TITLE
gate: dedupe the blocking-severity scan + revert-failing guard for the no-fanout label carve-out (#1643)

### DIFF
--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1538,6 +1538,34 @@ function deriveEffectiveNextAction(verdict, gate) {
   return gate === "draft_gate" ? "stay draft and fix" : "rerun gate";
 }
 
+// Shared per-angle blocking-severity scan over structuredFindings, used by both
+// roundCarriesBlockingSeverity's escalation check and the clean-verdict
+// refusal's structured-findings cross-check. The RESOLVED_DISPOSITIONS skip
+// applies only to parseable findings; an angle.unparseable entry carries no
+// disposition to resolve against and is judged on severity alone. Returns the
+// subset of `blocking` actually observed (in `blocking`'s order, so a caller
+// can render it directly into a message) plus whether any observed hit came
+// from an unparseable finding.
+function scanBlockingFindings(structuredFindings, blocking) {
+  const observed = new Set();
+  let unparseableBlocking = false;
+  for (const angle of structuredFindings) {
+    for (const f of angle.findings) {
+      if (RESOLVED_DISPOSITIONS.has(f.disposition)) continue;
+      const sev = /** @type {string} */ (normalizeSeverity(f.severity));
+      if (blocking.includes(sev)) observed.add(sev);
+    }
+    for (const u of angle.unparseable ?? []) {
+      const sev = /** @type {string} */ (normalizeSeverity(u.severity));
+      if (blocking.includes(sev)) {
+        observed.add(sev);
+        unparseableBlocking = true;
+      }
+    }
+  }
+  return { blockingObserved: blocking.filter((sev) => observed.has(sev)), unparseableBlocking };
+}
+
 // GATE-EXEC-LIGHT-ESCALATION (#1621): does this round carry a finding at a
 // blocking severity? A `findings_present` verdict is DEFINED as "found issues
 // at blocking severities" (GATE-COMMENT-VERDICT-VALUES), so it always carries
@@ -1551,21 +1579,7 @@ function roundCarriesBlockingSeverity({ verdict, structuredFindings, findingsSev
     return false;
   }
   if (structuredFindings) {
-    for (const angle of structuredFindings) {
-      for (const f of angle.findings) {
-        if (RESOLVED_DISPOSITIONS.has(f.disposition)) continue;
-        if (blocking.includes(/** @type {string} */ (normalizeSeverity(f.severity)))) return true;
-      }
-      // An unparseable finding carries no disposition to resolve against, so
-      // it is judged on its severity alone — the same representation the
-      // clean-verdict tally uses, so an inline round that surfaces an
-      // unparseable blocking finding escalates gate:full just as it would
-      // block a clean verdict (#1526).
-      for (const u of angle.unparseable ?? []) {
-        if (blocking.includes(/** @type {string} */ (normalizeSeverity(u.severity)))) return true;
-      }
-    }
-    return false;
+    return scanBlockingFindings(structuredFindings, blocking).blockingObserved.length > 0;
   }
   if (findingsSeverityCounts && typeof findingsSeverityCounts === "object") {
     return blocking.some((sev) => (findingsSeverityCounts[sev] ?? 0) > 0);
@@ -1936,31 +1950,17 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     && activeGateConfig.blockCleanOnFindingSeverities
     && activeGateConfig.blockCleanOnFindingSeverities.length > 0
   ) {
-    const observedCounts = Object.fromEntries(SEVERITY_ORDER.map((sev) => [sev, 0]));
-    // Track whether any blocking-severity hit came from an UNPARSEABLE finding,
-    // so the refusal message can name the real cause (#1526): a finding the
-    // normalizer dropped used to pass this cross-check silently; now it is
-    // tallied from the section's `unparseable` list and fails the verdict
-    // exactly as a parseable blocking finding would. An unparseable finding
-    // carries no disposition to resolve against, so it is judged on its
-    // severity alone — a blocking severity fails, any other value (including
-    // none at all) is reported explicitly as unparseable in the rendered
-    // comment rather than blocking the clean verdict.
-    let unparseableBlocking = false;
-    for (const angle of structuredFindings) {
-      for (const f of angle.findings) {
-        if (RESOLVED_DISPOSITIONS.has(f.disposition)) continue;
-        const sev = /** @type {string} */ (normalizeSeverity(f.severity));
-        if (Object.hasOwn(observedCounts, sev)) observedCounts[sev] += 1;
-      }
-      for (const u of angle.unparseable ?? []) {
-        const sev = /** @type {string} */ (normalizeSeverity(u.severity));
-        if (Object.hasOwn(observedCounts, sev)) observedCounts[sev] += 1;
-        if (activeGateConfig.blockCleanOnFindingSeverities.includes(sev)) unparseableBlocking = true;
-      }
-    }
-    const blockingObserved = activeGateConfig.blockCleanOnFindingSeverities.filter(
-      (sev) => (observedCounts[sev] ?? 0) > 0,
+    // An unparseable finding carries no disposition to resolve against, so it
+    // is judged on its severity alone — a blocking severity fails, any other
+    // value (including none at all) is reported explicitly as unparseable in
+    // the rendered comment rather than blocking the clean verdict. The
+    // `unparseableBlocking` flag lets the refusal message name the real cause
+    // (a finding the normalizer dropped used to pass this cross-check
+    // silently; now it fails the verdict exactly as a parseable blocking
+    // finding would).
+    const { blockingObserved, unparseableBlocking } = scanBlockingFindings(
+      structuredFindings,
+      activeGateConfig.blockCleanOnFindingSeverities,
     );
     if (blockingObserved.length > 0) {
       throw new Error(

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6262,6 +6262,12 @@ test("#1621: a findings_present draft_gate verdict DERIVES the next action, igno
     const body = JSON.parse(postCall.stdinText).body;
     assert.match(body, /\*\*Next action:\*\* stay draft and fix/);
     assert.doesNotMatch(body, /\*\*Next action:\*\* merge/);
+    // requireFanoutEvidence:false (stageConfigRepoRoot(false)) opts this repo
+    // out of gate:full escalation even though the round carries a blocking
+    // (high) severity: no label call fires and gateFullLabelApplied is unset.
+    assert.equal(result.gateFullLabelApplied, undefined);
+    assert.equal(calls.some((c) => c.args[0] === "label" && c.args[1] === "create"), false);
+    assert.equal(calls.some((c) => c.args[0] === "pr" && c.args[1] === "edit" && c.args.includes("--add-label")), false);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -2308,6 +2308,10 @@ test("upsert-checkpoint-verdict rejects a clean verdict whose --findings-json ca
     assert.match(payload.error, /Cannot set verdict "clean"/);
     assert.match(payload.error, /findings-json.*own per-angle findings show unresolved findings/);
     assert.match(payload.error, /high/);
+    // Parseable-only refusal: the UNPARSEABLE sentence must be absent, pinning
+    // that the shared scan reports unparseableBlocking only for genuinely
+    // unparseable entries.
+    assert.doesNotMatch(payload.error, /UNPARSEABLE/i);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Two deferred low findings from the verdict-precondition drive, landed together: the blocking-severity scan over structured findings now lives in one shared helper used by both `roundCarriesBlockingSeverity` and the clean-verdict cross-check (they could previously drift), and a revert-failing test now guards the `requireFanoutEvidence:false` non-application of the gate:full label.

## Scope and context

Two files. `scripts/github/upsert-checkpoint-verdict.mjs` gains the module-local `scanBlockingFindings(structuredFindings, blocking)` returning the observed blocking severities plus an unparseable-blocking flag; both former inline loops now call it. The disposition-skip asymmetry survives (resolved dispositions skip parseable findings only, never unparseable entries), the severity-counts and bare findings_present fallbacks stay in `roundCarriesBlockingSeverity`, and the clean-verdict refusal message is byte-identical. Two test edits: the existing derive test gains assertions that a findings_present inline round under `requireFanoutEvidence:false` applies no gate:full label (result field undefined; no label-create or add-label gh call), and the parseable-only clean-refusal test gains a negative pin asserting its message is UNPARSEABLE-free (binding the helper's unparseable-blocking flag in both directions).

## Acceptance criteria

- [x] One shared helper performs the per-angle blocking-severity scan; both call sites use it and neither retains its own loop.
- [x] The helper skips resolved parseable findings only; unparseable entries are never skipped.
- [x] The clean-verdict refusal message is byte-identical, UNPARSEABLE sentence included; the existing regex test passes unchanged.
- [x] The severity-counts and bare findings_present fallbacks remain in roundCarriesBlockingSeverity.
- [x] A test asserts gateFullLabelApplied is undefined for a findings_present inline round under requireFanoutEvidence:false.
- [x] The same test asserts no label-create and no add-label gh call fired.
- [x] Reverting the guard conjunct makes the new test fail (verified locally, revert not committed: strict-equal failure observed, plus six pre-existing tests also failing on the reverted guard).

## Definition of done

- [x] `node --test test/github/upsert-checkpoint-verdict.test.mjs` green (168 tests).
- [x] `npm run verify` green (gate validation artifact at head).
- [x] `npm run assets:check` (exit 0) and `npm run schema:check` (exit 0).
- [x] Behavior-preserving: no CLI output, exit-code, or posted-comment change; one module-local helper, no new exports.
- [x] Scope-bounded to the two files.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Shared scan helper, both call sites, no duplicate loops | upsert-checkpoint-verdict suite green (168) | blockCleanOnFindingSeverities policy unchanged |
| Disposition-skip asymmetry preserved | suite green; refusal message byte-identical | gate:full semantics unchanged |
| Severity-counts and bare findings_present fallbacks unchanged | suite green (fallback tests untouched) | ombase mirror untouched |
| Revert-failing label guard test | revert verified locally (not committed) | all-fetch-failure fail-closed question stays open |
| Full verification | npm run verify, assets:check, schema:check | ombase mirror untouched |

## Non-goals

- Changing the `blockCleanOnFindingSeverities` policy (medium/low deferral is intentional).
- The separate deferred question whether a ready-PR all-fetch-failure should fail closed on the unticked-AC check.
- Changing gate:full label semantics or escalation triggers.
- Touching the mirrored copy under ombase/.

## Open questions

None.

## Validation

```sh
node --test test/github/upsert-checkpoint-verdict.test.mjs
npm run verify
```

Closes #1643
