### PR TITLE
fix(guard): comment-id guard skips HTML numeric entities; verdict poster gains --allowed-refs (#1743)

### DIFF
--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -45,11 +45,12 @@ function isNumericCharacterReference(body, match) {
 }
 
 // An entity that DECODES to the hash character (`&#35;` decimal or `&#x23;`
-// hex, case-insensitive), immediately followed by an issue-length digit run,
-// renders as a bare `#<digits>` auto-link on GitHub even though no literal
-// hash-digit token exists in the raw body. Treated as a bare-id occurrence so
-// the encoded form cannot smuggle a reference past the guard.
-const ENCODED_HASH_ID_RE = /&#(?:35|x23);(\d{1,9})/gi;
+// hex, case-insensitive, zero-padding accepted — CommonMark decodes padded
+// forms too), immediately followed by an issue-length digit run, renders as a
+// bare `#<digits>` auto-link on GitHub even though no literal hash-digit token
+// exists in the raw body. Treated as a bare-id occurrence so the encoded form
+// cannot smuggle a reference past the guard.
+const ENCODED_HASH_ID_RE = /&#(?:0*35|x0*23);(\d{1,9})/gi;
 
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -22,10 +22,12 @@
  *
  * Deliberate cross-reference mechanism: pass the id(s) to allow as
  * `allowedRefs: ["1670"]`. Aside from a genuine HTML numeric character
- * reference (`&#<digits>;`, e.g. `&#91;` for `[`), which is never an
- * issue/PR auto-link and so is excluded from the scan entirely, this is the
- * ONLY sanctioned way a generated comment body may carry a `#<digits>` token.
- * Keep the allowlist small and deliberate.
+ * reference (`&#<digits>;`, e.g. `&#91;` for `[`) — each such OCCURRENCE is
+ * skipped; the same digit run appearing elsewhere as a bare token still
+ * refuses — this is the ONLY sanctioned way a generated comment body may
+ * carry a `#<digits>` token. An entity that itself decodes to the hash
+ * character followed by a digit run is treated as a bare id (it renders as
+ * an auto-link). Keep the allowlist small and deliberate.
  */
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
@@ -42,6 +44,13 @@ function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }
 
+// An entity that DECODES to the hash character (`&#35;` decimal or `&#x23;`
+// hex, case-insensitive), immediately followed by an issue-length digit run,
+// renders as a bare `#<digits>` auto-link on GitHub even though no literal
+// hash-digit token exists in the raw body. Treated as a bare-id occurrence so
+// the encoded form cannot smuggle a reference past the guard.
+const ENCODED_HASH_ID_RE = /&#(?:35|x23);(\d{1,9})/gi;
+
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).
  * Returns [] for non-string input (and for a body with no `#<digits>`).
