### PR TITLE
fix(github): bounded-backoff verification for the withdraw wrapper; shared verification helper

### DIFF
--- a/scripts/github/request-copilot-review.mjs
+++ b/scripts/github/request-copilot-review.mjs
@@ -281,6 +281,13 @@ function isReviewNowObservablyInProgress(before, after) {
     || reviewCountIncreased
     || reviewPresence.present;
 }
+// Shared verification-read step: re-fetch review state and check presence in
+// one call, so the initial post-edit read and every in-loop retry read below
+// share one implementation instead of two copies that could drift.
+async function checkReviewObservablyInProgress(options, runtime, before) {
+  const after = await fetchCopilotReviewState(options, runtime);
+  return isReviewNowObservablyInProgress(before, after);
+}
 
 async function fetchCopilotReviewState(options, runtime) {
   const requestedReviewers = await fetchRequestedReviewers(options, runtime);
@@ -868,25 +875,22 @@ export async function performCopilotReviewRequest(
   // the window also throws, in which case that last error is what the caller
   // sees (not the generic empty-result message below, which is reserved for
   // the case where every read succeeds but the review never shows up).
-  let after = null;
   let reviewNowObservablyInProgress = false;
   let lastReadError = null;
   try {
-    after = await fetchCopilotReviewState(options, runtime);
-    reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
+    reviewNowObservablyInProgress = await checkReviewObservablyInProgress(options, runtime, before);
   } catch (error) {
     lastReadError = error;
   }
   for (let attempt = 0; !reviewNowObservablyInProgress && attempt < VERIFICATION_RETRY_DELAYS_MS.length; attempt += 1) {
     await delayImpl(VERIFICATION_RETRY_DELAYS_MS[attempt]);
     try {
-      after = await fetchCopilotReviewState(options, runtime);
+      reviewNowObservablyInProgress = await checkReviewObservablyInProgress(options, runtime, before);
       lastReadError = null;
     } catch (error) {
       lastReadError = error;
       continue;
     }
-    reviewNowObservablyInProgress = isReviewNowObservablyInProgress(before, after);
   }
   if (!reviewNowObservablyInProgress) {
     if (lastReadError) {

--- a/scripts/github/withdraw-copilot-review-request.mjs
+++ b/scripts/github/withdraw-copilot-review-request.mjs
@@ -47,6 +47,7 @@
 // re-requesting — reusing the existing `suppressed_post_convergence_docs_only`
 // status rather than inventing a parallel mechanism. Any further push
 // invalidates the marker (new head no longer matches).
+import { setTimeout as delay } from "node:timers/promises";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 // SUBMITTED_REVIEW_STATES is shared with the loop-state reader on purpose:
@@ -60,6 +61,15 @@ import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { classifyDeltaSinceLastReview, getLastCopilotReviewHeadSha } from "./request-copilot-review.mjs";
 import { writeSuppressionMarker } from "../loop/_post-convergence-review-suppression.mjs";
+
+// The requested-reviewers read that verifies a `gh pr edit --remove-reviewer`
+// request landed is eventually consistent, mirroring the identical race
+// request-copilot-review.mjs guards against on its own request path: an
+// immediate read can still see stale (still-requested) state even though the
+// removal already succeeded. Re-read on this fixed backoff before declaring
+// failure — bounded, not open-ended, so a genuine failure still fails closed
+// after ~30s total instead of hanging indefinitely.
+const VERIFICATION_RETRY_DELAYS_MS = [5000, 10000, 15000];
 
 const USAGE = `Usage: node scripts/github/withdraw-copilot-review-request.mjs --repo <owner/name> --pr <number> [--reason <text>]
 
@@ -94,6 +104,13 @@ Options:
   --reason <text>         Recorded in the output for the audit trail.
   --dry-run               Report what would happen; withdraw nothing.
   --help, -h              Show this help.
+
+Verification:
+  After removing the reviewer, the requested-reviewers read is retried on a
+  fixed backoff (~30s total) before declaring failure, because that read is
+  eventually consistent and can briefly still show the request as pending
+  right after a genuinely successful removal. The removal itself is issued
+  exactly once and never re-issued per probe.
 
 Output (stdout, JSON):
   { ok, withdrawn, status: "withdrawn"|"refused"|"not-requested"|"dry-run", reason,
@@ -232,7 +249,7 @@ async function collectState(args, { env, runChild }) {
   };
 }
 
-async function main(args, { env = process.env, runChild = defaultRunChild, checkpointDir } = {}) {
+async function main(args, { env = process.env, runChild = defaultRunChild, checkpointDir, delayImpl = delay } = {}) {
   const state = await collectState(args, { env, runChild });
 
   if (!state.copilotRequested) {
@@ -319,7 +336,37 @@ async function main(args, { env = process.env, runChild = defaultRunChild, check
   // unsticking a deadlock must never report a withdrawal it did not perform.
   // Only the request flag matters here — re-reading reviews and threads would
   // be two more API calls to answer a question neither can change.
-  if (await fetchCopilotRequested(args, { env, runChild })) {
+  //
+  // Bounded retry against the read-after-write race documented above: only the
+  // verification READ repeats here, never the `gh pr edit --remove-reviewer`
+  // itself. A transient throw from ANY verification read — the initial
+  // post-edit read included — consumes the next scheduled delay and re-probes
+  // instead of aborting immediately; the error only propagates if the final
+  // attempt in the window also throws, in which case that last error is what
+  // the caller sees (not the generic still-pending message below, which is
+  // reserved for the case where every read succeeds but the request never
+  // clears).
+  let stillRequested = true;
+  let lastReadError = null;
+  try {
+    stillRequested = await fetchCopilotRequested(args, { env, runChild });
+  } catch (error) {
+    lastReadError = error;
+  }
+  for (let attempt = 0; stillRequested && attempt < VERIFICATION_RETRY_DELAYS_MS.length; attempt += 1) {
+    await delayImpl(VERIFICATION_RETRY_DELAYS_MS[attempt]);
+    try {
+      stillRequested = await fetchCopilotRequested(args, { env, runChild });
+      lastReadError = null;
+    } catch (error) {
+      lastReadError = error;
+      continue;
+    }
+  }
+  if (stillRequested) {
+    if (lastReadError) {
+      throw lastReadError;
+    }
     throw new Error("Copilot review request is still pending after gh pr edit --remove-reviewer; nothing was withdrawn.");
   }
 

--- a/scripts/github/withdraw-copilot-review-request.mjs
+++ b/scripts/github/withdraw-copilot-review-request.mjs
@@ -63,7 +63,7 @@ import { classifyDeltaSinceLastReview, getLastCopilotReviewHeadSha } from "./req
 import { writeSuppressionMarker } from "../loop/_post-convergence-review-suppression.mjs";
 
 // The requested-reviewers read that verifies a `gh pr edit --remove-reviewer`
-// request landed is eventually consistent, mirroring the identical race
+// request landed is eventually consistent, mirroring the identical race that
 // request-copilot-review.mjs guards against on its own request path: an
 // immediate read can still see stale (still-requested) state even though the
 // removal already succeeded. Re-read on this fixed backoff before declaring

--- a/scripts/github/withdraw-copilot-review-request.mjs
+++ b/scripts/github/withdraw-copilot-review-request.mjs
@@ -341,11 +341,12 @@ async function main(args, { env = process.env, runChild = defaultRunChild, check
   // verification READ repeats here, never the `gh pr edit --remove-reviewer`
   // itself. A transient throw from ANY verification read — the initial
   // post-edit read included — consumes the next scheduled delay and re-probes
-  // instead of aborting immediately; the error only propagates if the final
-  // attempt in the window also throws, in which case that last error is what
-  // the caller sees (not the generic still-pending message below, which is
-  // reserved for the case where every read succeeds but the request never
-  // clears).
+  // instead of aborting immediately; the error only propagates if the FINAL
+  // read in the window also throws, in which case that last error is what
+  // the caller sees. The generic still-pending message below only requires
+  // that final read to succeed — earlier reads may have thrown and been
+  // recovered by a later successful (but still-pending) probe, which clears
+  // the recorded error.
   let stillRequested = true;
   let lastReadError = null;
   try {
@@ -360,7 +361,6 @@ async function main(args, { env = process.env, runChild = defaultRunChild, check
       lastReadError = null;
     } catch (error) {
       lastReadError = error;
-      continue;
     }
   }
   if (stillRequested) {

--- a/test/github/withdraw-copilot-review-request.test.mjs
+++ b/test/github/withdraw-copilot-review-request.test.mjs
@@ -320,6 +320,58 @@ describe("withdraw-copilot-review-request", () => {
       assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
     });
 
+    it("recovers when the INITIAL post-edit read throws and a later read succeeds", async () => {
+      // The initial post-edit read sits inside the retry window: a throw there
+      // consumes the first scheduled delay and re-probes instead of
+      // propagating, so a transient blip immediately after a successful
+      // removal self-heals. This also pins the fail-closed `stillRequested`
+      // initializer — an initial throw never touches `stillRequested`, so it
+      // must start `true` for the loop below to run at all.
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check
+        { throws: true, message: "rate limited (initial read)" }, // initial post-edit read: throws
+        { requested: false }, // attempt 0: recovers, removal confirmed
+      ]);
+      const result = await main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl });
+      assert.equal(result.status, "withdrawn");
+      assert.deepEqual(delayCalls, [5000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
+    });
+
+    it("fails closed with the byte-identical exhaustion message when a mid-window throw recovers into a still-pending read", async () => {
+      // Mixed window: a non-final attempt throws, later attempts succeed but
+      // stay pending. The recovery clears the recorded read error, so
+      // exhaustion yields the generic still-pending message, never the stale
+      // mid-window error.
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check
+        { requested: true }, // initial post-edit read: stale
+        { throws: true, message: "rate limited (attempt 1)" }, // attempt 0: throws mid-window
+        { requested: true }, // attempt 1: recovers but still pending
+        { requested: true }, // attempt 2: still pending
+      ]);
+      await assert.rejects(
+        () => main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl }),
+        (error) => {
+          assert.equal(
+            error.message,
+            "Copilot review request is still pending after gh pr edit --remove-reviewer; nothing was withdrawn.",
+          );
+          return true;
+        },
+      );
+      assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
+    });
+
     it("propagates the final attempt's raw read error when every bounded retry read throws", async () => {
       const delayCalls = [];
       const delayImpl = async (ms) => {

--- a/test/github/withdraw-copilot-review-request.test.mjs
+++ b/test/github/withdraw-copilot-review-request.test.mjs
@@ -207,11 +207,140 @@ describe("withdraw-copilot-review-request", () => {
       // A wrong reviewer identity exits 0 and removes nothing. Without the
       // post-verify re-read the operator would be told the deadlock is cleared
       // while the PR stays stuck — the one lie this tool must never tell.
+      // Stubbed delayImpl keeps this fast: the request stays pending on every
+      // attempt, so the helper exhausts the full bounded retry window.
       const gh = ghStub({ copilotRequested: true, reviews: SUBMITTED_COPILOT_REVIEW, threads: [], removeIsNoop: true });
       await assert.rejects(
-        () => main({ repo: "o/n", pr: 10 }, { env: {}, runChild: gh.runChild }),
+        () => main({ repo: "o/n", pr: 10 }, { env: {}, runChild: gh.runChild, delayImpl: async () => {} }),
         /still pending after/,
       );
+    });
+  });
+
+  // Race regressions on the post-verify read, mirroring
+  // test/github/request-copilot-review.test.mjs: the requested-reviewers read
+  // that confirms a `gh pr edit --remove-reviewer` landed is eventually
+  // consistent, so it is retried on the same bounded backoff the request path
+  // uses. A custom runChild scripts the exact requested_reviewers response
+  // sequence (the before-state check, then the initial post-edit read, then
+  // one entry per bounded retry) independent of the removal call itself, so
+  // each test pins the exact race it exercises.
+  describe("the post-verify read race (mirrors request-copilot-review.mjs)", () => {
+    function raceRunChild(requestedReviewersSequence) {
+      const calls = [];
+      let index = 0;
+      const runChild = async (_cmd, argv) => {
+        calls.push(argv);
+        if (argv.some((a) => typeof a === "string" && a.includes("requested_reviewers"))) {
+          const step = requestedReviewersSequence[index];
+          index += 1;
+          if (!step) throw new Error("raceRunChild: requested_reviewers read beyond scripted sequence");
+          if (step.throws) {
+            return { code: 1, stdout: "", stderr: step.message };
+          }
+          return {
+            code: 0,
+            stdout: JSON.stringify({ users: step.requested ? [{ login: "copilot-pull-request-reviewer[bot]" }] : [], teams: [] }),
+            stderr: "",
+          };
+        }
+        if (argv.includes("--remove-reviewer")) {
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        if (argv.includes("graphql")) {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+            stderr: "",
+          };
+        }
+        return { code: 0, stdout: JSON.stringify({ headRefOid: "currentsha", reviews: SUBMITTED_COPILOT_REVIEW }), stderr: "" };
+      };
+      return { calls, runChild };
+    }
+
+    it("verification succeeds on a later attempt after an empty-then-populated race", async () => {
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check: request is pending
+        { requested: true }, // initial post-edit read: still stale
+        { requested: false }, // retry read: the removal has now landed
+      ]);
+      const result = await main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl });
+      assert.equal(result.status, "withdrawn");
+      assert.deepEqual(delayCalls, [5000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
+    });
+
+    it("a throwing read consumes a delay and a later read succeeds", async () => {
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check
+        { requested: true }, // initial post-edit read: stale
+        { throws: true, message: "rate limited" }, // attempt 0: transient gh failure
+        { requested: false }, // attempt 1: recovers, removal confirmed
+      ]);
+      const result = await main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl });
+      assert.equal(result.status, "withdrawn");
+      assert.deepEqual(delayCalls, [5000, 10000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
+    });
+
+    it("fails closed with the byte-identical exhaustion message when every bounded retry stays pending", async () => {
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check
+        { requested: true }, // initial post-edit read
+        { requested: true }, // attempt 0
+        { requested: true }, // attempt 1
+        { requested: true }, // attempt 2
+      ]);
+      await assert.rejects(
+        () => main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl }),
+        (error) => {
+          // Exact match, not a substring: this is a claimed byte-identical
+          // contract with pre-retry-loop behavior, so any drift must fail.
+          assert.equal(
+            error.message,
+            "Copilot review request is still pending after gh pr edit --remove-reviewer; nothing was withdrawn.",
+          );
+          return true;
+        },
+      );
+      assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
+    });
+
+    it("propagates the final attempt's raw read error when every bounded retry read throws", async () => {
+      const delayCalls = [];
+      const delayImpl = async (ms) => {
+        delayCalls.push(ms);
+      };
+      const { calls, runChild } = raceRunChild([
+        { requested: true }, // before-state check
+        { requested: true }, // initial post-edit read: stale, not a throw
+        { throws: true, message: "rate limited (attempt 1)" },
+        { throws: true, message: "rate limited (attempt 2)" },
+        { throws: true, message: "rate limited (attempt 3, final)" },
+      ]);
+      await assert.rejects(
+        () => main({ repo: "o/n", pr: 10 }, { env: {}, runChild, delayImpl }),
+        (error) => {
+          assert.equal(error.message, "gh command failed: rate limited (attempt 3, final)");
+          return true;
+        },
+      );
+      assert.deepEqual(delayCalls, [5000, 10000, 15000]);
+      assert.equal(calls.filter((argv) => argv.includes("--remove-reviewer")).length, 1);
     });
   });
 

--- a/test/github/withdraw-copilot-review-request.test.mjs
+++ b/test/github/withdraw-copilot-review-request.test.mjs
@@ -259,7 +259,7 @@ describe("withdraw-copilot-review-request", () => {
       return { calls, runChild };
     }
 
-    it("verification succeeds on a later attempt after an empty-then-populated race", async () => {
+    it("verification succeeds on a later attempt after a stale-pending-then-cleared race", async () => {
       const delayCalls = [];
       const delayImpl = async (ms) => {
         delayCalls.push(ms);


### PR DESCRIPTION
## Summary

The withdraw wrapper now verifies with the same bounded-backoff pattern as the request wrapper, and the request wrapper's two verification read+presence sites share one helper. The withdraw path previously did a single unretried post-edit read of the eventually-consistent requested-reviewers state, so a genuinely successful removal could be reported as a failure when the read raced the write — the same class the request path was hardened against.

## Scope and context

Three files. `scripts/github/withdraw-copilot-review-request.mjs`: the single verification read becomes the bounded pattern (fixed delay list totaling ~30 seconds, one `gh pr edit --remove-reviewer` never re-issued, every read including the initial post-edit one inside the retry window, a throwing read consumes a delay slot, the raw read error propagates only when the final attempt throws, and the exhaustion message stays byte-identical); `delayImpl` seam defaulting to the timers-promises `setTimeout`, mirroring the request wrapper; usage text gains the matching Verification section. `scripts/github/request-copilot-review.mjs`: the pre-loop and in-loop read+presence pairs now share `checkReviewObservablyInProgress` — behavior byte-identical, existing suite untouched and green. `test/github/withdraw-copilot-review-request.test.mjs`: six race regression tests mirroring the request suite (verification succeeds on a later attempt after a stale-pending-then-cleared race, throwing read consumes a delay and recovers, byte-identical exhaustion message, final-attempt raw-error propagation, initial post-edit read throwing and recovering inside the retry window, mid-window throw recovering into a still-pending exhaustion that pins the cleared read error — each asserting the delay sequence); one pre-existing still-pending test injects a fast `delayImpl` since that path now retries. The two initial/mid-window pins were mutation-checked (reverting the initial-read try/catch or the read-error reset fails exactly the corresponding pin).

## Acceptance criteria

- [ ] The withdraw wrapper verifies with the same bounded backoff and failure semantics as the request wrapper.
- [ ] One shared read+presence helper serves both the initial and in-loop verification paths in the request wrapper; behavior byte-identical (existing suite green unchanged).
- [ ] Withdraw suite gains the race regression tests mirroring the request suite's.

## Definition of done

- [ ] `node --test test/github/request-copilot-review.test.mjs` green (60 tests, unchanged file).
- [ ] `node --test test/github/withdraw-copilot-review-request.test.mjs` green (34 tests, 6 new).
- [ ] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Withdraw backoff mirrors request semantics | withdraw suite green (6 race pins asserting delay sequence, exhaustion message, raw-error propagation, initial-read window, read-error reset) | withdraw payloads and unavailable short-circuit unchanged |
| Shared helper, byte-identical behavior | request suite green with the file unmodified | no request-wrapper behavior change |
| Race regression tests added | withdraw suite green; npm run verify green | — |

## Non-goals

- No change to withdraw payloads or the unavailable short-circuit semantics.
- No behavior change in the request wrapper (refactor only).

## Open questions

None.

## Validation

```sh
node --test test/github/request-copilot-review.test.mjs
node --test test/github/withdraw-copilot-review-request.test.mjs
npm run verify
```

Closes #1757
