### PR TITLE
fix(guard): refuse the named hash entity; complete fallback boundary parity

### DIFF
--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -26,8 +26,9 @@
  * skipped; the same digit run appearing elsewhere as a bare token still
  * refuses — this is the ONLY sanctioned way a generated comment body may
  * carry a `#<digits>` token. An entity that itself decodes to the hash
- * character followed by a digit run is treated as a bare id (it renders as
- * an auto-link). Keep the allowlist small and deliberate.
+ * character — numeric (`&#35;`/`&#x23;`, zero-padded variants included) or
+ * the named `&num;` — followed by a digit run is treated as a bare id (it
+ * renders as an auto-link). Keep the allowlist small and deliberate.
  */
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
@@ -44,13 +45,17 @@ function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }
 
-// An entity that DECODES to the hash character (`&#35;` decimal or `&#x23;`
-// hex, case-insensitive, zero-padding accepted — CommonMark decodes padded
-// forms too), immediately followed by an issue-length digit run, renders as a
-// bare `#<digits>` auto-link on GitHub even though no literal hash-digit token
+// An entity that DECODES to the hash character (`&#35;` decimal, `&#x23;`
+// hex — case-insensitive, zero-padding accepted, CommonMark decodes padded
+// forms too — or the HTML5 named entity `&num;`, which GitHub also decodes),
+// immediately followed by an issue-length digit run, renders as a bare
+// `#<digits>` auto-link on GitHub even though no literal hash-digit token
 // exists in the raw body. Treated as a bare-id occurrence so the encoded form
-// cannot smuggle a reference past the guard.
-const ENCODED_HASH_ID_RE = /&#(?:0*35|x0*23);(\d{1,9})/gi;
+// cannot smuggle a reference past the guard. The `i` flag makes the named
+// form match case-variants like `&NUM;` too; only lowercase `&num;` actually
+// decodes, so that is deliberate over-refusal on a suspicious near-miss,
+// keeping the guard fail-closed.
+const ENCODED_HASH_ID_RE = /&(?:#(?:0*35|x0*23)|num);(\d{1,9})/gi;
 
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -53,7 +53,12 @@
 const ISSUE_PR_ID_RE = /#(\d{1,9})/g;
 
 function isNumericCharacterReference(body, match) {
-  return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
+  // The digit bound mirrors cmark-gfm's 8-digit entity parser: a 9-digit
+  // ampersand-wrapped run is NOT decoded by the renderer, so it renders
+  // literally and must not be excluded as a spent entity.
+  return match[1].length <= 8
+    && body[match.index - 1] === "&"
+    && body[match.index + match[0].length] === ";";
 }
 
 // Entity forms the renderer resolves that can participate in assembling a
@@ -73,14 +78,17 @@ function decodeRenderedText(body) {
     try {
       return String.fromCodePoint(code);
     } catch {
-      return entity;
+      // cmark substitutes the replacement character for a reference it cannot
+      // decode; mirroring that keeps decodable-shaped text from lingering in
+      // the decoded scan, where it could masquerade as a spent entity.
+      return "�";
     }
   });
 }
 