@@ -51,6 +60,9 @@ export function extractIssuePrIds(body) {
   const found = new Set();
   for (const m of body.matchAll(ISSUE_PR_ID_RE)) {
     if (isNumericCharacterReference(body, m)) continue;
+    found.add(m[1]);
+  }
+  for (const m of body.matchAll(ENCODED_HASH_ID_RE)) {
     found.add(m[1]);
   }
   return [...found];

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -21,16 +21,26 @@
  * helpers cannot emit an issue/PR id without an explicit allowlist entry.
  *
  * Deliberate cross-reference mechanism: pass the id(s) to allow as
- * `allowedRefs: ["1670"]`. This is the ONLY sanctioned way a generated comment
- * body may reference an issue/PR id. Keep the allowlist small and deliberate.
+ * `allowedRefs: ["1670"]`. Aside from a genuine HTML numeric character
+ * reference (`&#<digits>;`, e.g. `&#91;` for `[`), which is never an
+ * issue/PR auto-link and so is excluded from the scan entirely, this is the
+ * ONLY sanctioned way a generated comment body may carry a `#<digits>` token.
+ * Keep the allowlist small and deliberate.
  */
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
 // 1..9 digits to avoid absurd ids while covering the full GitHub id space.
-// Excludes a `#<digits>` preceded by `&`, since that's a numeric character
-// reference (e.g. `&#91;`, the entity-encoded form of `[`) rather than an
-// issue/PR auto-link.
-const ISSUE_PR_ID_RE = /(?<!&)#(\d{1,9})/g;
+// A match is excluded only when it forms a well-formed HTML numeric character
+// reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
+// the entity-encoded form of `[`). Any other shape (a bare `#123`, an
+// `&`-preceded run with no terminating `;`, or a `;`-followed run with no
+// preceding `&`) is not a well-formed entity and still refuses as a genuine
+// auto-link candidate.
+const ISSUE_PR_ID_RE = /#(\d{1,9})/g;
+
+function isNumericCharacterReference(body, match) {
+  return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
+}
 
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).
@@ -40,9 +50,26 @@ export function extractIssuePrIds(body) {
   if (typeof body !== "string" || body.length === 0) return [];
   const found = new Set();
   for (const m of body.matchAll(ISSUE_PR_ID_RE)) {
+    if (isNumericCharacterReference(body, m)) continue;
     found.add(m[1]);
   }
   return [...found];
+}
+
+// A caller-supplied allowlist is normally already an array (or other
+// iterable) of ids. Guard the one mis-shaped input that would otherwise
+// silently produce the wrong set: a plain CSV string. `Array.from` over a
+// string character-splits it ("1670" -> ["1","6","7","0"]), which would
+// spuriously allowlist single-digit refs while still refusing the id the
+// caller meant to allow. Mirrors parseAllowedRefsCsv's comma-split (trim,
+// drop empties) — deliberately without its numeric validation, since this is
+// a permissive low-level guard, not the CLI arg parser.
+function normalizeAllowedRefs(allowedRefs) {
+  if (allowedRefs == null) return [];
+  if (typeof allowedRefs === "string") {
+    return allowedRefs.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  return Array.from(allowedRefs, (id) => String(id));
 }
 
 /**
@@ -53,13 +80,15 @@ export function extractIssuePrIds(body) {
  * @param {string} body - the generated comment body to guard.
  * @param {object} [opts]
  * @param {string} [opts.ref] - human label for the guarded surface (error context).
- * @param {Iterable<number|string>} [opts.allowedRefs] - explicit allowlist of
- *   deliberate cross-reference ids permitted to appear in the body.
+ * @param {Iterable<number|string>|string} [opts.allowedRefs] - explicit
+ *   allowlist of deliberate cross-reference ids permitted to appear in the
+ *   body. A plain string is treated as a comma-separated list (like a CLI
+ *   `--allowed-refs` value), never character-split.
  * @returns {string} the (unchanged, since no stripping) body.
  */
 export function guardCommentBodyNoIssuePrIds(body, { ref = "generated comment body", allowedRefs = [] } = {}) {
   if (typeof body !== "string") return body;
-  const allow = new Set(Array.from(allowedRefs ?? [], (id) => String(id)));
+  const allow = new Set(normalizeAllowedRefs(allowedRefs));
   const offending = extractIssuePrIds(body).filter((id) => !allow.has(id));
   if (offending.length > 0) {
     throw new Error(

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -27,7 +27,10 @@
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
 // 1..9 digits to avoid absurd ids while covering the full GitHub id space.
-const ISSUE_PR_ID_RE = /#(\d{1,9})/g;
+// Excludes a `#<digits>` preceded by `&`, since that's a numeric character
+// reference (e.g. `&#91;`, the entity-encoded form of `[`) rather than an
+// issue/PR auto-link.
+const ISSUE_PR_ID_RE = /(?<!&)#(\d{1,9})/g;
 
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -97,6 +97,24 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.throws(() => guardCommentBodyNoIssuePrIds("see #456; details follow"), /#456/);
   });
 
+  test("an entity decoding to the hash character followed by a digit run is treated as a bare id (renders as an auto-link)", () => {
+    // decimal form
+    assert.deepEqual(extractIssuePrIds("see &#35;123 there"), ["123"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see &#35;123 there"), /#123/);
+    // hex form, case-insensitive
+    assert.deepEqual(extractIssuePrIds("see &#x23;456 there"), ["456"]);
+    assert.deepEqual(extractIssuePrIds("see &#X23;789 there"), ["789"]);
+    // an allowlisted id is still allowed through the encoded form
+    assert.equal(
+      guardCommentBodyNoIssuePrIds("see &#35;123 there", { allowedRefs: ["123"] }),
+      "see &#35;123 there",
+    );
+    // a hash-entity with no digit run after it stays inert
+    assert.deepEqual(extractIssuePrIds("literal hash: &#35; alone"), []);
+    // an unrelated entity whose code STARTS with the hash code point does not match
+    assert.deepEqual(extractIssuePrIds("&#3512; is one character"), []);
+  });
+
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {
     // Representative of renderGateReviewCommentBody output for a clean gate:
     // gate name, head SHA (hex), verdict, severity/angle labels — never a #digit.

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -67,6 +67,14 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
       () => guardCommentBodyNoIssuePrIds("&#91;see #123&#93;"),
       /#123/,
     );
+    // the SAME digit run as a well-formed entity AND as a bare id in one body:
+    // the entity occurrence is excluded, the bare occurrence still refuses —
+    // exclusion is per-occurrence, never per-id.
+    assert.deepEqual(extractIssuePrIds("&#91; and bare #91 too"), ["91"]);
+    assert.throws(
+      () => guardCommentBodyNoIssuePrIds("&#91; and bare #91 too"),
+      /#91/,
+    );
   });
 
   test("the numeric-character-reference exclusion requires BOTH the leading `&` AND the terminating `;` (well-formed &#<digits>; only)", () => {
@@ -83,6 +91,10 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     // swallow it just because it starts with `&#`.
     assert.deepEqual(extractIssuePrIds("A&#123 forms"), ["123"]);
     assert.throws(() => guardCommentBodyNoIssuePrIds("A&#123 forms"), /#123/);
+    // Third non-entity shape from the docblock: `;`-followed with no leading
+    // `&` — a bare id that happens to precede a semicolon still refuses.
+    assert.deepEqual(extractIssuePrIds("see #456; details follow"), ["456"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see #456; details follow"), /#456/);
   });
 
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -42,6 +42,20 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.throws(() => guardCommentBodyNoIssuePrIds("a #1670 b #999", { allowedRefs: ["1670"] }), /#999/);
   });
 
+  test("a CSV-string allowedRefs is comma-split, not character-split", () => {
+    const body = "Deliberate cross-ref to issue #1670, approved.";
+    // Array.from over a bare string would character-split "1670" into
+    // ["1","6","7","0"], silently allowlisting every single-digit ref while
+    // still refusing 1670 itself — the opposite of the caller's intent.
+    assert.equal(guardCommentBodyNoIssuePrIds(body, { allowedRefs: "1670" }), body);
+    assert.equal(
+      guardCommentBodyNoIssuePrIds("cross-refs #1670 and #9000 both allowed", { allowedRefs: "1670, 9000" }),
+      "cross-refs #1670 and #9000 both allowed",
+    );
+    // a single-digit ref is NOT silently allowed as a side effect of the split
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see #1", { allowedRefs: "1670" }), /#1\b/);
+  });
+
   test("does not match #digits inside an HTML numeric character reference", () => {
     assert.deepEqual(extractIssuePrIds("entity-encoded bracket: &#91;checkbox&#93;"), []);
     assert.equal(
@@ -53,6 +67,22 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
       () => guardCommentBodyNoIssuePrIds("&#91;see #123&#93;"),
       /#123/,
     );
+  });
+
+  test("the numeric-character-reference exclusion requires BOTH the leading `&` AND the terminating `;` (well-formed &#<digits>; only)", () => {
+    // Well-formed entity: excluded.
+    assert.deepEqual(extractIssuePrIds("&#91;"), []);
+    // No terminating `;`: not a well-formed entity, still a refused auto-link
+    // candidate — even though it happens to be `&`-preceded.
+    assert.deepEqual(extractIssuePrIds("&#91 no semicolon"), ["91"]);
+    // Bare `#<digits>`, no `&` at all: still refused.
+    assert.deepEqual(extractIssuePrIds("bare #123"), ["123"]);
+    // An `&`-preceded, issue-length digit run with no terminating `;` reads
+    // exactly like a real auto-link candidate that happens to sit after an
+    // ampersand (e.g. a query-string fragment) — the exclusion must not
+    // swallow it just because it starts with `&#`.
+    assert.deepEqual(extractIssuePrIds("A&#123 forms"), ["123"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("A&#123 forms"), /#123/);
   });
 
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -113,6 +113,11 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.deepEqual(extractIssuePrIds("literal hash: &#35; alone"), []);
     // an unrelated entity whose code STARTS with the hash code point does not match
     assert.deepEqual(extractIssuePrIds("&#3512; is one character"), []);
+    // zero-padded forms decode identically and are refused too
+    assert.deepEqual(extractIssuePrIds("see &#035;321 there"), ["321"]);
+    assert.deepEqual(extractIssuePrIds("see &#0035;654 there"), ["654"]);
+    assert.deepEqual(extractIssuePrIds("see &#x0023;987 there"), ["987"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see &#035;321 there"), /#321/);
   });
 
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -42,6 +42,19 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.throws(() => guardCommentBodyNoIssuePrIds("a #1670 b #999", { allowedRefs: ["1670"] }), /#999/);
   });
 
+  test("does not match #digits inside an HTML numeric character reference", () => {
+    assert.deepEqual(extractIssuePrIds("entity-encoded bracket: &#91;checkbox&#93;"), []);
+    assert.equal(
+      guardCommentBodyNoIssuePrIds("summary: &#91;x&#93; done", { ref: "inline finding" }),
+      "summary: &#91;x&#93; done",
+    );
+    // a genuine bare id right next to an entity is still refused
+    assert.throws(
+      () => guardCommentBodyNoIssuePrIds("&#91;see #123&#93;"),
+      /#123/,
+    );
+  });
+
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {
     // Representative of renderGateReviewCommentBody output for a clean gate:
     // gate name, head SHA (hex), verdict, severity/angle labels — never a #digit.

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -667,12 +667,12 @@ function parseReviewMutationResponse(payload) {
  * comment per locatable finding. GitHub 422s a COMMENT-event review with an
  * empty body, so the caller must always pass a rendered body.
  */
-export async function createGateReview({ repo, pr, headSha, body, comments }, { env, ghCommand, runChild = defaultRunChild }) {
-  // ISSUE/PR-ID GUARD (#1731): refuse a verdict body or inline finding comment
+export async function createGateReview({ repo, pr, headSha, body, comments, allowedRefs }, { env, ghCommand, runChild = defaultRunChild }) {
+  // ISSUE/PR-ID GUARD: refuse a verdict body or inline finding comment
   // that emits a raw issue/PR id (fail-closed) unless explicitly allowlisted.
-  guardCommentBodyNoIssuePrIds(body, { ref: "gate verdict comment body" });
+  guardCommentBodyNoIssuePrIds(body, { ref: "gate verdict comment body", allowedRefs });
   for (const comment of comments ?? []) {
-    guardCommentBodyNoIssuePrIds(comment?.body, { ref: "gate review inline finding comment" });
+    guardCommentBodyNoIssuePrIds(comment?.body, { ref: "gate review inline finding comment", allowedRefs });
   }
   const payload = { commit_id: headSha, event: "COMMENT", body, comments };
   const result = await runChild(
@@ -691,9 +691,9 @@ export async function createGateReview({ repo, pr, headSha, body, comments }, { 
  * already-submitted review — which is exactly why the caller body-files every
  * still-unposted finding on the update path.
  */
-export async function updateGateReview({ repo, pr, reviewId, body }, { env, ghCommand, runChild = defaultRunChild }) {
-  // ISSUE/PR-ID GUARD (#1731) — see createGateReview.
-  guardCommentBodyNoIssuePrIds(body, { ref: "gate verdict comment body" });
+export async function updateGateReview({ repo, pr, reviewId, body, allowedRefs }, { env, ghCommand, runChild = defaultRunChild }) {
+  // ISSUE/PR-ID GUARD — see createGateReview.
+  guardCommentBodyNoIssuePrIds(body, { ref: "gate verdict comment body", allowedRefs });
   const result = await runChild(
     ghCommand,
     ["api", "-X", "PUT", `repos/${repo}/pulls/${pr}/reviews/${reviewId}`, "--input", "-"],

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -6,7 +6,7 @@ import { GATE_FULL_LABEL, loadDevLoopConfig, resolveEffectiveCopilotRoundCap, re
 import { GATE_CONFIG_KEY, SEVERITY_ORDER, VALID_SEVERITIES, checkFanoutAngleCoverage, normalizeSeverity, normalizeSeverityCounts, provenanceConsistencyError, severityRank } from "@dev-loops/core/loop/gate-fanin";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
-import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
+import { parseAllowedRefsCsv, parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { buildFanoutEnforcement, evaluateInlineFanoutMode } from "./detect-checkpoint-evidence.mjs";
@@ -199,6 +199,12 @@ Optional:
                                             --execution-mode nor --inline-reason
                                             errors. Optional and ignored (dropped)
                                             for --execution-mode fanout_fanin.
+  --allowed-refs <csv>                      Comma-separated numeric issue/PR ids to
+                                            allow as deliberate cross-references in
+                                            the posted verdict body and any inline/
+                                            body-filed finding text (the
+                                            no-ids-in-comments guard refuses any
+                                            other bare #<digits>).
 Output (stdout, JSON):
   {
     "ok": true,
@@ -429,6 +435,7 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       "findings-severity-counts": { type: "string" },
       "execution-mode": { type: "string" },
       "inline-reason": { type: "string" },
+      "allowed-refs": { type: "string" },
       lightweight: { type: "boolean" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
@@ -451,6 +458,7 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     findingsSeverityCounts: undefined,
     executionMode: undefined,
     inlineReason: undefined,
+    allowedRefs: [],
     lightweight: false,
     jq: undefined,
     silent: false,
@@ -571,6 +579,10 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
         throw parseError("--inline-reason must be a non-empty string");
       }
       options.inlineReason = enforcePostedCommentLimit(reason, MAX_GATE_COMMENT_TEXT_LENGTH, "--inline-reason");
+      continue;
+    }
+    if (token.name === "allowed-refs") {
+      options.allowedRefs = parseAllowedRefsCsv(requireTokenValue(token, parseError), "--allowed-refs", parseError);
       continue;
     }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
@@ -2134,7 +2146,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // the single desiredBody choke point so BOTH the review surface (create/update
   // gate review) and the legacy issue-comment surface (updateComment below) are
   // covered, in addition to the low-level guards in the write helpers.
-  guardCommentBodyNoIssuePrIds(desiredBody, { ref: "gate verdict comment body" });
+  guardCommentBodyNoIssuePrIds(desiredBody, { ref: "gate verdict comment body", allowedRefs: options.allowedRefs });
   const findingSurfaceFields = findingSurface
     ? {
         round: findingSurface.round,
@@ -2227,7 +2239,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     // review, which is why resolveFindingSurface body-files everything on this
     // path.
     const updated = existing.surface === "review"
-      ? await updateGateReview({ repo: options.repo, pr: options.pr, reviewId: existing.commentId, body: desiredBody }, gh)
+      ? await updateGateReview({ repo: options.repo, pr: options.pr, reviewId: existing.commentId, body: desiredBody, allowedRefs: options.allowedRefs }, gh)
         .then((r) => ({ commentId: r.reviewId, commentUrl: r.reviewUrl ?? existing.commentUrl }))
       : await updateComment({ repo: options.repo, commentId: existing.commentId, body: desiredBody }, gh);
     // Post-update verification: verify the updated surface is retrievable via a
@@ -2278,6 +2290,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       side: "RIGHT",
       body: renderInlineCommentBody(finding, { round: findingSurface.round }),
     })),
+    allowedRefs: options.allowedRefs,
   }, gh);
   const created = { commentId: createdReview.reviewId, commentUrl: createdReview.reviewUrl };
   // Post-creation verification: verify the review is retrievable before returning.

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -162,8 +162,10 @@ function collapseWhitespace(value) {
 // which this fallback cannot import — it ships in the plugin without @dev-loops/core). A
 // generated gate verdict body must never carry a raw `#<digits>` token: public comment
 // surfaces auto-link a bare `#<digits>` to that issue/PR, leaking internal cross-references.
-// Fail-closed: refuse to POST rather than strip — no `--allowed-refs` escape on this
-// guard because a gate verdict body is never a place for a deliberate cross-reference.
+// Fail-closed: refuse to POST rather than strip. The full helper offers an
+// allowed-refs escape for deliberate cross-references; this degraded fallback
+// deliberately omits it — an emergency posting path should stay maximally
+// strict, and a body needing a cross-reference can use the full helper.
 // A match is excluded only when it forms a well-formed HTML numeric character
 // reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
 // the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -171,6 +171,9 @@ function collapseWhitespace(value) {
 // the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own
 // entity exclusion so the two copies stay behaviorally identical.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
+// An entity decoding to the hash character followed by a digit run renders as
+// a bare auto-link; treated as a bare-id occurrence (mirrors the shared copy).
+const ENCODED_HASH_ID_RE = /&#(?:35|x23);(\d{1,9})/giu;
 function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }
@@ -179,6 +182,9 @@ function guardFallbackBodyNoIssuePrIds(body, ctx) {
   const found = [];
   for (const m of String(body).matchAll(ISSUE_PR_ID_RE)) {
     if (isNumericCharacterReference(body, m)) continue;
+    found.push(m[1]);
+  }
+  for (const m of String(body).matchAll(ENCODED_HASH_ID_RE)) {
     found.push(m[1]);
   }
   if (found.length > 0) {

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -164,11 +164,19 @@ function collapseWhitespace(value) {
 // surfaces auto-link a bare `#<digits>` to that issue/PR, leaking internal cross-references.
 // Fail-closed: refuse to POST rather than strip — no `--allowed-refs` escape on this
 // guard because a gate verdict body is never a place for a deliberate cross-reference.
+// A match is excluded only when it forms a well-formed HTML numeric character
+// reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
+// the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own
+// entity exclusion so the two copies stay behaviorally identical.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
+function isNumericCharacterReference(body, match) {
+  return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
+}
 function guardFallbackBodyNoIssuePrIds(body, ctx) {
   if (typeof body !== "string") return body;
   const found = [];
   for (const m of String(body).matchAll(ISSUE_PR_ID_RE)) {
+    if (isNumericCharacterReference(body, m)) continue;
     found.push(m[1]);
   }
   if (found.length > 0) {

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -173,7 +173,7 @@ function collapseWhitespace(value) {
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
 // An entity decoding to the hash character followed by a digit run renders as
 // a bare auto-link; treated as a bare-id occurrence (mirrors the shared copy).
-const ENCODED_HASH_ID_RE = /&#(?:35|x23);(\d{1,9})/giu;
+const ENCODED_HASH_ID_RE = /&#(?:0*35|x0*23);(\d{1,9})/giu;
 function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -579,6 +579,20 @@ test("runCli's id guard does not mistake a well-formed HTML numeric character re
     assert.equal(exitCode, 0);
     assert.equal(JSON.parse(stdout.join("")).ok, true);
 
+    // An entity decoding to the hash character followed by a digit run renders
+    // as a bare auto-link and is refused (mirrors the shared guard copy).
+    const stubHashEntity = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "smuggled &#35;123 reference", "--next-action", "go",
+        ],
+        { env: stubHashEntity.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#123/,
+    );
+
     // Not a well-formed entity (no terminating `;`): still refused.
     const stubNoSemicolon = await writeGhStub(tempDir, [], {});
     await assert.rejects(

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -554,6 +554,61 @@ test("runCli refuses to post a rendered body containing a raw #digits id (no id 
   }
 });
 
+test("runCli's id guard does not mistake a well-formed HTML numeric character reference for an issue/PR id, but still refuses a non-semicolon-terminated or bare digit run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-idguard-entity-"));
+  try {
+    const stub = await writeGhStub(
+      tempDir,
+      [
+        {
+          assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+          assertStdinIncludes: ["entity-encoded bracket: &#91;checkbox&#93;"],
+          stdout: '{"id":202,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-202"}\n',
+        },
+      ],
+      {},
+    );
+    const stdout = [];
+    const exitCode = await runCli(
+      [
+        "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+        "--verdict", "clean", "--findings-summary", "entity-encoded bracket: &#91;checkbox&#93;", "--next-action", "go",
+      ],
+      { env: stub.env, spawn: spawn, ghCommand: "gh", stdoutSink: stdout, stderrSink: [] },
+    );
+    assert.equal(exitCode, 0);
+    assert.equal(JSON.parse(stdout.join("")).ok, true);
+
+    // Not a well-formed entity (no terminating `;`): still refused.
+    const stubNoSemicolon = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "malformed &#91 reference", "--next-action", "go",
+        ],
+        { env: stubNoSemicolon.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#91/,
+    );
+
+    // A genuine bare id (no `&` at all) is still refused even next to an entity.
+    const stubBareId = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "&#91;see #123&#93;", "--next-action", "go",
+        ],
+        { env: stubBareId.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#123/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("runCli posts a clean rendered body with no id guard leak", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loop-gate-fallback-idguard-clean-"));
   try {

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6823,6 +6823,9 @@ test("upsertCheckpointVerdict posts a verdict body whose findings summary carrie
       allowedRefs: ["1670"],
     }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
     assert.equal(result.ok, true);
+    // Pins that the review POST stub entry actually fired (not a vacuous pass
+    // if the flow ever short-circuited before posting).
+    assert.equal(result.action, "created");
 
     const { runChild: runChildBlocked } = makeGhMock([
       ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
@@ -6879,6 +6882,123 @@ test("upsert-checkpoint-verdict posts a --findings-json finding whose summary ca
     assert.equal(result.code, 0, result.stderr);
     const payload = JSON.parse(result.stdout);
     assert.equal(payload.ok, true);
+    // Pins that the review POST stub entry actually fired (not a vacuous pass
+    // if the flow ever short-circuited before posting).
+    assert.equal(payload.action, "created");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// The above test's finding carries no file/line, so it is body-filed rather
+// than posted as an inline review comment — it never reaches
+// renderInlineCommentBody or createGateReview's per-comment id-guard loop
+// (guardCommentBodyNoIssuePrIds over `comments`), which is the exact surface
+// the reported production symptom (an inline finding quoting a literal `[`)
+// went through. A locatable finding here, carrying BOTH the entity-encoded
+// bracket AND a genuine deliberate cross-reference id, pins the inline path
+// and the guard loop running with a non-empty allowedRefs in the same call.
+const ENTITY_AND_ALLOWED_REF_FINDING = {
+  severity: "nice-to-have",
+  angle: "coverage",
+  summary: "rename the [id] route segment to [slug]; deliberate cross-ref to issue #1670",
+  files: ["src/db.mjs"],
+  line: 2,
+};
+
+test("upsert-checkpoint-verdict --findings-ledger posts a LOCATABLE finding as an inline comment whose entity-encoded bracket is not mistaken for an issue/PR id, and whose deliberate cross-reference id is threaded through allowedRefs", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-single-surface-entity-allowedrefs-"));
+  try {
+    const ledgerPath = await writeSingleSurfaceLedger(tempDir, [ENTITY_AND_ALLOWED_REF_FINDING]);
+    const entries = [
+      ...singleSurfaceLeadingEntries(),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        assertStdinIncludes: ["&#91;id] route segment to &#91;slug]", "deliberate cross-ref to issue #1670"],
+        stdout: '{"id":701,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-701"}\n',
+      },
+    ];
+    const { runChild, calls } = makeGhMock(entries);
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: SINGLE_SURFACE_HEAD,
+      verdict: "findings_present",
+      findingsLedger: ledgerPath,
+      findingsSummary: "1 finding, inline",
+      nextAction: "stay draft and fix",
+      executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
+      allowedRefs: ["1670"],
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+    assert.equal(result.action, "created");
+    assert.equal(result.inlineComments, 1);
+
+    const postCall = calls.find((c) => c.args.includes("repos/owner/repo/pulls/17/reviews") && c.args.includes("POST"));
+    const posted = JSON.parse(postCall.stdinText);
+    assert.equal(posted.comments.length, 1);
+    // The entity-encoded bracket survives, unmangled, on the inline comment
+    // this finding actually renders on (not the review body).
+    assert.match(posted.comments[0].body, /&#91;id] route segment to &#91;slug]/);
+    // The allowlisted id rides through unstripped on that same inline comment
+    // — the guard loop over `comments` ran with a non-empty allowedRefs and
+    // did not refuse it.
+    assert.match(posted.comments[0].body, /#1670/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// AC4 + the update-path guard surface: updateGateReview must thread
+// allowedRefs the same as createGateReview, or a same-head correction whose
+// findings summary carries a deliberate cross-reference id would wrongly
+// refuse on the SECOND round even though the first round's create allowed it.
+test("upsert-checkpoint-verdict --findings-ledger threads allowedRefs into the update-path PUT (updateGateReview) when correcting an existing same-head review", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-single-surface-update-allowedrefs-"));
+  try {
+    const ledgerPath = await writeSingleSurfaceLedger(tempDir, [LOCATABLE_FINDING]);
+    const existingReview = {
+      id: 705,
+      submitted_at: "2026-08-03T10:00:00Z",
+      html_url: "https://github.com/owner/repo/pull/17#pullrequestreview-705",
+      body: renderGateReviewCommentBody({
+        gate: "draft_gate",
+        headSha: SINGLE_SURFACE_HEAD,
+        verdict: "clean",
+        findingsSummary: "no issues found",
+        nextAction: "mark ready for review",
+        executionMode: "inline_single_agent",
+        inlineReason: "single-agent inline review (test)",
+      }),
+    };
+    const entries = [
+      ...singleSurfaceLeadingEntries({ reviews: [existingReview], files: null }),
+      {
+        assertArgs: ["api", "-X", "PUT", "repos/owner/repo/pulls/17/reviews/705", "--input", "-"],
+        assertStdinIncludes: ["deliberate cross-ref to issue #1670"],
+        stdout: '{"id":705,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-705"}\n',
+      },
+    ];
+    const { runChild, calls } = makeGhMock(entries);
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: SINGLE_SURFACE_HEAD,
+      verdict: "findings_present",
+      findingsSummary: "deliberate cross-ref to issue #1670",
+      findingsLedger: ledgerPath,
+      nextAction: "stay draft and fix",
+      executionMode: "inline_single_agent",
+      inlineReason: "single-agent inline review (test)",
+      allowedRefs: ["1670"],
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+    assert.equal(result.action, "updated");
+    assert.equal(result.commentId, 705);
+    assert.equal(calls.filter((c) => c.args.includes("PUT") && c.args.includes("repos/owner/repo/pulls/17/reviews/705")).length, 1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6766,3 +6766,120 @@ test("#1731: upsertCheckpointVerdict refuses a verdict body containing a raw iss
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("parseUpsertCheckpointVerdictCliArgs parses --allowed-refs csv", () => {
+  const parsed = parseUpsertCheckpointVerdictCliArgs([
+    "--repo", "owner/repo",
+    "--pr", "17",
+    "--gate", "draft_gate",
+    "--head-sha", "abc1234000000000000000000000000000000000",
+    "--verdict", "clean",
+    "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"nice-to-have":0}',
+    "--findings-summary", "no issues found",
+    "--next-action", "mark ready for review",
+    "--inline-reason", "tiny docs change",
+    "--allowed-refs", "1670, 9000",
+  ]);
+  assert.deepEqual(parsed.allowedRefs, ["1670", "9000"]);
+});
+
+test("parseUpsertCheckpointVerdictCliArgs rejects a non-numeric --allowed-refs entry", () => {
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs([
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "clean",
+      "--findings-severity-counts", '{"must-fix":0,"worth-fixing-now":0,"nice-to-have":0}',
+      "--findings-summary", "no issues found",
+      "--next-action", "mark ready for review",
+      "--allowed-refs", "1670,abc",
+    ]),
+    /positive integers/,
+  );
+});
+
+test("upsertCheckpointVerdict posts a verdict body whose findings summary carries a deliberate cross-reference id via allowedRefs, while an unallowlisted id in the same body still refuses", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-verdict-allowed-refs-"));
+  try {
+    const { runChild } = makeGhMock([
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        assertStdinIncludes: ["deliberate cross-ref to issue #1670"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-101"}\n',
+      },
+    ], { repeatLastOnOverflow: true });
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "draft_gate",
+      headSha: "abc1234000000000000000000000000000000000",
+      verdict: "clean",
+      findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 },
+      findingsSummary: "deliberate cross-ref to issue #1670",
+      nextAction: "Mark ready for review",
+      allowedRefs: ["1670"],
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: fanoutDisabledRepoRoot });
+    assert.equal(result.ok, true);
+
+    const { runChild: runChildBlocked } = makeGhMock([
+      ...buildGateCoordinationEntries({ isDraft: true, statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }] }),
+    ], { repeatLastOnOverflow: true });
+    await assert.rejects(
+      () => upsertCheckpointVerdict({
+        repo: "owner/repo",
+        pr: 17,
+        gate: "draft_gate",
+        headSha: "abc1234000000000000000000000000000000000",
+        verdict: "clean",
+        findingsSeverityCounts: { "must-fix": 0, "worth-fixing-now": 0 },
+        findingsSummary: "allowlisted #1670 but also unallowlisted #999",
+        nextAction: "Mark ready for review",
+        allowedRefs: ["1670"],
+      }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild: runChildBlocked, repoRoot: fanoutDisabledRepoRoot }),
+      /#999/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("upsert-checkpoint-verdict posts a --findings-json finding whose summary carries a markdown bracket (entity-encoded by the structured render's sanitizer) without the id guard mistaking the numeric character reference for an issue/PR id", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-json-entity-bracket-"));
+  try {
+    const findingsPath = path.join(tempDir, "findings.json");
+    await writeFile(
+      findingsPath,
+      JSON.stringify([
+        { angle: "correctness", verdict: "findings_present", findings: [{ severity: "nice-to-have", summary: "rename the [id] route segment to [slug]" }] },
+        { angle: "pr-description", verdict: "clean", findings: [] },
+      ]),
+      "utf8",
+    );
+    const env = await writeGhStub(tempDir, [
+      ...buildGateCoordinationEntries({
+        isDraft: true,
+        statusCheckRollup: [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }],
+      }),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        assertStdinIncludes: ["&#91;id] route segment to &#91;slug]"],
+        stdout: '{"id":101,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-101"}\n',
+      },
+    ]);
+
+    const result = await runNode([
+      "--repo", "owner/repo", "--pr", "17", "--gate", "draft_gate", "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "findings_present", "--findings-json", findingsPath,
+      "--next-action", "fix before merge", "--execution-mode", "fanout_fanin",
+    ], { env });
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

The comment-id guard no longer false-positives on HTML numeric character references: the shared matcher excludes a hash-digit run that is both ampersand-preceded and semicolon-terminated (a well-formed numeric character reference, checked post-match, per occurrence), while an entity that itself decodes to the hash character followed by a digit run is treated as a bare id (it renders as an auto-link on GitHub), so the sanitizer's entity-encoded brackets (`&#91;`) pass while genuine bare ids still refuse. The gate verdict poster gains the `--allowed-refs` escape the other guarded writers already have, threaded to every guarded surface it posts (verdict body, inline finding comments, updated review bodies).

## Scope and context

Seven files: the shared matcher in `packages/core/src/github/comment-id-guard.mjs` (post-match context check on the single shared regex — excluded only when ampersand-preceded AND semicolon-terminated — consumed by both extract and guard paths, plus a csv-string allowlist coercion so a string input cannot character-split), its unit suite, the `--allowed-refs` flag in `scripts/github/upsert-checkpoint-verdict.mjs` (parsed via the existing `parseAllowedRefsCsv`, documented like the sibling writers), the threaded guard calls in `scripts/github/_gate-finding-surface.mjs` (create and update review paths, body plus per-inline-comment), the upsert test suite, and the zero-dep inline matcher copy in the dev-loop fallback poster (`skills/dev-loop/scripts/post-gate-verdict-fallback.mjs`) with its test — synced to the identical exclusion so the emergency posting path honors the same contract. The module is not vendored into hooks (verified; regeneration produced no diff).

## Acceptance criteria

- [x] The guard does not match ids inside `&#<digits>;` entities: bodies carrying well-formed bracket entities pass both `extractIssuePrIds` and `guardCommentBodyNoIssuePrIds`.
- [x] A regression test covers an entity-encoded body passing and a genuine bare id (adjacent to entities) still failing.
- [x] `upsert-checkpoint-verdict.mjs` accepts `--allowed-refs <csv>` and threads it to every guarded write surface, matching the comment-issue/edit-comment flag contract.
- [x] Existing guard refusals for genuine bare ids are unchanged.
- [x] An entity decoding to the hash character immediately followed by an issue-length digit run is refused as a bare-id occurrence (decimal and hex forms, zero-padding included, both matcher copies), closing the encoded-hash smuggle path the pre-approval review surfaced.

## Definition of done

- [x] `node --test packages/core/test/comment-id-guard.test.mjs` green (10 tests, incl. the semicolon-boundary and encoded-hash pins).
- [x] `node --test test/github/upsert-checkpoint-verdict.test.mjs` green (174 tests, incl. 6 new: csv parse, non-numeric rejection, allowlisted cross-reference posts while unallowlisted still refuses, end-to-end entity-encoded bracket in a findings-json summary).
- [x] `node --test test/github/gate-finding-surface.test.mjs` green (54 tests).
- [x] `node --test skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs` green (28 tests, incl. the synced-copy boundary and encoded-hash pins).
- [x] `npm run assets:check` green (module not vendored; regeneration no-op).
- [x] `npm run verify` green (recorded in the gate validation artifact).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Well-formed entities pass per occurrence; bare ids still refuse | comment-id-guard suite (10); fallback poster suite (28) | no relaxation for genuine bare references |
| Encoded-hash entity followed by digits refused (both copies) | comment-id-guard suite (10); fallback poster suite (28) | sanitizer entity-encoding unchanged |
| Regression tests both directions | comment-id-guard suite; upsert suite end-to-end entity test | sanitizer entity-encoding unchanged |
| --allowed-refs on the verdict poster, threaded everywhere | upsert suite (174, incl. allowlist + refusal pair) | other writers' flag contracts unchanged |
| Existing refusals unchanged | gate-finding-surface suite (54); upsert suite; fallback poster suite (28) | — |

## Non-goals

- No change to the entity-encoding sanitizer itself (escape-vs-entity policy stands).
- No relaxation of the no-ids-in-comments rule for genuinely bare references.
- No change to the sibling writers' flag contracts (comment-issue, edit-comment keep their existing --allowed-refs semantics).

## Open questions

None.

## Validation

```sh
node --test packages/core/test/comment-id-guard.test.mjs
node --test test/github/upsert-checkpoint-verdict.test.mjs
npm run verify
```

Closes #1743
