### PR TITLE
fix(config): fail closed on schema-invalid blockCleanOnFindingSeverities in gate severity paths

### DIFF
--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -219,6 +219,13 @@ const GateDynamicConfig = z.strictObject({
 // accepted but INERT for spike (a findings-doc deliverable has no "clean
 // verdict" escalation path and no additive dynamic pool) rather than being
 // split into a second schema.
+// Canonical defect-severity vocabulary for blockCleanOnFindingSeverities:
+// the post-normalization form of the schema enum below (legacy spellings
+// normalize into these three). resolveGateConfig fails closed against this
+// set so a config that bypassed schema validation cannot reach severity
+// consumers with an unknown value.
+const BLOCKING_SEVERITY_VOCABULARY = new Set(["high", "medium", "low"]);
+
 const GateConfig = z.strictObject({
   angles: z.array(GateAngleEntry).optional().describe("Review lenses this gate fans out to. A bare string is sugar for { name }; an object may set mandatory/enabled/persona/prompt/model/tier."),
   dynamic: GateDynamicConfig.optional().describe("Diff-driven dynamic angle selection policy for this gate."),
@@ -1839,9 +1846,30 @@ export function resolveRefinement(config) {
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
  * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean, mediumFixWindow: number, tiers: Array<{name: string, match: object, angles: string[]}> }}
+ * @throws {Error} when a configured `blockCleanOnFindingSeverities` entry is
+ *   outside the defect vocabulary after normalization — such a value can only
+ *   arrive through a config that failed schema validation (the schema's enum
+ *   rejects it), and passing it through would make the gate silently block on
+ *   nothing. Refusing here, at the one resolve boundary every severity
+ *   consumer shares, keeps unvalidated vocabulary out of every gate verdict
+ *   path. Absent keys still fall back to the defaults unchanged.
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
+  const rawBlocking = gateConfig?.blockCleanOnFindingSeverities;
+  let blockCleanOnFindingSeverities = ["high"];
+  if (rawBlocking && Array.isArray(rawBlocking)) {
+    blockCleanOnFindingSeverities = [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
+    const invalid = blockCleanOnFindingSeverities.filter((s) => !BLOCKING_SEVERITY_VOCABULARY.has(s));
+    if (invalid.length > 0) {
+      throw new Error(
+        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities contains ` +
+        `out-of-vocabulary severity value(s) after normalization: ${invalid.map((s) => JSON.stringify(s)).join(", ")}. ` +
+        `Allowed: high, medium, low (legacy spellings must-fix, worth-fixing-now, nice-to-have, defer normalize to these). ` +
+        `Fix the config before gate operations can proceed.`
+      );
+    }
+  }
   const entries = normalizeAngleEntries(gateConfig?.angles);
   // An explicitly-empty (or all-garbage/malformed) array is a real configured
   // "no angles" — distinct from the key being absent entirely, which callers
@@ -1855,12 +1883,11 @@ export function resolveGateConfig(config, gate) {
     requireCi: gateConfig?.requireCi ?? true,
     dynamicAngles: gateConfig?.dynamic?.subtractive ?? true,
     additiveAngles: gateConfig?.dynamic?.additive ?? false,
-    // Normalized + deduped at the resolve boundary so every consumer (envelope,
-    // verdict poster, fan-in, viewer) sees canonical spellings only; a
-    // half-migrated ["must-fix","low","defer"] collapses to two entries.
-    blockCleanOnFindingSeverities: gateConfig?.blockCleanOnFindingSeverities && Array.isArray(gateConfig.blockCleanOnFindingSeverities)
-      ? [...new Set(gateConfig.blockCleanOnFindingSeverities.map((s) => normalizeSeverity(s)))]
-      : ["high"],
+    // Normalized + deduped at the resolve boundary (above) so every consumer
+    // (envelope, verdict poster, fan-in, viewer) sees canonical spellings
+    // only; a half-migrated ["must-fix","low","defer"] collapses to two
+    // entries, and anything outside the vocabulary has already thrown.
+    blockCleanOnFindingSeverities,
     // `mediumFixWindow` wins; `worthFixingNowFixWindow` is the deprecated
     // pre-rename key, still honored so an unmigrated config keeps its
     // configured window rather than silently reverting to the default.

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -220,23 +220,29 @@ const GateDynamicConfig = z.strictObject({
 // verdict" escalation path and no additive dynamic pool) rather than being
 // split into a second schema.
 // Single source for the blockCleanOnFindingSeverities vocabulary: the schema
-// enum below consumes the spellings verbatim, and the fail-closed set in
-// resolveGateConfig derives from the same list through normalizeSeverity, so
-// widening the enum can never leave the runtime guard behind (drift would
-// have refused configs that pass schema validation).
+// enum below consumes these spellings verbatim, and resolveGateConfig's
+// fail-closed guard exact-matches raw entries against the same list, so the
+// guard's accept set is byte-identical to the schema's (no trim/normalize
+// superset) and widening the enum can never leave the runtime guard behind.
 const BLOCKING_SEVERITY_SPELLINGS = ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"];
-const BLOCKING_SEVERITY_VOCABULARY = new Set(BLOCKING_SEVERITY_SPELLINGS.map((s) => normalizeSeverity(s)));
+const BLOCKING_SEVERITY_SPELLING_SET = new Set(BLOCKING_SEVERITY_SPELLINGS);
 
 // Render an offending config value for a refusal message without letting the
 // renderer itself throw: JSON.stringify raises on BigInt and circular
-// structures and returns undefined for undefined/symbol/function, so those
-// fall back to String().
+// structures and returns undefined for undefined/symbol/function (those fall
+// back to String()), and String() itself can throw for exotic values (a
+// null-prototype cycle, a throwing Symbol.toPrimitive) — those get a literal
+// placeholder so the refusal always surfaces as the refusal.
 function formatConfigValue(value) {
   try {
     const rendered = JSON.stringify(value);
     return rendered === undefined ? String(value) : rendered;
   } catch {
-    return String(value);
+    try {
+      return String(value);
+    } catch {
+      return "<unrenderable value>";
+    }
   }
 }
 
@@ -1860,21 +1866,25 @@ export function resolveRefinement(config) {
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
  * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean, mediumFixWindow: number, tiers: Array<{name: string, match: object, angles: string[]}> }}
- * @throws {Error} when a PRESENT `blockCleanOnFindingSeverities` key is any
- *   schema-invalid shape: a non-array value, an empty array, or an entry
- *   outside the defect vocabulary after normalization. Every such shape can
- *   only arrive through a config that failed schema validation (the schema
- *   requires a min-1 array of the enum spellings), and passing it through
- *   would make the gate block on the wrong severities or on nothing at all.
- *   The refusal deliberately reaches EVERY caller of this resolver — including
- *   ones reading unrelated fields (resolveRefinement's requireCi read, angle
- *   and tier resolution, state detection) — because no gate operation should
- *   proceed on a config whose verdict-semantics key failed validation. This
- *   is the stated boundary with the module's degrade-to-default convention
- *   (resolveMaxAnglesPerGroup, resolveFanoutGroups): keys that only shape
- *   dispatch ergonomics degrade quietly; the key that decides what blocks a
- *   clean verdict refuses. An ABSENT key still falls back to the default
- *   unchanged.
+ * @throws {Error} when THIS gate's PRESENT `blockCleanOnFindingSeverities`
+ *   key is any schema-invalid shape: a non-array value, an empty array, or an
+ *   entry that is not one of the schema enum's exact spellings. Every such
+ *   shape can only arrive through a config that failed schema validation (the
+ *   schema requires a min-1 array of the enum spellings; the guard
+ *   exact-matches raw entries against the same spelling list, so its accept
+ *   set is byte-identical to the schema's), and passing it through would make
+ *   the gate block on the wrong severities or on nothing at all. The refusal
+ *   reaches every caller that resolves the affected gate — including ones
+ *   reading unrelated fields from it (resolveRefinement's preApproval
+ *   requireCi read, angle and tier resolution, state detection) — because no
+ *   gate operation should proceed on a config whose verdict-semantics key
+ *   failed validation; a caller resolving a DIFFERENT gate of the same config
+ *   is untouched. This is the stated boundary with the module's
+ *   degrade-quietly convention for dispatch-ergonomics keys
+ *   (resolveMaxAnglesPerGroup substitutes its default, resolveFanoutGroups
+ *   drops malformed entries): those keys only shape dispatch, so they degrade;
+ *   the key that decides what blocks a clean verdict refuses. An ABSENT key
+ *   still falls back to the default unchanged.
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
@@ -1888,23 +1898,24 @@ export function resolveGateConfig(config, gate) {
         `Fix the config before gate operations can proceed.`
       );
     }
-    blockCleanOnFindingSeverities = [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
-    if (blockCleanOnFindingSeverities.length === 0) {
+    if (rawBlocking.length === 0) {
       throw new Error(
         `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities is empty; ` +
         `the schema requires at least one blocking severity, and an empty list would make the gate block on nothing. ` +
         `Fix the config before gate operations can proceed.`
       );
     }
-    const invalid = blockCleanOnFindingSeverities.filter((s) => !BLOCKING_SEVERITY_VOCABULARY.has(s));
+    const invalid = rawBlocking.filter((s) => typeof s !== "string" || !BLOCKING_SEVERITY_SPELLING_SET.has(s));
     if (invalid.length > 0) {
       throw new Error(
         `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities contains ` +
-        `out-of-vocabulary severity value(s) after normalization: ${invalid.map((s) => formatConfigValue(s)).join(", ")}. ` +
-        `Allowed: high, medium, low (legacy spellings must-fix, worth-fixing-now, nice-to-have, defer normalize to these). ` +
+        `value(s) outside the schema's severity vocabulary: ${invalid.map((s) => formatConfigValue(s)).join(", ")}. ` +
+        `Allowed (exact spellings): ${BLOCKING_SEVERITY_SPELLINGS.join(", ")} ` +
+        `(the legacy spellings normalize to high/medium/low). ` +
         `Fix the config before gate operations can proceed.`
       );
     }
+    blockCleanOnFindingSeverities = [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
   }
   const entries = normalizeAngleEntries(gateConfig?.angles);
   // An explicitly-empty (or all-garbage/malformed) array is a real configured

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -219,12 +219,26 @@ const GateDynamicConfig = z.strictObject({
 // accepted but INERT for spike (a findings-doc deliverable has no "clean
 // verdict" escalation path and no additive dynamic pool) rather than being
 // split into a second schema.
-// Canonical defect-severity vocabulary for blockCleanOnFindingSeverities:
-// the post-normalization form of the schema enum below (legacy spellings
-// normalize into these three). resolveGateConfig fails closed against this
-// set so a config that bypassed schema validation cannot reach severity
-// consumers with an unknown value.
-const BLOCKING_SEVERITY_VOCABULARY = new Set(["high", "medium", "low"]);
+// Single source for the blockCleanOnFindingSeverities vocabulary: the schema
+// enum below consumes the spellings verbatim, and the fail-closed set in
+// resolveGateConfig derives from the same list through normalizeSeverity, so
+// widening the enum can never leave the runtime guard behind (drift would
+// have refused configs that pass schema validation).
+const BLOCKING_SEVERITY_SPELLINGS = ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"];
+const BLOCKING_SEVERITY_VOCABULARY = new Set(BLOCKING_SEVERITY_SPELLINGS.map((s) => normalizeSeverity(s)));
+
+// Render an offending config value for a refusal message without letting the
+// renderer itself throw: JSON.stringify raises on BigInt and circular
+// structures and returns undefined for undefined/symbol/function, so those
+// fall back to String().
+function formatConfigValue(value) {
+  try {
+    const rendered = JSON.stringify(value);
+    return rendered === undefined ? String(value) : rendered;
+  } catch {
+    return String(value);
+  }
+}
 
 const GateConfig = z.strictObject({
   angles: z.array(GateAngleEntry).optional().describe("Review lenses this gate fans out to. A bare string is sugar for { name }; an object may set mandatory/enabled/persona/prompt/model/tier."),
@@ -238,7 +252,7 @@ const GateConfig = z.strictObject({
   // admitting either here would let a config block on a severity the
   // disposition pass simultaneously auto-resolves.
   blockCleanOnFindingSeverities: z
-    .array(z.enum(["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]))
+    .array(z.enum(/** @type {[string, ...string[]]} */ (BLOCKING_SEVERITY_SPELLINGS)))
     .min(1)
     .default(["high"])
     .describe("Defect finding severities that block a clean gate verdict (high/medium/low only — \"question\"/\"nit\" are non-defect categories and never block by severity). \"must-fix\" is the deprecated legacy spelling of \"high\", \"worth-fixing-now\" of \"medium\", and \"nice-to-have\"/\"defer\" of \"low\"; consumers normalize them."),
@@ -1846,25 +1860,47 @@ export function resolveRefinement(config) {
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
  * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean, mediumFixWindow: number, tiers: Array<{name: string, match: object, angles: string[]}> }}
- * @throws {Error} when a configured `blockCleanOnFindingSeverities` entry is
- *   outside the defect vocabulary after normalization — such a value can only
- *   arrive through a config that failed schema validation (the schema's enum
- *   rejects it), and passing it through would make the gate silently block on
- *   nothing. Refusing here, at the one resolve boundary every severity
- *   consumer shares, keeps unvalidated vocabulary out of every gate verdict
- *   path. Absent keys still fall back to the defaults unchanged.
+ * @throws {Error} when a PRESENT `blockCleanOnFindingSeverities` key is any
+ *   schema-invalid shape: a non-array value, an empty array, or an entry
+ *   outside the defect vocabulary after normalization. Every such shape can
+ *   only arrive through a config that failed schema validation (the schema
+ *   requires a min-1 array of the enum spellings), and passing it through
+ *   would make the gate block on the wrong severities or on nothing at all.
+ *   The refusal deliberately reaches EVERY caller of this resolver — including
+ *   ones reading unrelated fields (resolveRefinement's requireCi read, angle
+ *   and tier resolution, state detection) — because no gate operation should
+ *   proceed on a config whose verdict-semantics key failed validation. This
+ *   is the stated boundary with the module's degrade-to-default convention
+ *   (resolveMaxAnglesPerGroup, resolveFanoutGroups): keys that only shape
+ *   dispatch ergonomics degrade quietly; the key that decides what blocks a
+ *   clean verdict refuses. An ABSENT key still falls back to the default
+ *   unchanged.
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
   const rawBlocking = gateConfig?.blockCleanOnFindingSeverities;
   let blockCleanOnFindingSeverities = ["high"];
-  if (rawBlocking && Array.isArray(rawBlocking)) {
+  if (rawBlocking !== undefined) {
+    if (!Array.isArray(rawBlocking)) {
+      throw new Error(
+        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities must be an array ` +
+        `of defect severities, got ${formatConfigValue(rawBlocking)}. ` +
+        `Fix the config before gate operations can proceed.`
+      );
+    }
     blockCleanOnFindingSeverities = [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
+    if (blockCleanOnFindingSeverities.length === 0) {
+      throw new Error(
+        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities is empty; ` +
+        `the schema requires at least one blocking severity, and an empty list would make the gate block on nothing. ` +
+        `Fix the config before gate operations can proceed.`
+      );
+    }
     const invalid = blockCleanOnFindingSeverities.filter((s) => !BLOCKING_SEVERITY_VOCABULARY.has(s));
     if (invalid.length > 0) {
       throw new Error(
         `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities contains ` +
-        `out-of-vocabulary severity value(s) after normalization: ${invalid.map((s) => JSON.stringify(s)).join(", ")}. ` +
+        `out-of-vocabulary severity value(s) after normalization: ${invalid.map((s) => formatConfigValue(s)).join(", ")}. ` +
         `Allowed: high, medium, low (legacy spellings must-fix, worth-fixing-now, nice-to-have, defer normalize to these). ` +
         `Fix the config before gate operations can proceed.`
       );

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2613,6 +2613,62 @@ describe("role resolution", () => {
       );
     });
 
+    test("resolveGateConfig names every out-of-vocabulary value when several are invalid", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { blockCleanOnFindingSeverities: ["critical", "blocker", "high"] } },
+      };
+      assert.throws(
+        () => resolveGateConfig(config, "draft"),
+        (err) => err.message.includes('"critical"') && err.message.includes('"blocker"') && !err.message.includes('"high"'),
+      );
+    });
+
+    test("resolveGateConfig refuses an entry JSON.stringify cannot render instead of crashing the renderer", () => {
+      const circular = {};
+      circular.self = circular;
+      for (const entry of [10n, circular]) {
+        assert.throws(
+          () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: [entry] } } }, "draft"),
+          /out-of-vocabulary/,
+        );
+      }
+    });
+
+    // The schema requires min 1; an empty list reaches this resolver only
+    // through a config that failed validation, and passing it through would
+    // make the gate block on nothing (and severity consumers diverge on it).
+    test("resolveGateConfig throws on an explicitly-empty blockCleanOnFindingSeverities array", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { blockCleanOnFindingSeverities: [] } },
+      };
+      assert.throws(() => resolveGateConfig(config, "draft"), /is empty/);
+    });
+
+    // The schema requires an array; a scalar or mapping here is the same
+    // failed-validation channel and previously fell back to the high default
+    // silently, under-blocking relative to the author's intent.
+    test("resolveGateConfig throws on a present-but-non-array blockCleanOnFindingSeverities value", () => {
+      for (const value of ["medium", { medium: true }, 3, null]) {
+        assert.throws(
+          () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: value } } }, "draft"),
+          /must be an array/,
+          String(value),
+        );
+      }
+    });
+
+    // Parity pin for the derived vocabulary: every spelling the schema enum
+    // accepts must resolve without refusal, so the guard can never drift
+    // ahead of the schema.
+    test("resolveGateConfig accepts every schema-enum blockCleanOnFindingSeverities spelling", () => {
+      for (const spelling of ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]) {
+        const result = resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: [spelling] } } }, "draft");
+        assert.equal(result.blockCleanOnFindingSeverities.length, 1, spelling);
+      }
+    });
+
     // Case-sensitivity is deliberate (normalizeSeverity never lowercases):
     // a mixed-case spelling is out of vocabulary and must refuse, not coerce.
     test("resolveGateConfig throws on a mixed-case blockCleanOnFindingSeverities spelling", () => {

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2577,6 +2577,52 @@ describe("role resolution", () => {
       assert.deepEqual(result.blockCleanOnFindingSeverities, ["high", "medium"]);
     });
 
+    // Fail-closed posture: an out-of-vocabulary blocking severity can only
+    // arrive through a config that failed schema validation (the schema enum
+    // rejects it; loadDevLoopConfig returns the raw merged config alongside
+    // its errors). Passing it through would make the gate silently block on
+    // nothing, so the resolve boundary refuses instead.
+    test("resolveGateConfig throws on an out-of-vocabulary blockCleanOnFindingSeverities value, naming the value and the gate key", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: {
+            angles: ["scope"],
+            blockCleanOnFindingSeverities: ["high", "critical"],
+          },
+        },
+      };
+      assert.throws(
+        () => resolveGateConfig(config, "draft"),
+        (err) =>
+          err instanceof Error &&
+          err.message.includes("Config validation failed") &&
+          err.message.includes("gates.draft.blockCleanOnFindingSeverities") &&
+          err.message.includes('"critical"'),
+      );
+    });
+
+    test("resolveGateConfig throws on a non-string blockCleanOnFindingSeverities entry", () => {
+      const config = {
+        version: 1,
+        gates: { preApproval: { blockCleanOnFindingSeverities: ["high", 3] } },
+      };
+      assert.throws(
+        () => resolveGateConfig(config, "preApproval"),
+        (err) => err instanceof Error && err.message.includes("gates.preApproval.blockCleanOnFindingSeverities"),
+      );
+    });
+
+    // Case-sensitivity is deliberate (normalizeSeverity never lowercases):
+    // a mixed-case spelling is out of vocabulary and must refuse, not coerce.
+    test("resolveGateConfig throws on a mixed-case blockCleanOnFindingSeverities spelling", () => {
+      const config = {
+        version: 1,
+        gates: { draft: { blockCleanOnFindingSeverities: ["HIGH"] } },
+      };
+      assert.throws(() => resolveGateConfig(config, "draft"), /out-of-vocabulary/);
+    });
+
     test("resolveGateConfig honors the deprecated worthFixingNowFixWindow alias when mediumFixWindow is absent", () => {
       const config = {
         version: 1,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2627,12 +2627,34 @@ describe("role resolution", () => {
     test("resolveGateConfig refuses an entry JSON.stringify cannot render instead of crashing the renderer", () => {
       const circular = {};
       circular.self = circular;
-      for (const entry of [10n, circular]) {
+      const nullProtoCycle = Object.create(null);
+      nullProtoCycle.self = nullProtoCycle;
+      for (const entry of [10n, circular, nullProtoCycle]) {
         assert.throws(
           () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: [entry] } } }, "draft"),
-          /out-of-vocabulary/,
+          /outside the schema's severity vocabulary/,
         );
       }
+    });
+
+    // JSON.stringify returns undefined (without throwing) for symbol values;
+    // the formatter's String() fallback must render a real token so the
+    // refusal message never carries an empty slot.
+    test("resolveGateConfig renders a non-empty token for a symbol entry in the refusal message", () => {
+      assert.throws(
+        () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: [Symbol("oops")] } } }, "draft"),
+        (err) => err.message.includes("Symbol(oops)"),
+      );
+    });
+
+    // The guard's accept set is exact-spelling parity with the schema enum:
+    // a whitespace-varied entry fails schema validation, so it must refuse
+    // here too rather than being trim-normalized into acceptance.
+    test("resolveGateConfig refuses a whitespace-varied spelling the schema rejects", () => {
+      assert.throws(
+        () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: ["high "] } } }, "draft"),
+        /outside the schema's severity vocabulary/,
+      );
     });
 
     // The schema requires min 1; an empty list reaches this resolver only