-function collectBareIds(text, found) {
+function collectBareIds(text, found, { excludeEntities }) {
   for (const m of text.matchAll(ISSUE_PR_ID_RE)) {
-    if (isNumericCharacterReference(text, m)) continue;
+    if (excludeEntities && isNumericCharacterReference(text, m)) continue;
     found.add(m[1]);
   }
 }
@@ -88,15 +96,19 @@ function collectBareIds(text, found) {
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).
  * Scans the body as written AND after a single renderer-like entity decode,
- * so an id assembled from entity-encoded pieces is still found. Returns []
- * for non-string input (and for a body with no `#<digits>`).
+ * so an id assembled from entity-encoded pieces is still found. The entity
+ * exclusion applies only to the RAW scan: in decoded text the renderer's one
+ * decode is already spent, so an ampersand-then-digits-then-semicolon shape
+ * there is plain text a wrapper cannot re-protect (an ampersand-wrapped
+ * encoded hash plus digits must refuse, not hide). Returns [] for non-string
+ * input (and for a body with no `#<digits>`).
  */
 export function extractIssuePrIds(body) {
   if (typeof body !== "string" || body.length === 0) return [];
   const found = new Set();
-  collectBareIds(body, found);
+  collectBareIds(body, found, { excludeEntities: true });
   const decoded = decodeRenderedText(body);
-  if (decoded !== body) collectBareIds(decoded, found);
+  if (decoded !== body) collectBareIds(decoded, found, { excludeEntities: false });
   return [...found];
 }
 

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -25,10 +25,17 @@
  * reference (`&#<digits>;`, e.g. `&#91;` for `[`) — each such OCCURRENCE is
  * skipped; the same digit run appearing elsewhere as a bare token still
  * refuses — this is the ONLY sanctioned way a generated comment body may
- * carry a `#<digits>` token. An entity that itself decodes to the hash
- * character — numeric (`&#35;`/`&#x23;`, zero-padded variants included) or
- * the named `&num;` — followed by a digit run is treated as a bare id (it
- * renders as an auto-link). Keep the allowlist small and deliberate.
+ * carry a `#<digits>` token. Extraction is decode-aware on BOTH sides of the
+ * token: the body is also scanned after a single left-to-right decode of the
+ * entity forms GitHub's renderer resolves (numeric character references,
+ * zero-padding and hex included, plus the named hash and ampersand entities),
+ * so a hash or any digit of the id smuggled as an entity — `&#35;123`,
+ * `&num;123`, `#&#49;23`, any mix — still refuses. The decode is single-pass
+ * like the renderer's, so a double-encoded form (`&amp;#35;123`), which
+ * renders as inert literal text, is NOT refused. Case-variants of the named
+ * entities are decoded too even where GitHub would not (`&NUM;`): deliberate
+ * over-refusal on a suspicious near-miss, keeping the guard fail-closed.
+ * Keep the allowlist small and deliberate.
  */
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
@@ -45,32 +52,47 @@ function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }
 
-// An entity that DECODES to the hash character (`&#35;` decimal, `&#x23;`
-// hex — case-insensitive, zero-padding accepted, CommonMark decodes padded
-// forms too — or the HTML5 named entity `&num;`, which GitHub also decodes),
-// immediately followed by an issue-length digit run, renders as a bare
-// `#<digits>` auto-link on GitHub even though no literal hash-digit token
-// exists in the raw body. Treated as a bare-id occurrence so the encoded form
-// cannot smuggle a reference past the guard. The `i` flag makes the named
-// form match case-variants like `&NUM;` too; only lowercase `&num;` actually
-// decodes, so that is deliberate over-refusal on a suspicious near-miss,
-// keeping the guard fail-closed.
-const ENCODED_HASH_ID_RE = /&(?:#(?:0*35|x0*23)|num);(\d{1,9})/gi;
+// Entity forms the renderer resolves that can participate in assembling a
+// rendered `#<digits>` auto-link: numeric character references (any code
+// point — the hash AND the digits themselves are smuggleable) plus the named
+// hash and ampersand entities. `&amp;` is decoded (consumed) precisely so a
+// double-encoded form's output is never re-read as a fresh entity opener —
+// one pass, like the renderer.
+const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,7}|x[0-9a-f]{1,6})|num|amp);/gi;
+
+function decodeRenderedText(body) {
+  return body.replace(DECODABLE_ENTITY_RE, (entity) => {
+    const inner = entity.slice(1, -1).toLowerCase();
+    if (inner === "num") return "#";
+    if (inner === "amp") return "&";
+    const code = inner[1] === "x" ? Number.parseInt(inner.slice(2), 16) : Number.parseInt(inner.slice(1), 10);
+    try {
+      return String.fromCodePoint(code);
+    } catch {
+      return entity;
+    }
+  });
+}
+
+function collectBareIds(text, found) {
+  for (const m of text.matchAll(ISSUE_PR_ID_RE)) {
+    if (isNumericCharacterReference(text, m)) continue;
+    found.add(m[1]);
+  }
+}
 
 /**
  * Extract the raw issue/PR id tokens found in a body (as strings, deduped).
- * Returns [] for non-string input (and for a body with no `#<digits>`).
+ * Scans the body as written AND after a single renderer-like entity decode,
+ * so an id assembled from entity-encoded pieces is still found. Returns []
+ * for non-string input (and for a body with no `#<digits>`).
  */
 export function extractIssuePrIds(body) {
   if (typeof body !== "string" || body.length === 0) return [];
   const found = new Set();
-  for (const m of body.matchAll(ISSUE_PR_ID_RE)) {
-    if (isNumericCharacterReference(body, m)) continue;
-    found.add(m[1]);
-  }
-  for (const m of body.matchAll(ENCODED_HASH_ID_RE)) {
-    found.add(m[1]);
-  }
+  collectBareIds(body, found);
+  const decoded = decodeRenderedText(body);
+  if (decoded !== body) collectBareIds(decoded, found);
   return [...found];
 }
 

