### PR TITLE
fix(copilot): bounded-backoff verification after the review-request edit (#1748)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,7 +107,7 @@ Contract:
 - enforces a round cap (default: 5, configurable via `maxCopilotRounds` in settings); clean round-cap PRs with new commits, resolved threads, and green current GitHub CI automatically re-open for a normal re-request, while `--force-rerequest-review` remains the operator override for other new-commit cases
 - should be paired with a fresh unresolved-thread check after Copilot posts again; requesting review alone does not complete the loop
 - verifies the result through `gh api repos/<owner>/<name>/pulls/<pr>/requested_reviewers`
-- the verification read is eventually consistent: an immediate read can still see stale (empty) state right after a genuinely successful request, so the helper retries the read on a fixed backoff (~30s total) before declaring failure; the `gh pr edit` request itself is issued exactly once and never re-issued per probe
+- the verification read is eventually consistent: an immediate read can still see stale (empty) state right after a genuinely successful request, so the helper retries the read on a fixed backoff (~30s total) before declaring failure; the `gh pr edit` request itself is issued exactly once and never re-issued per probe. A verification read that throws (transient gh failure) also consumes a scheduled retry instead of failing immediately; only a throw on the final attempt propagates, as the raw underlying error
 - does **not** rely on `gh pr view --json reviewRequests`, which can be incomplete for Copilot reviewer state
 - normalizes known repository/tooling limitations into a machine-readable `unavailable` result instead of forcing callers to parse ad hoc stderr
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,6 +107,7 @@ Contract:
 - enforces a round cap (default: 5, configurable via `maxCopilotRounds` in settings); clean round-cap PRs with new commits, resolved threads, and green current GitHub CI automatically re-open for a normal re-request, while `--force-rerequest-review` remains the operator override for other new-commit cases
 - should be paired with a fresh unresolved-thread check after Copilot posts again; requesting review alone does not complete the loop
 - verifies the result through `gh api repos/<owner>/<name>/pulls/<pr>/requested_reviewers`
+- the verification read is eventually consistent: an immediate read can still see stale (empty) state right after a genuinely successful request, so the helper retries the read on a fixed backoff (~30s total) before declaring failure; the `gh pr edit` request itself is issued exactly once and never re-issued per probe
 - does **not** rely on `gh pr view --json reviewRequests`, which can be incomplete for Copilot reviewer state
 - normalizes known repository/tooling limitations into a machine-readable `unavailable` result instead of forcing callers to parse ad hoc stderr
 

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -860,17 +860,23 @@ export async function performCopilotReviewRequest(
   if (requestResult.status === "already-requested") {
     return withConfigWarning(requestResult);
   }
-  let after = await fetchCopilotReviewState(options, runtime);
-  let reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
   // Bounded retry against the read-after-write race documented above: only the
   // verification READ repeats here, never the `gh pr edit` request itself. A
-  // transient throw from the read (rate limit, 5xx, network blip) during this
-  // window consumes its delay and re-probes on the next attempt instead of
+  // transient throw from ANY verification read — the initial post-edit read
+  // included — consumes the next scheduled delay and re-probes instead of
   // aborting immediately; the error only propagates if the final attempt in
   // the window also throws, in which case that last error is what the caller
   // sees (not the generic empty-result message below, which is reserved for
   // the case where every read succeeds but the review never shows up).
+  let after = null;
+  let reviewNowObservablyInProgress = false;
   let lastReadError = null;
+  try {
+    after = await fetchCopilotReviewState(options, runtime);
+    reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
+  } catch (error) {
+    lastReadError = error;
+  }
   for (let attempt = 0; !reviewNowObservablyInProgress && attempt < VERIFICATION_RETRY_DELAYS_MS.length; attempt += 1) {
     await delayImpl(VERIFICATION_RETRY_DELAYS_MS[attempt]);
     try {

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -49,6 +49,12 @@ Optional:
                             composed round cap min(localImplementation.lightMode.
                             maxCopilotRounds ?? 1, refinement.maxCopilotRounds)
                             instead of refinement.maxCopilotRounds alone.
+Verification:
+  After requesting Copilot as a reviewer, the requested-reviewer/review-list
+  read is retried on a fixed backoff (~30s total) before declaring failure,
+  because that read is eventually consistent and can briefly still show stale
+  (empty) state right after a genuinely successful request. The request
+  itself is issued exactly once and never re-issued per probe.
 Debug:
   DEVLOOPS_DEBUG=1      Emit stderr traces when best-effort same-head clean
                             convergence detection falls back to unsuppressed behavior
@@ -857,13 +863,29 @@ export async function performCopilotReviewRequest(
   let after = await fetchCopilotReviewState(options, runtime);
   let reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
   // Bounded retry against the read-after-write race documented above: only the
-  // verification READ repeats here, never the `gh pr edit` request itself.
+  // verification READ repeats here, never the `gh pr edit` request itself. A
+  // transient throw from the read (rate limit, 5xx, network blip) during this
+  // window consumes its delay and re-probes on the next attempt instead of
+  // aborting immediately; the error only propagates if the final attempt in
+  // the window also throws, in which case that last error is what the caller
+  // sees (not the generic empty-result message below, which is reserved for
+  // the case where every read succeeds but the review never shows up).
+  let lastReadError = null;
   for (let attempt = 0; !reviewNowObservablyInProgress && attempt < VERIFICATION_RETRY_DELAYS_MS.length; attempt += 1) {
     await delayImpl(VERIFICATION_RETRY_DELAYS_MS[attempt]);
-    after = await fetchCopilotReviewState(options, runtime);
+    try {
+      after = await fetchCopilotReviewState(options, runtime);
+      lastReadError = null;
+    } catch (error) {
+      lastReadError = error;
+      continue;
+    }
     reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
   }
   if (!reviewNowObservablyInProgress) {
+    if (lastReadError) {
+      throw lastReadError;
+    }
     throw new Error("Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit");
   }
   return withConfigWarning({

--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   buildParseError,
   containsBareCopilotSummon,
@@ -28,6 +29,13 @@ const ROUND_CAP_REACHED_STATUS = "round_cap_reached";
 const NO_CHANGES_SINCE_LAST_REVIEW_STATUS = "no_changes_since_last_review";
 const SUPPRESSED_POST_CONVERGENCE_DOCS_ONLY_STATUS = "suppressed_post_convergence_docs_only";
 const SUPPRESSED_DRAFT_STATUS = "suppressed_draft";
+// The requested-reviewer / review-list reads that verify a `gh pr edit` request
+// landed are eventually consistent: an immediate read can still see stale
+// (empty) state even though the request already succeeded. Re-read on this
+// fixed backoff before declaring failure — bounded, not open-ended, so a
+// genuine failure (Copilot truly unavailable on the repo) still fails closed
+// after ~30s total instead of hanging indefinitely.
+const VERIFICATION_RETRY_DELAYS_MS = [5000, 10000, 15000];
 const USAGE = `Usage: request-copilot-review.mjs --repo <owner/name> --pr <number>
 Request Copilot as a reviewer on a GitHub pull request.
 Required:
@@ -248,6 +256,24 @@ async function resolveDraftGateAdjustedRounds(options, { env = process.env, ghCo
   } catch {
     return before.completedCopilotReviewRounds ?? 0;
   }
+}
+
+// Review-surface presence: Copilot is present when it is a requested reviewer
+// OR has submitted any review on this PR — never decided by assignee
+// membership. A reviewer-configured repo (`copilot-pull-request-reviewer[bot]`)
+// auto-reviews without appearing in requested_reviewers and `@copilot` can be a
+// silent no-op, so prior submitted reviews prove presence and must not be
+// misreported as "Copilot absent / not enabled".
+function isReviewNowObservablyInProgress(before, after) {
+  const reviewCountIncreased = after.copilotReviewIds.length > before.copilotReviewIds.length;
+  const reviewPresence = resolveCopilotReviewPresence({
+    requested: after.requested,
+    reviews: after.prData?.reviews ?? [],
+  });
+  return after.requested
+    || after.hasPendingReviewOnCurrentHead
+    || reviewCountIncreased
+    || reviewPresence.present;
 }
 
 async function fetchCopilotReviewState(options, runtime) {
@@ -569,7 +595,10 @@ export async function checkForCopilotComments({ repo, pr }, { env = process.env,
     violationCommentIds,
   };
 }
-export async function performCopilotReviewRequest(options, { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
+export async function performCopilotReviewRequest(
+  options,
+  { env = process.env, ghCommand = "gh", runChild = defaultRunChild, delayImpl = delay } = {},
+) {
   const runtime = { env, ghCommand, runChild };
   const before = await fetchCopilotReviewState(options, runtime);
   if (before.prData?.isDraft) {
@@ -825,22 +854,15 @@ export async function performCopilotReviewRequest(options, { env = process.env, 
   if (requestResult.status === "already-requested") {
     return withConfigWarning(requestResult);
   }
-  const after = await fetchCopilotReviewState(options, runtime);
-  const reviewCountIncreased = after.copilotReviewIds.length > before.copilotReviewIds.length;
-  // Review-surface presence (#1670): Copilot is present when it is a requested
-  // reviewer OR has submitted any review on this PR — never decided by assignee
-  // membership. A reviewer-configured repo (`copilot-pull-request-reviewer[bot]`)
-  // auto-reviews without appearing in requested_reviewers and `@copilot` can be a
-  // silent no-op, so prior submitted reviews prove presence and must not be
-  // misreported as "Copilot absent / not enabled".
-  const reviewPresence = resolveCopilotReviewPresence({
-    requested: after.requested,
-    reviews: after.prData?.reviews ?? [],
-  });
-  const reviewNowObservablyInProgress = after.requested
-    || after.hasPendingReviewOnCurrentHead
-    || reviewCountIncreased
-    || reviewPresence.present;
+  let after = await fetchCopilotReviewState(options, runtime);
+  let reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
+  // Bounded retry against the read-after-write race documented above: only the
+  // verification READ repeats here, never the `gh pr edit` request itself.
+  for (let attempt = 0; !reviewNowObservablyInProgress && attempt < VERIFICATION_RETRY_DELAYS_MS.length; attempt += 1) {
+    await delayImpl(VERIFICATION_RETRY_DELAYS_MS[attempt]);
+    after = await fetchCopilotReviewState(options, runtime);
+    reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
+  }
   if (!reviewNowObservablyInProgress) {
     throw new Error("Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit");
   }

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -35,7 +35,7 @@ const PR_EDIT_ARGS = ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewe
 // worktree cwd, matching the no-cwd spawn tests.
 // Fail-fast default: every non-race test proves it never enters the
 // verification retry window (zero delays consumed). A test that needs the
-// retry window supplies its own recording delayImpl (see the two race tests
+// retry window supplies its own recording delayImpl (see the six race tests
 // below); anything else that starts sleeping here is a regression pushing a
 // case onto the retry path, so throw instead of silently waiting ~30s.
 async function unexpectedDelay(ms) {
@@ -623,11 +623,62 @@ test("request-copilot-review fails closed with the empty-result message when a m
     () => runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl }),
     (error) => {
       assert.equal(error.message, "Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit");
+      assert.deepEqual(error.calls.map((call) => call.args), [
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        PR_EDIT_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+      ]);
       assert.equal(error.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
       return true;
     },
   );
   assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+});
+
+test("request-copilot-review recovers when the INITIAL post-edit read throws and a later read succeeds", async () => {
+  // The initial post-edit read sits inside the retry window: a throw there
+  // consumes the first scheduled delay and re-probes instead of propagating,
+  // so a transient blip immediately after a successful edit self-heals.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const entries = [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    // Initial post-edit read: throws.
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      exitCode: 1,
+      stderr: "rate limited (initial read)\n",
+    },
+    // Attempt 1: recovers, review observable.
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[{"login":"copilot-pull-request-reviewer[bot]"}],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+  ];
+  const { result, calls } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl });
+  assert.equal(result.status, "requested");
+  assert.deepEqual(delayCalls, [5000]);
+  assert.equal(calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
 });
 
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -20,17 +20,41 @@ const EMPTY_REVIEW_STREAM_ENTRY = {
   stdout: "[[]]\n",
 };
 
+// Full gh argv for owner/repo#17's verification/request calls, reused by the
+// retry-window tests below to pin the exact gh call sequence (not just the
+// delay schedule) — including that `pr edit` is issued exactly once.
+const REQUESTED_REVIEWERS_ARGS = ["api", "repos/owner/repo/pulls/17/requested_reviewers"];
+const PR_VIEW_ARGS = ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"];
+const PR_EDIT_ARGS = ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"];
+
 // In-process run: replay the same gh entries via makeGhMock and call the exported
 // entry fn directly, so the CLI logic runs without a node subprocess per gh call.
 // GH_SEQUENCE_PATH is set by default to preserve the production skip of the
 // copilot-comment check (the CLI treats it as the "under stub harness" signal);
 // pass `env: {}` to exercise that check end to end. Config is loaded from the
 // worktree cwd, matching the no-cwd spawn tests.
-async function runInProcess(args, entries, { env = { GH_SEQUENCE_PATH: "1" }, delayImpl } = {}) {
+// Fail-fast default: every non-race test proves it never enters the
+// verification retry window (zero delays consumed). A test that needs the
+// retry window supplies its own recording delayImpl (see the two race tests
+// below); anything else that starts sleeping here is a regression pushing a
+// case onto the retry path, so throw instead of silently waiting ~30s.
+async function unexpectedDelay(ms) {
+  throw new Error(`runInProcess: unexpected delay(${ms}ms) — this test path must not enter the verification retry loop`);
+}
+
+async function runInProcess(args, entries, { env = { GH_SEQUENCE_PATH: "1" }, delayImpl = unexpectedDelay } = {}) {
   const { runChild, calls } = makeGhMock(entries, { repeatLastOnOverflow: true });
   const options = parseRequestCliArgs(args);
-  const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild, delayImpl });
-  return { result, calls };
+  try {
+    const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild, delayImpl });
+    return { result, calls };
+  } catch (error) {
+    // Attach the recorded gh calls to a rejection too, so a test asserting
+    // via `assert.rejects` can still pin the exact gh call sequence that led
+    // to the failure (not just the delay schedule).
+    error.calls = calls;
+    throw error;
+  }
 }
 
 async function writeGhStub(tempDir, entries) {
@@ -310,7 +334,7 @@ test("request-copilot-review retries the post-edit verification read on an empty
   const delayImpl = async (ms) => {
     delayCalls.push(ms);
   };
-  const { result } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
+  const { result, calls } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
     {
       assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
       stdout: '{"users":[],"teams":[]}\n',
@@ -351,6 +375,18 @@ test("request-copilot-review retries the post-edit verification read on an empty
     reviewer: "Copilot",
   });
   assert.deepEqual(delayCalls, [5000]);
+  // Pin the gh call sequence itself, not just the delay schedule: exactly one
+  // `pr edit` (never re-issued per probe) and exactly the expected number of
+  // verification reads (before-state check, stale post-edit read, landed
+  // retry read) — `repeatLastOnOverflow` would otherwise silently mask a
+  // surplus read past this exact sequence.
+  assert.deepEqual(calls.map((call) => call.args), [
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+    PR_EDIT_ARGS,
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+  ]);
+  assert.equal(calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
 });
 
 test("request-copilot-review fails closed after the bounded verification retries stay empty", async () => {
@@ -389,7 +425,159 @@ test("request-copilot-review fails closed after the bounded verification retries
 
   await assert.rejects(
     () => runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl }),
-    /Copilot review request did not appear in requested reviewers or fresh\/in-progress Copilot reviews after gh pr edit/,
+    (error) => {
+      // Exact match, not a substring: the message is a claimed byte-identical
+      // contract with pre-retry-loop behavior, so any drift (a prefix/suffix
+      // like an appended "after N retries") must fail this assertion.
+      assert.equal(
+        error.message,
+        "Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit",
+      );
+      // Pin the gh call sequence too: exactly one `pr edit` and exactly the
+      // expected number of verification reads (before-state check, plus one
+      // initial post-edit read and one per bounded retry, all stale) —
+      // `repeatLastOnOverflow` would otherwise silently mask a surplus read
+      // past this exact sequence.
+      assert.deepEqual(error.calls.map((call) => call.args), [
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        PR_EDIT_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+      ]);
+      assert.equal(error.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
+      return true;
+    },
+  );
+  assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+});
+
+test("request-copilot-review retries a throwing verification read inside the bounded window and recovers", async () => {
+  // A transient gh failure (rate limit, 5xx, network) during the retry window
+  // must not abort the helper outright: the request already landed by this
+  // point, so a throwing read consumes its scheduled delay and re-probes on
+  // the next attempt, exactly like the empty-result case, instead of
+  // propagating immediately.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const { result, calls } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    {
+      // Initial post-edit read (pre-loop): still stale/empty.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      // Loop attempt 0: the read itself throws (transient gh failure). The
+      // second call inside fetchCopilotReviewState (pr view) is never reached.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      exitCode: 1,
+      stderr: "rate limited\n",
+    },
+    {
+      // Loop attempt 1: recovers.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+  ], { delayImpl });
+
+  assert.deepEqual(result, {
+    ok: true,
+    status: "requested",
+    repo: "owner/repo",
+    pr: 17,
+    reviewer: "Copilot",
+  });
+  assert.deepEqual(delayCalls, [5000, 10000]);
+  assert.deepEqual(calls.map((call) => call.args), [
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+    PR_EDIT_ARGS,
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+    REQUESTED_REVIEWERS_ARGS,
+    REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+  ]);
+  assert.equal(calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
+});
+
+test("request-copilot-review propagates the final attempt's error when every bounded retry read throws", async () => {
+  // Every attempt in the retry window throws (persistent transient failure,
+  // never a genuine empty-result). The generic "did not appear in requested
+  // reviewers..." message is reserved for the case where reads succeed but
+  // never observe the review; here the caller needs the underlying gh error
+  // instead, so the last attempt's raw error propagates verbatim.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const throwingRequestedReviewersEntry = (label) => ({
+    assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+    exitCode: 1,
+    stderr: `rate limited (${label})\n`,
+  });
+  const entries = [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    {
+      // Initial post-edit read (pre-loop): stale/empty, not a throw.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    throwingRequestedReviewersEntry("attempt 1"),
+    throwingRequestedReviewersEntry("attempt 2"),
+    throwingRequestedReviewersEntry("attempt 3, final"),
+  ];
+
+  await assert.rejects(
+    () => runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl }),
+    (error) => {
+      assert.equal(error.message, "gh command failed: rate limited (attempt 3, final)");
+      assert.deepEqual(error.calls.map((call) => call.args), [
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        PR_EDIT_ARGS,
+        REQUESTED_REVIEWERS_ARGS, PR_VIEW_ARGS,
+        REQUESTED_REVIEWERS_ARGS,
+        REQUESTED_REVIEWERS_ARGS,
+        REQUESTED_REVIEWERS_ARGS,
+      ]);
+      assert.equal(error.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
+      return true;
+    },
   );
   assert.deepEqual(delayCalls, [5000, 10000, 15000]);
 });

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -26,10 +26,10 @@ const EMPTY_REVIEW_STREAM_ENTRY = {
 // copilot-comment check (the CLI treats it as the "under stub harness" signal);
 // pass `env: {}` to exercise that check end to end. Config is loaded from the
 // worktree cwd, matching the no-cwd spawn tests.
-async function runInProcess(args, entries, { env = { GH_SEQUENCE_PATH: "1" } } = {}) {
+async function runInProcess(args, entries, { env = { GH_SEQUENCE_PATH: "1" }, delayImpl } = {}) {
   const { runChild, calls } = makeGhMock(entries, { repeatLastOnOverflow: true });
   const options = parseRequestCliArgs(args);
-  const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild });
+  const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild, delayImpl });
   return { result, calls };
 }
 
@@ -298,6 +298,100 @@ test("request-copilot-review accepts review-surface presence (prior submitted Co
     pr: 17,
     reviewer: "Copilot",
   });
+});
+
+test("request-copilot-review retries the post-edit verification read on an empty-then-populated race and succeeds", async () => {
+  // The requested-reviewer/review-list reads that verify a `gh pr edit` request
+  // landed are eventually consistent: this replays a first verification read
+  // that still sees stale (empty) state, followed by a retry read that sees the
+  // request landed. delayImpl is stubbed to resolve immediately so the test
+  // stays fast while still exercising the real retry loop and delay schedule.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const { result } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    {
+      // First post-edit verification read: still stale/empty.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+    {
+      // Retry read: the request has now landed.
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+  ], { delayImpl });
+
+  assert.deepEqual(result, {
+    ok: true,
+    status: "requested",
+    repo: "owner/repo",
+    pr: 17,
+    reviewer: "Copilot",
+  });
+  assert.deepEqual(delayCalls, [5000]);
+});
+
+test("request-copilot-review fails closed after the bounded verification retries stay empty", async () => {
+  // Genuine failure: every verification read (initial + all bounded retries)
+  // stays empty, so the helper must still throw the existing error after
+  // exhausting the fixed retry schedule instead of retrying forever.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const emptyRequestedReviewersEntry = {
+    assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+    stdout: '{"users":[],"teams":[]}\n',
+  };
+  const emptyReviewsEntry = {
+    assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+    stdout: '{"reviews":[]}\n',
+  };
+  const entries = [
+    emptyRequestedReviewersEntry,
+    emptyReviewsEntry,
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    // Initial post-edit verification read, plus one per bounded retry — all stale.
+    emptyRequestedReviewersEntry,
+    emptyReviewsEntry,
+    emptyRequestedReviewersEntry,
+    emptyReviewsEntry,
+    emptyRequestedReviewersEntry,
+    emptyReviewsEntry,
+    emptyRequestedReviewersEntry,
+    emptyReviewsEntry,
+  ];
+
+  await assert.rejects(
+    () => runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl }),
+    /Copilot review request did not appear in requested reviewers or fresh\/in-progress Copilot reviews after gh pr edit/,
+  );
+  assert.deepEqual(delayCalls, [5000, 10000, 15000]);
 });
 
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -582,6 +582,54 @@ test("request-copilot-review propagates the final attempt's error when every bou
   assert.deepEqual(delayCalls, [5000, 10000, 15000]);
 });
 
+test("request-copilot-review fails closed with the empty-result message when a mid-window throw recovers into empty reads", async () => {
+  // Mixed window: a non-final attempt throws, later attempts succeed but stay
+  // empty. The recovery clears the recorded read error, so exhaustion yields
+  // the generic empty-result message, never the stale mid-window error.
+  const delayCalls = [];
+  const delayImpl = async (ms) => {
+    delayCalls.push(ms);
+  };
+  const emptyVerificationPair = [
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      stdout: '{"users":[],"teams":[]}\n',
+    },
+    {
+      assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+      stdout: '{"reviews":[]}\n',
+    },
+  ];
+  const entries = [
+    ...emptyVerificationPair,
+    {
+      assertArgs: ["pr", "edit", "17", "--repo", "owner/repo", "--add-reviewer", "@copilot"],
+      stdout: "https://github.com/owner/repo/pull/17\n",
+    },
+    // Initial post-edit read: empty.
+    ...emptyVerificationPair,
+    // Attempt 1: throws mid-window.
+    {
+      assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"],
+      exitCode: 1,
+      stderr: "rate limited (attempt 1)\n",
+    },
+    // Attempts 2 and 3: recover but stay empty.
+    ...emptyVerificationPair,
+    ...emptyVerificationPair,
+  ];
+
+  await assert.rejects(
+    () => runInProcess(["--repo", "owner/repo", "--pr", "17"], entries, { delayImpl }),
+    (error) => {
+      assert.equal(error.message, "Copilot review request did not appear in requested reviewers or fresh/in-progress Copilot reviews after gh pr edit");
+      assert.equal(error.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "edit").length, 1);
+      return true;
+    },
+  );
+  assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+});
+
 test("request-copilot-review normalizes known unrequestable/unavailable failures", async () => {
   const { result } = await runInProcess(["--repo", "owner/repo", "--pr", "17"], [
       {


### PR DESCRIPTION
## Summary

The Copilot review-request wrapper no longer races GitHub's eventual consistency: after the single request edit, the presence verification is re-read on a bounded backoff (three retries over roughly thirty seconds) before declaring failure. Observed across five drives: the first verification always failed while the request itself had often landed; the check window, not the request, was the defect.

## Scope and context

Three files: the verification loop in `scripts/github/request-copilot-review.mjs` (fixed delay schedule as a module constant; presence check extracted to one helper re-evaluated per read; `delayImpl` injection seam matching the repo's existing watcher pattern; the request edit still issued exactly once) six new tests (empty-then-populated succeeds with one delay consumed; always-empty fails closed with the exact byte-identical message after the full schedule; throw-then-succeed recovers consuming the paired delays; all-attempts-throw propagates the final raw gh error; a mid-window throw that recovers into empty reads yields the empty-result message; an initial post-edit read that throws recovers into a later successful read), and the scripts/README.md contract section documenting the backoff and the throwing-read retry. Every verification read AFTER a successful request edit is inside the retry window: an initial post-edit read that throws consumes the first scheduled delay rather than propagating immediately. The availability probe on the unavailable short-circuit path stays fail-fast by design and is not retried.

## Acceptance criteria

- [x] The verification retries with bounded backoff (initial read plus retries at five, ten, and fifteen seconds) before declaring failure.
- [x] A genuine failure still fails closed with the exact existing message after the bounded probes; a verification read that throws — the initial post-edit read included — consumes a scheduled retry, and only a final-attempt throw propagates (as the raw gh error); a mid-window throw that recovers into empty reads yields the empty-result message.
- [x] Exit codes and JSON output shape unchanged; the request edit is never re-issued per probe.

## Definition of done

- [x] `node --test test/github/request-copilot-review.test.mjs` green (60 tests, incl. the six stub-injecting race cases — the harness default delay stub fails fast so non-race tests prove zero delays — and pinned gh call sequences, no real waiting).
- [x] `npm run assets:check` (exit 0) and `npm run schema:check` (exit 0).
- [x] `npm run verify` green (recorded in the gate validation artifact).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Bounded backoff verification (initial + three reads over ~30s) | request-copilot-review suite (60, incl. race cases asserting the delay schedule and gh call sequences) | request payload unchanged |
| Genuine failure fails closed, message byte-identical | always-empty test asserting the exact message after the full schedule; final-throw propagation test | reviewer selection unchanged |
| Output shape and exit codes unchanged | suite green; no shape assertions changed | no re-issued request per probe |

## Non-goals

- No change to the review-request payload or reviewer selection.
- No new CLI flag or env knob; the schedule is a fixed module constant with the injection seam reserved for tests.

## Open questions

None.

## Validation

```sh
node --test test/github/request-copilot-review.test.mjs
npm run verify
```

Closes #1748