@@ -2676,7 +2698,7 @@ describe("role resolution", () => {
         version: 1,
         gates: { draft: { blockCleanOnFindingSeverities: ["HIGH"] } },
       };
-      assert.throws(() => resolveGateConfig(config, "draft"), /out-of-vocabulary/);
+      assert.throws(() => resolveGateConfig(config, "draft"), /outside the schema's severity vocabulary/);
     });
 
     test("resolveGateConfig honors the deprecated worthFixingNowFixWindow alias when mediumFixWindow is absent", () => {

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1626,6 +1626,17 @@ async function applyGateFullLabel({ repo, pr }, { env, ghCommand, runChild = def
 
 export async function upsertCheckpointVerdict(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), runChild = defaultRunChild } = {}) {
   const gh = { env, ghCommand, repoRoot, runChild };
+  // loadDevLoopConfig never throws: on a validation failure it returns the raw
+  // merged config alongside its errors. Every other severity consumer
+  // (consolidate-fanin, close-gate-findings, detect-checkpoint-evidence) fails
+  // closed on a non-empty errors array; the poster that WRITES the verdict
+  // must not be the one place a schema-invalid config still resolves gate
+  // config and posts. Checked before any GitHub read so the refusal is
+  // immediate and side-effect free.
+  const { config, errors: configErrors } = await loadDevLoopConfig({ repoRoot });
+  if (Array.isArray(configErrors) && configErrors.length > 0) {
+    throw new Error(`This worktree's config (--repo-root ${JSON.stringify(repoRoot)}) could not be fully loaded/validated; refusing to post a gate verdict: ${JSON.stringify(configErrors)}`);
+  }
   // Root cause 1: allow resurrected sessions to claim ownership when the previous
   // run's coordination record is stale. Without this, a new run ID is rejected even
   // though the old run is dead, forcing manual file deletion.
@@ -1647,7 +1658,6 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   const coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr, lightweight: options.lightweight === true }, gh);
   const evidence = coordinationContext.gateEvidence;
   const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
-  const { config } = await loadDevLoopConfig({ repoRoot });
   const draftGateConfig = resolveGateConfig(config, "draft");
   const preApprovalGateConfig = resolveGateConfig(config, "preApproval");
   const maxCopilotRounds = options.lightweight === true

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -1635,7 +1635,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // immediate and side-effect free.
   const { config, errors: configErrors } = await loadDevLoopConfig({ repoRoot });
   if (Array.isArray(configErrors) && configErrors.length > 0) {
-    throw new Error(`This worktree's config (--repo-root ${JSON.stringify(repoRoot)}) could not be fully loaded/validated; refusing to post a gate verdict: ${JSON.stringify(configErrors)}`);
+    throw new Error(`This worktree's config (repoRoot ${JSON.stringify(repoRoot)}) could not be fully loaded/validated; refusing to post a gate verdict: ${JSON.stringify(configErrors)}`);
   }
   // Root cause 1: allow resurrected sessions to claim ownership when the previous
   // run's coordination record is stale. Without this, a new run ID is rejected even

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -338,6 +338,36 @@ test("buildCoordinationEvaluatorInput threads postConvergenceReviewSuppressed fr
   assert.equal(missingFieldInput.postConvergenceReviewSuppressed, false);
 });
 
