### PR TITLE
polish(hook): SubagentStop guard count phrasing, unified fixture arithmetic, derived remainder (#1750)

### DIFF
--- a/.claude/hooks/_hook-decisions.mjs
+++ b/.claude/hooks/_hook-decisions.mjs
@@ -426,7 +426,9 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
   // The reason is fed back to the stopping subagent as context, so the path
   // enumeration is capped: an unbounded list on a very dirty worktree produces a
   // multi-megabyte reason that consumers truncate or choke on, burying the one
-  // actionable line. The count always reports the full total.
+  // actionable line. The "Dirty paths (N):" header below always carries the full
+  // dirty count; the trailing "… and X more" line (when present) carries the
+  // remaining count past the cap, not the full total.
   const MAX_LISTED_DIRTY_PATHS = 50;
   const listed = dirty.slice(0, MAX_LISTED_DIRTY_PATHS).map((p) => "  " + p);
   if (dirty.length > MAX_LISTED_DIRTY_PATHS) {

--- a/.claude/hooks/subagent-stop-uncommitted-guard.mjs
+++ b/.claude/hooks/subagent-stop-uncommitted-guard.mjs
@@ -6,8 +6,9 @@
  * uncommitted changes in a worktree are destroyed with no warning — the only data-loss gap in
  * the enforcement audit. `LOCAL-COMMIT-BEFORE-EXIT` existed only as prose; this hook makes it
  * mechanical: when a subagent stops with a dirty worktree under `tmp/worktrees/`, refuse the
- * stop (exit code 2 + stderr JSON naming `LOCAL-COMMIT-BEFORE-EXIT` and up to 50 dirty paths,
- * plus a summary line with the full count when there are more) so the subagent commits before
+ * stop (exit code 2 + stderr JSON naming `LOCAL-COMMIT-BEFORE-EXIT`; a `Dirty paths (N):` header
+ * with the full dirty count, up to 50 listed paths, and — when there are more than 50 — a
+ * trailing `… and X more` line with the remaining count) so the subagent commits before
  * exiting. Post-merge cleanup that force-removes worktrees can no longer destroy uncommitted
  * work silently.
  *

--- a/packages/core/src/claude/hook-decisions.mjs
+++ b/packages/core/src/claude/hook-decisions.mjs
@@ -425,7 +425,9 @@ export function decideSubagentStopGuard({ cwd, porcelain, pendingCommitAuthoriza
   // The reason is fed back to the stopping subagent as context, so the path
   // enumeration is capped: an unbounded list on a very dirty worktree produces a
   // multi-megabyte reason that consumers truncate or choke on, burying the one
-  // actionable line. The count always reports the full total.
+  // actionable line. The "Dirty paths (N):" header below always carries the full
+  // dirty count; the trailing "… and X more" line (when present) carries the
+  // remaining count past the cap, not the full total.
   const MAX_LISTED_DIRTY_PATHS = 50;
   const listed = dirty.slice(0, MAX_LISTED_DIRTY_PATHS).map((p) => "  " + p);
   if (dirty.length > MAX_LISTED_DIRTY_PATHS) {

--- a/test/contracts/claude-hooks-settings.test.mjs
+++ b/test/contracts/claude-hooks-settings.test.mjs
@@ -370,18 +370,22 @@ test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node 
   // turns that into a fail-safe allow — defeating the guard on exactly the worktrees
   // with the most uncommitted work. The hook raises maxBuffer to 10MB; this test
   // creates enough long-named untracked files to push porcelain past 1MB and asserts
-  // the guard still blocks. Using this fixture's long (~245-byte) porcelain lines, that
-  // takes ~4300+ files; real (much shorter) paths need far more to hit the same bound.
-  // Beyond 10MB (~43k+ such long-line paths) the fail-safe allow is the documented ceiling.
+  // the guard still blocks. Each fixture file's porcelain line is the `?? ` status prefix
+  // (3 bytes) + the filename + a newline (1 byte); with the 241-byte filename below that's
+  // 245 bytes/line, so ~4600 files (~1.1MB) clears the 1MB bound while real (much shorter)
+  // paths need far more to hit the same bound. Beyond 10MB (~43k+ such long-line paths) the
+  // fail-safe allow is the documented ceiling.
   const dir = makeWorktree("maxbuffer", false);
   try {
     const name = (i) => `f${String(i).padStart(5, "0")}-${"x".repeat(230)}.txt`;
-    // ~4600 files x ~240-byte porcelain lines ≈ 1.1MB of status output.
-    for (let i = 0; i < 4600; i++) {
+    const fileCount = 4600;
+    for (let i = 0; i < fileCount; i++) {
       fs.writeFileSync(path.join(dir, name(i)), "", "utf8");
     }
-    const porcelainBytes = Buffer.byteLength(spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }).stdout, "utf8");
+    const porcelain = spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }).stdout;
+    const porcelainBytes = Buffer.byteLength(porcelain, "utf8");
     assert.ok(porcelainBytes > 1024 * 1024, `fixture must exceed the 1MB default maxBuffer (got ${porcelainBytes} bytes)`);
+    const dirtyLineCount = porcelain.split("\n").filter((l) => l.trim() !== "").length;
     const { code, stderrJson } = runHook("subagent-stop-uncommitted-guard.mjs", { cwd: dir });
     assert.equal(code, 2, "a >1MB-porcelain dirty worktree must still be refused (exit 2)");
     assert.ok(stderrJson, "block reason JSON on stderr");
@@ -389,8 +393,11 @@ test("SubagentStop hook still blocks when porcelain output exceeds the 1MB Node 
     assert.match(stderrJson.reason, /LOCAL-COMMIT-BEFORE-EXIT/);
     // The reason itself stays bounded (the 50-path cap), not merely parseable off stderr —
     // pins the cap end to end rather than relying on runHook's own maxBuffer as an incidental
-    // proxy for it.
-    assert.match(stderrJson.reason, /… and 4550 more/);
+    // proxy for it. The remainder is derived from the actual porcelain line count so a fixture
+    // change (e.g. a different fileCount) cannot silently desync this assertion.
+    const MAX_LISTED_DIRTY_PATHS = 50;
+    const expectedRemainder = dirtyLineCount - MAX_LISTED_DIRTY_PATHS;
+    assert.match(stderrJson.reason, new RegExp(`… and ${expectedRemainder} more`));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Polish batch for the SubagentStop guard from the judge-deferred items: the docblock and cap comment now distinguish the header's full count from the summary line's remaining count, the e2e fixture's byte arithmetic is stated once with one derivation, and the truncation-remainder assertion is derived from the captured porcelain instead of a hardcoded literal. The byte-level reason cap is explicitly rejected with rationale.

## Scope and context

Four files: the hook docblock (`.claude/hooks/subagent-stop-uncommitted-guard.mjs`), the cap comment in core (`packages/core/src/claude/hook-decisions.mjs`) with its regenerated vendored copy, and the e2e test (`test/contracts/claude-hooks-settings.test.mjs`) where the fixture arithmetic is unified (241-byte filename, 245-byte porcelain line) and the remainder is computed as captured-line-count minus the 50-path cap.

## Acceptance criteria

- [x] Docblock phrasing distinguishes the header's full count from the summary line's remaining count (hook docblock and core cap comment; vendored copy regenerated byte-identical).
- [x] The two fixture-size comments share one figure with one derivation.
- [x] The e2e remainder assertion is derived from the captured porcelain line count, not hardcoded.
- [x] The byte-level cap decision is recorded: rejected — the 50-path cap bounds the realistic reason size (paths are bounded by filesystem name limits plus git quoting; the ceiling is low hundreds of KB), and a byte cap would add a second truncation mechanism with its own edge cases for a case the path cap already bounds.

## Definition of done

- [x] `node --test test/contracts/claude-hooks-settings.test.mjs` green (24 tests).
- [x] `node --test packages/core/test/claude-hook-decisions.test.mjs` green (73 tests).
- [x] `npm run assets:check` (exit 0, vendored copy regenerated) and `npm run schema:check` (exit 0).
- [x] `npm run verify` green (recorded in the gate validation artifact).
- [x] Byte-cap decision recorded in this PR body (rejected with rationale).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Count phrasing distinguishes full vs remaining | both suites green; assets:check pins the vendored copy; schema:check green | no blocking/fail-safe behavior change |
| One fixture-size derivation | claude-hooks-settings suite green | fixture size unchanged |
| Derived remainder assertion | claude-hooks-settings suite green (regexp built from captured count); npm run verify green | — |
| Byte-cap decision recorded | DoD item: byte-cap decision recorded in this PR body | no second truncation mechanism |

## Non-goals

- No behavior change to the guard's blocking or fail-safe-allow semantics.
- No byte-level truncation mechanism (rejected above).

## Open questions

None.

## Validation

```sh
node --test test/contracts/claude-hooks-settings.test.mjs
node --test packages/core/test/claude-hook-decisions.test.mjs
npm run verify
```

Closes #1750