--- a/packages/core/src/github/comment-id-guard.mjs
+++ b/packages/core/src/github/comment-id-guard.mjs
@@ -28,14 +28,18 @@
  * carry a `#<digits>` token. Extraction is decode-aware on BOTH sides of the
  * token: the body is also scanned after a single left-to-right decode of the
  * entity forms GitHub's renderer resolves (numeric character references,
- * zero-padding and hex included, plus the named hash and ampersand entities),
+ * zero-padding and hex included at cmark-gfm's 8-digit bound, plus the named
+ * hash entity),
  * so a hash or any digit of the id smuggled as an entity — `&#35;123`,
  * `&num;123`, `#&#49;23`, any mix — still refuses. The decode is single-pass
- * like the renderer's, so a double-encoded form (`&amp;#35;123`), which
- * renders as inert literal text, is NOT refused. Case-variants of the named
- * entities are decoded too even where GitHub would not (`&NUM;`): deliberate
- * over-refusal on a suspicious near-miss, keeping the guard fail-closed.
- * Keep the allowlist small and deliberate.
+ * like the renderer's: a double-encoded form (`&amp;#35;123`) renders as
+ * inert literal text and the decode pass never manufactures a refusal of its
+ * INNER id — though the raw scan still refuses the outer digit run of the
+ * numeric form as a pre-existing fail-closed near-miss (the outer entity's
+ * semicolon sits before the hash, so the well-formed-entity exclusion does
+ * not apply). Case-variants of the named hash entity are decoded too even
+ * where GitHub would not (`&NUM;`): deliberate over-refusal, keeping the
+ * guard fail-closed. Keep the allowlist small and deliberate.
  */
 
 // Matches a bare GitHub auto-link issue/PR reference: `#<digits>`. Bound to