+// The poster is the artifact that WRITES the verdict; like its sibling
+// severity consumers (consolidate-fanin, close-gate-findings,
+// detect-checkpoint-evidence) it must fail closed on a config that failed
+// schema validation instead of resolving gate config from the raw merged
+// object. The refusal happens before any gh read, so no stub is needed.
+test("upsert refuses to post when the worktree config failed schema validation", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-invalid-config-"));
+  try {
+    await writeFile(
+      path.join(tempDir, ".devloops"),
+      "version: 1\ngates:\n  draft:\n    blockCleanOnFindingSeverity:\n      - high\n",
+      "utf8",
+    );
+    const result = await runNodeHelper(scriptPath, [
+      "--repo", "owner/repo",
+      "--pr", "17",
+      "--gate", "draft_gate",
+      "--head-sha", "abc1234000000000000000000000000000000000",
+      "--verdict", "clean",
+      "--findings-summary", "no issues found",
+      "--next-action", "n/a",
+      "--inline-reason", "config refusal test",
+    ], { cwd: tempDir, env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }) });
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /could not be fully loaded\/validated; refusing to post a gate verdict/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("parseUpsertCheckpointVerdictCliArgs rejects malformed arguments deterministically", () => {
   assert.throws(
     () => parseUpsertCheckpointVerdictCliArgs([]),
@@ -5261,6 +5291,8 @@ test("upsert-checkpoint-verdict refuses an inline pre_approval_gate verdict at p
     // lightMode disabled so the lazy light-facts fetch does not fire (no fetch
     // needed to prove the marker is evaluated); requireFanoutEvidence on so the
     // pre_approval_gate candidate marker IS evaluated by enforcePostTimeFanoutMode.
+    // maxFiles/maxLines are schema-required on a present lightMode object, and
+    // the poster now refuses outright on a schema-invalid config.
     await writeFile(path.join(tempDir, ".devloops"), [
       "version: 1",
       "gates:",
@@ -5268,6 +5300,8 @@ test("upsert-checkpoint-verdict refuses an inline pre_approval_gate verdict at p
       "localImplementation:",
       "  lightMode:",
       "    enabled: false",
+      "    maxFiles: 5",
+      "    maxLines: 200",
       "",
     ].join("\n"), "utf8");
     const env = await writeGhStub(tempDir, [


### PR DESCRIPTION
## Summary

The fail-closed posture the issue asked to decide is implemented on both arms. Arm 1, key-scoped: `resolveGateConfig` refuses every schema-invalid shape of a present `blockCleanOnFindingSeverities` key (non-array, empty array, entry outside the schema's exact spellings), so no severity consumer resolving the affected gate can operate on unvalidated vocabulary. Arm 2, wholesale: the verdict poster (`upsert-checkpoint-verdict.mjs`) now fails closed on a non-empty `loadDevLoopConfig` errors array before any GitHub read — previously it discarded the errors and posted a verdict computed from a raw merged config. Among the sibling severity consumers, consolidate-fanin already throws on a non-empty errors array; close-gate-findings and detect-checkpoint-evidence degrade to defaults instead, and aligning their posture (plus the adjacent comments) is follow-up issue 1763.

## Scope and context

Four files. `packages/core/src/config/config.mjs`: `resolveGateConfig` refuses every schema-invalid shape of a present `blockCleanOnFindingSeverities` key with an explicit error naming the offending value(s) and the `gates.<gate>.blockCleanOnFindingSeverities` key. The guard exact-matches raw entries against `BLOCKING_SEVERITY_SPELLINGS`, the same list the schema enum consumes, so its accept set is byte-identical to the schema's (a whitespace-varied or mixed-case spelling refuses rather than being trim-normalized into acceptance). Offending values render through `formatConfigValue`, safe against throwing `JSON.stringify` (BigInt, cycles), undefined-returning renders (symbols), and throwing `String()` (null-prototype cycles). The docblock states the refusal's per-gate blast radius and the boundary with the degrade-quietly convention (resolveMaxAnglesPerGroup substitutes its default, resolveFanoutGroups drops malformed entries). `scripts/github/upsert-checkpoint-verdict.mjs`: refuses on a non-empty config errors array at entry. `packages/core/test/config.test.mjs`: refusal pins for out-of-vocabulary tokens (single and multiple, named in the message), non-string, unrenderable, and symbol entries, mixed-case and whitespace-varied spellings, the empty array, present-but-non-array shapes, plus a schema-enum parity pin. `test/github/upsert-checkpoint-verdict.test.mjs`: pins the poster's refusal on a schema-invalid worktree config, and repairs a pre-existing test fixture whose `.devloops` was itself schema-invalid (a `lightMode` block missing the required `maxFiles`/`maxLines`) — concrete evidence of the wholesale refusal's blast radius: any worktree whose config fails validation for any reason now refuses at the poster.

## Acceptance criteria

- [ ] A schema-invalid config reaching gate verdict/severity paths produces an explicit refusal naming the validation failure, not silent raw-config passthrough: non-array, empty-array, and out-of-vocabulary `blockCleanOnFindingSeverities` shapes throw from `resolveGateConfig` (the boundary severity consumers resolve through), and the verdict poster refuses on any config that failed validation wholesale.
- [ ] In-vocabulary configs and the legacy severity aliases behave unchanged (existing normalization/dedup tests untouched and green; absent key still defaults to high).
- [ ] A test pins the refusal for an out-of-vocabulary `blockCleanOnFindingSeverities` value.

## Definition of done

- [ ] `node --test packages/core/test/config.test.mjs` green.
- [ ] `node --test test/github/upsert-checkpoint-verdict.test.mjs` green.
- [ ] `npm run schema:check` green (no schema change; vocabulary set mirrors the existing enum).
- [ ] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Explicit refusal on schema-invalid severity shapes | config suite green (resolver refusal pins for non-array, empty, out-of-vocabulary); upsert suite green (poster wholesale-refusal pin) | resolveGateConfig fallback for absent keys unchanged |
| In-vocabulary and legacy aliases unchanged | config suite green (existing normalization tests); npm run verify green | vocabulary not widened |
| Refusal test pinned | config suite green (out-of-vocabulary refusal pin present and passing) | — |

## Non-goals

- Widening the severity vocabulary.
- Changing `resolveGateConfig` fallback semantics for merely-absent keys (an absent key still resolves to the high default).
- Changing how other severity consumers (`consolidateFanin`, the verdict poster's own re-normalization) treat directly-passed severity lists; they receive resolved values and a follow-up covers their redundant re-normalization.
- Changing `loadDevLoopConfig`'s raw-config-plus-errors return shape.

## Open questions

None.

## Validation

```sh
node --test packages/core/test/config.test.mjs
node --test test/github/upsert-checkpoint-verdict.test.mjs
npm run schema:check
npm run verify
```

Closes #1753