@@ -55,16 +59,16 @@ function isNumericCharacterReference(body, match) {
 // Entity forms the renderer resolves that can participate in assembling a
 // rendered `#<digits>` auto-link: numeric character references (any code
 // point — the hash AND the digits themselves are smuggleable) plus the named
-// hash and ampersand entities. `&amp;` is decoded (consumed) precisely so a
-// double-encoded form's output is never re-read as a fresh entity opener —
-// one pass, like the renderer.
-const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,7}|x[0-9a-f]{1,6})|num|amp);/gi;
+// hash entity. The digit bounds match cmark-gfm's numeric-entity parser
+// (up to 8 digits, decimal or hex) so nothing GitHub decodes escapes the
+// pass. Single non-rescanning replace = one decode, like the renderer, so a
+// double-encoded form's output is never re-read as a fresh entity.
+const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,8}|x[0-9a-f]{1,8})|num);/gi;
 
 function decodeRenderedText(body) {
   return body.replace(DECODABLE_ENTITY_RE, (entity) => {
     const inner = entity.slice(1, -1).toLowerCase();
     if (inner === "num") return "#";
-    if (inner === "amp") return "&";
     const code = inner[1] === "x" ? Number.parseInt(inner.slice(2), 16) : Number.parseInt(inner.slice(1), 10);
     try {
       return String.fromCodePoint(code);

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -151,6 +151,10 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.deepEqual(extractIssuePrIds("see &#35;&#49;2&#x33; there"), ["123"]);
     // named hash entity + encoded digit
     assert.deepEqual(extractIssuePrIds("see &num;&#52;2 there"), ["42"]);
+    // cmark-gfm decodes numeric references up to 8 digits (decimal or hex):
+    // maximally padded hash forms still refuse.
+    assert.deepEqual(extractIssuePrIds("see &#00000035;77 there"), ["77"]);
+    assert.deepEqual(extractIssuePrIds("see &#x00000023;88 there"), ["88"]);
     // allowlist still works through the assembled form
     assert.equal(
       guardCommentBodyNoIssuePrIds("see #&#49;23 there", { allowedRefs: ["123"] }),

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -139,6 +139,36 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     );
   });
 
+  // Decode-aware extraction on the DIGIT side: GitHub decodes entity-encoded
+  // digits too, so an id assembled from entity pieces still renders as a live
+  // auto-link and must refuse. A double-encoded form renders as inert literal
+  // text (the renderer decodes once) and must NOT refuse.
+  test("an id assembled from entity-encoded digits is treated as a bare id", () => {
+    // literal hash + encoded first digit
+    assert.deepEqual(extractIssuePrIds("see #&#49;23 there"), ["123"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see #&#49;23 there"), /#123/);
+    // encoded hash + mixed literal/encoded digits (hex form included)
+    assert.deepEqual(extractIssuePrIds("see &#35;&#49;2&#x33; there"), ["123"]);
+    // named hash entity + encoded digit
+    assert.deepEqual(extractIssuePrIds("see &num;&#52;2 there"), ["42"]);
+    // allowlist still works through the assembled form
+    assert.equal(
+      guardCommentBodyNoIssuePrIds("see #&#49;23 there", { allowedRefs: ["123"] }),
+      "see #&#49;23 there",
+    );
+  });
+
+  test("the single-pass decode never manufactures a refusal from a double-encoded form", () => {
+    // Both forms render as inert literal entity text (the renderer decodes
+    // once). The named double-encoded form extracts nothing. The numeric
+    // double-encoded form was already over-refused BEFORE the decode pass —
+    // the raw scan sees the inner hash-digit run in a non-entity context
+    // (preceded by the semicolon of the outer entity) — and stays refused:
+    // pre-existing fail-closed behavior, not a decode regression.
+    assert.deepEqual(extractIssuePrIds("see &amp;num;123 there"), []);
+    assert.deepEqual(extractIssuePrIds("see &amp;#35;123 there"), ["35"]);
+  });
+
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {
     // Representative of renderGateReviewCommentBody output for a clean gate:
     // gate name, head SHA (hex), verdict, severity/angle labels — never a #digit.

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -162,6 +162,26 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     );
   });
 
+  // The entity exclusion applies only to the raw scan: after the renderer's
+  // one decode, an ampersand-wrapped shape in decoded text is plain text —
+  // wrapping an encoded hash-digit assembly in ampersand-and-semicolon must
+  // refuse, not hide (this exact shape escaped both scans once).
+  test("an ampersand-wrapped encoded hash-digit assembly still refuses", () => {
+    assert.deepEqual(extractIssuePrIds("x &&#35;123; y"), ["123"]);
+    assert.deepEqual(extractIssuePrIds("x &&num;123; y"), ["123"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("x &&#35;123; y"), /#123/);
+  });
+
+  // Exclusion bound parity with cmark's 8-digit entity parser: a 9-digit
+  // wrapped run is not decoded by the renderer, renders literally, and must
+  // not be excluded as a spent entity. An 8-digit reference whose code point
+  // cannot decode becomes the replacement character (as on GitHub) and stays
+  // inert.
+  test("a 9-digit ampersand-wrapped run refuses; an undecodable 8-digit reference stays inert", () => {
+    assert.deepEqual(extractIssuePrIds("see &#123456789; there"), ["123456789"]);
+    assert.deepEqual(extractIssuePrIds("see &#99999999; there"), []);
+  });
+
   test("the single-pass decode never manufactures a refusal from a double-encoded form", () => {
     // Both forms render as inert literal entity text (the renderer decodes
     // once). The named double-encoded form extracts nothing. The numeric

--- a/packages/core/test/comment-id-guard.test.mjs
+++ b/packages/core/test/comment-id-guard.test.mjs
@@ -120,6 +120,25 @@ describe("comment-id-guard (#1731 no-issue/PR-ids-in-comments)", () => {
     assert.throws(() => guardCommentBodyNoIssuePrIds("see &#035;321 there"), /#321/);
   });
 
+  test("the HTML5 named entity for the hash character followed by a digit run is treated as a bare id", () => {
+    // &num; is a real HTML5 named entity for the hash code point; GitHub
+    // decodes it, so &num;123 renders as the #123 auto-link.
+    assert.deepEqual(extractIssuePrIds("see &num;123 there"), ["123"]);
+    assert.throws(() => guardCommentBodyNoIssuePrIds("see &num;123 there"), /#123/);
+    // Case-variants do not decode on GitHub, but the guard over-refuses them
+    // deliberately (fail-closed on a suspicious near-miss).
+    assert.deepEqual(extractIssuePrIds("see &NUM;456 there"), ["456"]);
+    // The named entity with no digit run after it stays inert.
+    assert.deepEqual(extractIssuePrIds("a literal hash: &num; alone"), []);
+    // A different named entity followed by digits does not match.
+    assert.deepEqual(extractIssuePrIds("&nbsp;123 stays"), []);
+    // An allowlisted id is still allowed through the named form.
+    assert.equal(
+      guardCommentBodyNoIssuePrIds("see &num;123 there", { allowedRefs: ["123"] }),
+      "see &num;123 there",
+    );
+  });
+
   test("a generated gate verdict body (the production render) contains no issue/PR id", () => {
     // Representative of renderGateReviewCommentBody output for a clean gate:
     // gate name, head SHA (hex), verdict, severity/angle labels — never a #digit.

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -170,17 +170,16 @@ function collapseWhitespace(value) {
 // reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
 // the entity-encoded form of `[`). Extraction mirrors the shared copy's
 // decode-aware behavior: the body is also scanned after a single
-// renderer-like entity decode (numeric references, the named hash and
-// ampersand entities — `&amp;` consumed so double-encoded forms stay inert;
-// named-entity case-variants decoded as deliberate over-refusal), so a hash
-// or digit smuggled as an entity still refuses.
+// renderer-like entity decode (numeric references at cmark-gfm's 8-digit
+// bound, plus the named hash entity; named case-variants decoded as
+// deliberate over-refusal), so a hash or digit smuggled as an entity still
+// refuses, while a double-encoded form's output is never re-read.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
-const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,7}|x[0-9a-f]{1,6})|num|amp);/giu;
+const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,8}|x[0-9a-f]{1,8})|num);/giu;
 function decodeRenderedText(body) {
   return body.replace(DECODABLE_ENTITY_RE, (entity) => {
     const inner = entity.slice(1, -1).toLowerCase();
     if (inner === "num") return "#";
-    if (inner === "amp") return "&";
     const code = inner[1] === "x" ? Number.parseInt(inner.slice(2), 16) : Number.parseInt(inner.slice(1), 10);
     try {
       return String.fromCodePoint(code);

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -171,10 +171,13 @@ function collapseWhitespace(value) {
 // the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own
 // entity exclusion so the two copies stay behaviorally identical.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
-// An entity decoding to the hash character (numeric forms, or the HTML5 named
-// entity form) followed by a digit run renders as a bare auto-link; treated
-// as a bare-id occurrence (mirrors the shared copy, including its deliberate
-// case-insensitive over-refusal of non-decoding variants of the named form).
+// An entity decoding to the hash character (`&#35;`/`&#x23;`, zero-padding
+// accepted, or the HTML5 named entity `&num;`) followed by a digit run
+// renders as a bare auto-link; treated as a bare-id occurrence. The `i` flag
+// mirrors the shared copy's deliberate over-refusal: it also matches
+// case-variants of the named form (e.g. `&NUM;`) even though only lowercase
+// `&num;` actually decodes, keeping this fallback fail-closed on that
+// suspicious near-miss.
 const ENCODED_HASH_ID_RE = /&(?:#(?:0*35|x0*23)|num);(\d{1,9})/giu;
 function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -168,12 +168,15 @@ function collapseWhitespace(value) {
 // strict, and a body needing a cross-reference can use the full helper.
 // A match is excluded only when it forms a well-formed HTML numeric character
 // reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
-// the entity-encoded form of `[`). Extraction mirrors the shared copy's
-// decode-aware behavior: the body is also scanned after a single
-// renderer-like entity decode (numeric references at cmark-gfm's 8-digit
-// bound, plus the named hash entity; named case-variants decoded as
-// deliberate over-refusal), so a hash or digit smuggled as an entity still
-// refuses, while a double-encoded form's output is never re-read.
+// the entity-encoded form of `[`), bounded at cmark-gfm's 8 digits (a longer
+// wrapped run is not decoded, renders literally, and must refuse). Extraction
+// mirrors the shared copy's decode-aware behavior: the body is also scanned
+// after a single renderer-like entity decode (numeric references at the same
+// 8-digit bound, plus the named hash entity; undecodable references become
+// the replacement character as on GitHub; named case-variants decoded as
+// deliberate over-refusal). The entity exclusion applies only to the raw
+// scan — in decoded text the renderer's one decode is spent, so an
+// ampersand-wrapped assembled id refuses rather than hides.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
 const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,8}|x[0-9a-f]{1,8})|num);/giu;
 function decodeRenderedText(body) {
@@ -184,25 +187,27 @@ function decodeRenderedText(body) {
     try {
       return String.fromCodePoint(code);
     } catch {
-      return entity;
+      return "�";
     }
   });
 }
 function isNumericCharacterReference(body, match) {
-  return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
+  return match[1].length <= 8
+    && body[match.index - 1] === "&"
+    && body[match.index + match[0].length] === ";";
 }
-function collectBareIds(text, found) {
+function collectBareIds(text, found, { excludeEntities }) {
   for (const m of text.matchAll(ISSUE_PR_ID_RE)) {
-    if (isNumericCharacterReference(text, m)) continue;
+    if (excludeEntities && isNumericCharacterReference(text, m)) continue;
     found.push(m[1]);
   }
 }
 function guardFallbackBodyNoIssuePrIds(body, ctx) {
   if (typeof body !== "string") return body;
   const found = [];
-  collectBareIds(String(body), found);
+  collectBareIds(String(body), found, { excludeEntities: true });
   const decoded = decodeRenderedText(String(body));
-  if (decoded !== String(body)) collectBareIds(decoded, found);
+  if (decoded !== String(body)) collectBareIds(decoded, found, { excludeEntities: false });
   if (found.length > 0) {
     const unique = [...new Set(found)].join(", #");
     throw new Error(

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -171,9 +171,11 @@ function collapseWhitespace(value) {
 // the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own
 // entity exclusion so the two copies stay behaviorally identical.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
-// An entity decoding to the hash character followed by a digit run renders as
-// a bare auto-link; treated as a bare-id occurrence (mirrors the shared copy).
-const ENCODED_HASH_ID_RE = /&#(?:0*35|x0*23);(\d{1,9})/giu;
+// An entity decoding to the hash character (numeric forms, or the HTML5 named
+// entity form) followed by a digit run renders as a bare auto-link; treated
+// as a bare-id occurrence (mirrors the shared copy, including its deliberate
+// case-insensitive over-refusal of non-decoding variants of the named form).
+const ENCODED_HASH_ID_RE = /&(?:#(?:0*35|x0*23)|num);(\d{1,9})/giu;
 function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
 }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.mjs
@@ -168,30 +168,42 @@ function collapseWhitespace(value) {
 // strict, and a body needing a cross-reference can use the full helper.
 // A match is excluded only when it forms a well-formed HTML numeric character
 // reference — preceded by `&` AND immediately followed by `;` (e.g. `&#91;`,
-// the entity-encoded form of `[`) — mirroring comment-id-guard.mjs's own
-// entity exclusion so the two copies stay behaviorally identical.
+// the entity-encoded form of `[`). Extraction mirrors the shared copy's
+// decode-aware behavior: the body is also scanned after a single
+// renderer-like entity decode (numeric references, the named hash and
+// ampersand entities — `&amp;` consumed so double-encoded forms stay inert;
+// named-entity case-variants decoded as deliberate over-refusal), so a hash
+// or digit smuggled as an entity still refuses.
 const ISSUE_PR_ID_RE = /#(\d{1,9})/gu;
-// An entity decoding to the hash character (`&#35;`/`&#x23;`, zero-padding
-// accepted, or the HTML5 named entity `&num;`) followed by a digit run
-// renders as a bare auto-link; treated as a bare-id occurrence. The `i` flag
-// mirrors the shared copy's deliberate over-refusal: it also matches
-// case-variants of the named form (e.g. `&NUM;`) even though only lowercase
-// `&num;` actually decodes, keeping this fallback fail-closed on that
-// suspicious near-miss.
-const ENCODED_HASH_ID_RE = /&(?:#(?:0*35|x0*23)|num);(\d{1,9})/giu;
+const DECODABLE_ENTITY_RE = /&(?:#(?:\d{1,7}|x[0-9a-f]{1,6})|num|amp);/giu;
+function decodeRenderedText(body) {
+  return body.replace(DECODABLE_ENTITY_RE, (entity) => {
+    const inner = entity.slice(1, -1).toLowerCase();
+    if (inner === "num") return "#";
+    if (inner === "amp") return "&";
+    const code = inner[1] === "x" ? Number.parseInt(inner.slice(2), 16) : Number.parseInt(inner.slice(1), 10);
+    try {
+      return String.fromCodePoint(code);
+    } catch {
+      return entity;
+    }
+  });
+}
 function isNumericCharacterReference(body, match) {
   return body[match.index - 1] === "&" && body[match.index + match[0].length] === ";";
+}
+function collectBareIds(text, found) {
+  for (const m of text.matchAll(ISSUE_PR_ID_RE)) {
+    if (isNumericCharacterReference(text, m)) continue;
+    found.push(m[1]);
+  }
 }
 function guardFallbackBodyNoIssuePrIds(body, ctx) {
   if (typeof body !== "string") return body;
   const found = [];
-  for (const m of String(body).matchAll(ISSUE_PR_ID_RE)) {
-    if (isNumericCharacterReference(body, m)) continue;
-    found.push(m[1]);
-  }
-  for (const m of String(body).matchAll(ENCODED_HASH_ID_RE)) {
-    found.push(m[1]);
-  }
+  collectBareIds(String(body), found);
+  const decoded = decodeRenderedText(String(body));
+  if (decoded !== String(body)) collectBareIds(decoded, found);
   if (found.length > 0) {
     const unique = [...new Set(found)].join(", #");
     throw new Error(

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -674,6 +674,20 @@ test("runCli's id guard does not mistake a well-formed HTML numeric character re
       /#456/,
     );
 
+    // Decode-aware digit-side parity with the shared copy: an id assembled
+    // from entity-encoded digits still refuses.
+    const stubEncodedDigit = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "see #&#49;23 there", "--next-action", "go",
+        ],
+        { env: stubEncodedDigit.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#123/,
+    );
+
     // Non-match parity with the shared copy: the named entity with no digit
     // run stays inert, and a different named entity followed by digits does
     // not match — both bodies must POST successfully.

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -618,6 +618,47 @@ test("runCli's id guard does not mistake a well-formed HTML numeric character re
       ),
       /#123/,
     );
+
+    // Semicolon with no leading `&` is not a well-formed entity: still refused.
+    const stubNoAmpersand = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "malformed #91; reference", "--next-action", "go",
+        ],
+        { env: stubNoAmpersand.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#91/,
+    );
+
+    // The entity exclusion is per-OCCURRENCE: the same digit run well-formed
+    // in one place and bare in another still refuses.
+    const stubPerOccurrence = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "&#91;ok&#93; but bare #91 too", "--next-action", "go",
+        ],
+        { env: stubPerOccurrence.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#91/,
+    );
+
+    // The HTML5 named entity for the hash character followed by digits decodes
+    // to a bare auto-link: refused (mirrors the shared guard copy).
+    const stubNamedEntity = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "see &num;123 there", "--next-action", "go",
+        ],
+        { env: stubNamedEntity.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#123/,
+    );
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -659,6 +659,46 @@ test("runCli's id guard does not mistake a well-formed HTML numeric character re
       ),
       /#123/,
     );
+
+    // Over-refusal parity with the shared copy: a non-decoding case-variant of
+    // the named form is refused deliberately (fail-closed near-miss).
+    const stubNamedCaseVariant = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "see &NUM;456 there", "--next-action", "go",
+        ],
+        { env: stubNamedCaseVariant.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#456/,
+    );
+
+    // Non-match parity with the shared copy: the named entity with no digit
+    // run stays inert, and a different named entity followed by digits does
+    // not match — both bodies must POST successfully.
+    for (const inertSummary of ["a literal hash: &num; alone", "&nbsp;123 stays"]) {
+      const stubInert = await writeGhStub(
+        tempDir,
+        [
+          {
+            assertArgIncludes: ["api", "repos/owner/repo/issues/17/comments"],
+            stdout: '{"id":301,"html_url":"https://github.com/owner/repo/pull/17#issuecomment-301"}\n',
+          },
+        ],
+        {},
+      );
+      const inertStdout = [];
+      const inertExit = await runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", inertSummary, "--next-action", "go",
+        ],
+        { env: stubInert.env, spawn: spawn, ghCommand: "gh", stdoutSink: inertStdout, stderrSink: [] },
+      );
+      assert.equal(inertExit, 0, inertSummary);
+      assert.equal(JSON.parse(inertStdout.join("")).ok, true, inertSummary);
+    }
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
+++ b/skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
@@ -674,6 +674,20 @@ test("runCli's id guard does not mistake a well-formed HTML numeric character re
       /#456/,
     );
 
+    // Decoded-scan exclusion parity with the shared copy: wrapping an encoded
+    // hash-digit assembly in ampersand-and-semicolon must refuse, not hide.
+    const stubWrappedAssembly = await writeGhStub(tempDir, [], {});
+    await assert.rejects(
+      () => runCli(
+        [
+          "--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000",
+          "--verdict", "clean", "--findings-summary", "x &&#35;123; y", "--next-action", "go",
+        ],
+        { env: stubWrappedAssembly.env, spawn: spawn, ghCommand: "gh", stdoutSink: [], stderrSink: [] },
+      ),
+      /#123/,
+    );
+
     // Decode-aware digit-side parity with the shared copy: an id assembled
     // from entity-encoded digits still refuses.
     const stubEncodedDigit = await writeGhStub(tempDir, [], {});


### PR DESCRIPTION
## Summary

The comment-id guard's extraction is now decode-aware on both sides of the token. The issue asked for a decision between extending the matcher to the named hash entity and narrowing the documented claim: extended, because the named entity is a real HTML5 entity GitHub decodes into a live auto-link. The pre-approval gate's renderer-security review then found the sibling gap on the digit side — an id assembled from entity-encoded digits (a literal or encoded hash followed by numeric character references for the digits) also renders as an auto-link — so extraction now also scans the body after a single renderer-like entity decode (numeric character references plus the named hash entity; the single non-rescanning replace means a double-encoded form's output is never re-read). The fallback suite also gains the boundary-parity pins the core suite already had.

## Scope and context

Four files, two matcher copies kept semantically identical. `packages/core/src/github/comment-id-guard.mjs`: extraction scans the body as written AND after a single left-to-right decode of the entity forms the renderer resolves (`decodeRenderedText` over numeric character references and the named hash entity; undecodable references become the replacement character as on GitHub; the replace never rescans its own output, so a double-encoded form is never re-read as a fresh entity opener). The well-formed-entity exclusion applies only to the raw scan and is bounded at cmark-gfm's 8 digits — in decoded text the renderer's one decode is spent, so an ampersand-wrapped assembled id refuses rather than hides, and a 9-digit wrapped run (which the renderer does not decode) refuses too. This replaces the hash-side-only encoded pattern with one mechanism covering encoded hash, encoded digits, and every mix; the numeric bounds match cmark-gfm's 8-digit entity parser so nothing GitHub decodes escapes the pass, and named-entity case-variants decode too, as deliberate fail-closed over-refusal. `skills/dev-loop/scripts/post-gate-verdict-fallback.mjs`: same decode-aware extraction in the zero-dep inline copy, mirror comments. `packages/core/test/comment-id-guard.test.mjs`: named-entity refusal pin (decode form, case-variant over-refusal, inert no-digit form, unrelated-entity non-match, allowlist passthrough), digit-side assembly pins (literal hash plus encoded digit, encoded hash plus mixed literal/encoded digits, named hash plus encoded digit, allowlist through the assembled form), a double-encoded pin documenting that the single-pass decode never manufactures a new refusal (the numeric double-encoded form stays refused by the pre-existing raw scan; the named form stays inert), ampersand-wrapped assembly refusal pins, and exclusion-bound pins (9-digit wrapped run refuses; an undecodable 8-digit reference stays inert as the replacement character). `skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs`: named-entity refusal plus the missing boundary-parity pins — semicolon-without-ampersand refused, per-occurrence exclusion (same digit run well-formed in one place and bare in another still refuses), named-form case-variant over-refusal, and inert non-match shapes (no-digit named form, unrelated named entity followed by digits, both posting successfully); well-formed exclusion and ampersand-without-semicolon were already pinned.

## Acceptance criteria

- [ ] The named-entity hash form is refused, with tests in both suites (the extend arm of the issue's decision, rationale recorded above).
- [ ] The fallback suite pins the same boundary shapes as the core suite: well-formed excluded; ampersand-no-semicolon refused; semicolon-no-ampersand refused; per-occurrence.
- [ ] Both matcher copies stay semantically identical (same pattern, mirror comments).

## Definition of done

- [ ] `node --test packages/core/test/comment-id-guard.test.mjs` green.
- [ ] `node --test skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs` green.
- [ ] `npm run verify` green (its legs include the asset-sync check; no standalone evidence claim beyond the recorded gate validation).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Named-entity form refused in both copies | core suite green (named-entity pin); fallback suite green (named-entity pin) | sanitizer and allowlist contract untouched |
| Fallback boundary parity | fallback suite green (all four boundary pins, named-form over-refusal, inert non-match, and digit-side assembly parity pins) | — |
| Matcher copies semantically identical | identical extraction code and patterns in both copies; each suite green on its own pins (the core suite pins more shapes than the fallback suite); npm run verify green | — |

## Non-goals

- No change to the sanitizer or the allowlist contract.
- No general HTML entity decoding: the decode pass covers exactly the forms that can assemble a rendered hash-digit auto-link (numeric character references at cmark-gfm's 8-digit bound, plus the named hash entity); arbitrary named entities stay untouched.

## Open questions

None.

## Validation

```sh
node --test packages/core/test/comment-id-guard.test.mjs
node --test skills/dev-loop/scripts/post-gate-verdict-fallback.test.mjs
npm run verify
```

Closes #1755
