### PR TITLE
fix(gate): unify caller-verdict validation across wrapper and bare-array paths

### DIFF
--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -445,7 +445,10 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // the fan-in actually computed for this head/gate — not whatever a caller
   // hand-passed to `--verdict`. Optional and additive: a bare-array input
   // (legacy `--findings-file`, hand-authored `--findings`) leaves it
-  // undefined and the ledger writes exactly as before. Validated in the
+  // undefined, so the ledger never gains an `overallVerdict` key — but the
+  // recorded `verdict` itself is still the canonical (normalized) caller
+  // verdict on this path, same as the wrapper path below, not a byte-identical
+  // echo of a non-canonical raw `--verdict` (e.g. " Clean "). Validated in the
   // wrapper branch below (not by the caller-verdict guard immediately
   // following this comment) so a malformed wrapper cannot silently record an
   // invalid verdict as the consolidator's truth (#1616).

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -441,31 +441,19 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   }
   // The consolidator's computed verdict (consolidate-fanin.mjs's
   // `overallVerdict`) threads through `--ledger-out`'s `{overallVerdict,
-  // findings}` wrapper into here, so the durable ledger records the verdict
-  // the fan-in actually computed for this head/gate — not whatever a caller
-  // hand-passed to `--verdict`. Optional and additive: a bare-array input
-  // (legacy `--findings-file`, hand-authored `--findings`) leaves it
-  // undefined, so the ledger never gains an `overallVerdict` key — but the
-  // recorded `verdict` itself is still the canonical (normalized) caller
-  // verdict on this path, same as the wrapper path below, not a byte-identical
-  // echo of a non-canonical raw `--verdict` (e.g. " Clean "). Validated in the
-  // wrapper branch below (not by the caller-verdict guard immediately
-  // following this comment) so a malformed wrapper cannot silently record an
-  // invalid verdict as the consolidator's truth (#1616).
+  // findings}` wrapper into here, recording the verdict fan-in actually
+  // computed rather than whatever a caller hand-passed to `--verdict`. A
+  // bare-array input (legacy `--findings-file`, hand-authored `--findings`)
+  // has no wrapper, so `overallVerdict` stays undefined and the ledger gains
+  // no `overallVerdict` key — but the persisted `verdict` below is still the
+  // canonical (normalized) caller verdict on both paths (#1616).
 
-  // Validate the caller's own --verdict domain (same message the CLI parse
-  // path throws for --verdict) BEFORE any wrapper comparison, so the guard
-  // covers BOTH input paths — a bare-array input (no wrapper) never persists a
-  // null/undefined/non-string/out-of-domain verdict un-normalized into the
-  // ledger, and a wrapper input still compares against an already-validated
-  // caller verdict rather than misattributing a domain failure as a
-  // contradiction. Normalizing here also makes the wrapper comparison below
-  // symmetric for every caller — a direct programmatic caller passes a
-  // non-canonical verdict by the same normalizeVerdict path the CLI parse
-  // normally canonicalizes it through, so a canonical-value wrapper never
-  // false-rejects a differently-cased/whitespaced but semantically equal
-  // caller verdict. typeof is checked before normalizeVerdict runs because
-  // normalizeVerdict coerces via String(), which would otherwise let a
+  // Validate the caller's own --verdict domain up front, before any wrapper
+  // comparison: a bare-array input never persists a null/undefined/
+  // non-string/out-of-domain verdict un-normalized, and a wrapper input
+  // compares against an already-normalized caller verdict so a domain failure
+  // is never misattributed as a contradiction. typeof is checked before
+  // normalizeVerdict, which coerces via String() and would otherwise let a
   // non-string (e.g. an array) silently pass as its stringified form.
   const callerVerdict = typeof options.verdict === "string" ? normalizeVerdict(options.verdict) : null;
   if (!callerVerdict) {
@@ -543,10 +531,10 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     loggedAt: new Date().toISOString(),
     findings,
   };
-  // The consolidator's computed verdict, threaded from `--ledger-out`'s
-  // wrapper. Optional and additive: when absent (a bare-array input or an
-  // older producer) the ledger writes byte-identically to before, so inline
-  // and fallback paths are unaffected (#1616 AC: absent ledger unchanged).
+  // `overallVerdict` is optional and additive: absent on a bare-array input
+  // (no wrapper) or an older producer, so the ledger gains no `overallVerdict`
+  // key — but `verdict` above is always the canonical, normalized caller
+  // value regardless (#1616).
   if (normalizedOverallVerdict !== undefined) {
     log.overallVerdict = normalizedOverallVerdict;
   }

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -445,9 +445,11 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // the fan-in actually computed for this head/gate — not whatever a caller
   // hand-passed to `--verdict`. Optional and additive: a bare-array input
   // (legacy `--findings-file`, hand-authored `--findings`) leaves it
-  // undefined and the ledger writes exactly as before. Validated here so a
-  // malformed wrapper cannot silently record an invalid verdict as the
-  // consolidator's truth (#1616).
+  // undefined and the ledger writes exactly as before. Validated in the
+  // wrapper branch below (not by the caller-verdict guard immediately
+  // following this comment) so a malformed wrapper cannot silently record an
+  // invalid verdict as the consolidator's truth (#1616).
+
   // Validate the caller's own --verdict domain (same message the CLI parse
   // path throws for --verdict) BEFORE any wrapper comparison, so the guard
   // covers BOTH input paths — a bare-array input (no wrapper) never persists a
@@ -466,12 +468,12 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   if (!callerVerdict) {
     throw parseError("--verdict must be clean, findings_present, or blocked");
   }
+  let normalizedOverallVerdict;
   // Persist the canonical (normalized) verdict, not the raw caller value, on
   // BOTH input paths, so the durable ledger never records a differently-cased/
   // whitespaced verdict. Kept in a local instead of mutating the
   // caller-provided options object, which programmatic callers may reuse
   // across calls.
-  let normalizedOverallVerdict;
   let persistedVerdict = callerVerdict;
   if (overallVerdict !== undefined) {
     // The wrapper's overallVerdict must itself be a string BEFORE

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -448,10 +448,38 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // undefined and the ledger writes exactly as before. Validated here so a
   // malformed wrapper cannot silently record an invalid verdict as the
   // consolidator's truth (#1616).
+  // Validate the caller's own --verdict domain (same message the CLI parse
+  // path throws for --verdict) BEFORE any wrapper comparison, so the guard
+  // covers BOTH input paths — a bare-array input (no wrapper) never persists a
+  // null/undefined/non-string/out-of-domain verdict un-normalized into the
+  // ledger, and a wrapper input still compares against an already-validated
+  // caller verdict rather than misattributing a domain failure as a
+  // contradiction. Normalizing here also makes the wrapper comparison below
+  // symmetric for every caller — a direct programmatic caller passes a
+  // non-canonical verdict by the same normalizeVerdict path the CLI parse
+  // normally canonicalizes it through, so a canonical-value wrapper never
+  // false-rejects a differently-cased/whitespaced but semantically equal
+  // caller verdict. typeof is checked before normalizeVerdict runs because
+  // normalizeVerdict coerces via String(), which would otherwise let a
+  // non-string (e.g. an array) silently pass as its stringified form.
+  const callerVerdict = typeof options.verdict === "string" ? normalizeVerdict(options.verdict) : null;
+  if (!callerVerdict) {
+    throw parseError("--verdict must be clean, findings_present, or blocked");
+  }
+  // Persist the canonical (normalized) verdict, not the raw caller value, on
+  // BOTH input paths, so the durable ledger never records a differently-cased/
+  // whitespaced verdict. Kept in a local instead of mutating the
+  // caller-provided options object, which programmatic callers may reuse
+  // across calls.
   let normalizedOverallVerdict;
-  let persistedVerdict = options.verdict;
+  let persistedVerdict = callerVerdict;
   if (overallVerdict !== undefined) {
-    const verdict = normalizeVerdict(overallVerdict);
+    // The wrapper's overallVerdict must itself be a string BEFORE
+    // normalization runs — normalizeVerdict coerces via String(), which would
+    // otherwise let an array-wrapped wrapper verdict (e.g. ["clean"], whose
+    // String() form is the bare string "clean") silently pass as a valid
+    // wrapper instead of being rejected as malformed.
+    const verdict = typeof overallVerdict === "string" ? normalizeVerdict(overallVerdict) : null;
     if (!verdict) {
       throw parseError(
         `--${options.findingsFile ? "findings-file" : "findings"} "${options.findingsFile ?? "<inline>"}" wrapper "overallVerdict" must be one of: clean, findings_present, or blocked (got: ${JSON.stringify(overallVerdict)})`,
@@ -461,32 +489,11 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     // Fail closed on a caller-passed --verdict that contradicts the
     // consolidator's computed verdict, mirroring the consumer-side refusal in
     // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES).
-    // Normalize options.verdict here so the comparison is symmetric for every
-    // caller — a direct programmatic caller passes a non-canonical verdict by
-    // the same normalizeVerdict path the CLI parse normally canonicalizes it
-    // through, so a canonical-value wrapper never false-rejects a
-    // differently-cased/whitespaced but semantically equal caller verdict.
-    // Validate options.verdict's own domain first (same message the CLI parse
-    // path throws for --verdict) so a null/undefined/non-string/out-of-domain
-    // value is reported as an invalid verdict, not misattributed as a
-    // contradiction with the wrapper. typeof is checked before normalizeVerdict
-    // runs because normalizeVerdict coerces via String(), which would otherwise
-    // let a non-string (e.g. an array) silently pass as its stringified form.
-    const callerVerdict = typeof options.verdict === "string" ? normalizeVerdict(options.verdict) : null;
-    if (!callerVerdict) {
-      throw parseError("--verdict must be clean, findings_present, or blocked");
-    }
     if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
         `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
       );
     }
-    // Persist the canonical (normalized) verdict, not the raw caller value, so
-    // the durable ledger never records a differently-cased/whitespaced verdict
-    // beside the canonical overallVerdict it was just checked against. Kept in
-    // a local instead of mutating the caller-provided options object, which
-    // programmatic callers may reuse across calls.
-    persistedVerdict = callerVerdict;
   }
   let provenance;
   if (options.provenance === undefined) {

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1542,6 +1542,43 @@ test("#1641: CLI path — a direct write-gate-findings-log.mjs with a contradict
   }
 });
 
+// The contradiction-refusal tests above all drive the wrapper through inline
+// --findings; this one drives the SAME refusal through --findings-file (a
+// wrapper-shaped file), since the guard lives in resolveFindings/resolveFindingsInput
+// shared plumbing both flags route through, not in either flag's own parsing.
+test("writeGateFindingsLog rejects a --verdict contradicting a --findings-file wrapper overallVerdict", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-file-conflict-"));
+  try {
+    const findingsFile = path.join(tmpDir, "findings.json");
+    await writeFile(findingsFile, JSON.stringify({ overallVerdict: "findings_present", findings: [] }), "utf8");
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 7,
+        gate: "draft_gate",
+        headSha: "a1".repeat(20),
+        verdict: "clean",
+        findingsFile,
+        tmpRoot: tmpDir,
+      }),
+      (err) => {
+        assert.match(err.message, /--verdict "clean"/);
+        assert.match(err.message, /"overallVerdict" "findings_present"/);
+        assert.match(err.message, /GATE-COMMENT-VERDICT-VALUES/);
+        return true;
+      },
+    );
+    // No ledger must be written on the rejection.
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "o/n", pr: 7, gate: "draft_gate", headSha: "a1".repeat(20), tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "a contradicting --findings-file pair must not write a ledger before failing",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("#1616: writeGateFindingsLog rejects a malformed wrapper overallVerdict", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-bad-"));
   try {
@@ -1553,6 +1590,60 @@ test("#1616: writeGateFindingsLog rejects a malformed wrapper overallVerdict", a
         headSha: "a1".repeat(20),
         verdict: "clean",
         findings: JSON.stringify({ overallVerdict: "bogus", findings: [] }),
+        tmpRoot: tmpDir,
+      }),
+      /"overallVerdict" must be one of: clean, findings_present, or blocked/,
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// The verdict domain guard previously lived only inside the wrapper branch —
+// a bare-array input (no overallVerdict) skipped it entirely and would have
+// persisted an invalid/non-string --verdict straight into the ledger.
+test("writeGateFindingsLog rejects an invalid --verdict on a bare-array input (no wrapper) as a domain error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-bare-invalid-verdict-"));
+  try {
+    for (const badVerdict of ["bogus", undefined, ["clean"]]) {
+      await assert.rejects(
+        () => writeGateFindingsLog({
+          repo: "o/n",
+          pr: 7,
+          gate: "draft_gate",
+          headSha: "a1".repeat(20),
+          verdict: badVerdict,
+          findings: "[]",
+          tmpRoot: tmpDir,
+        }),
+        /--verdict must be clean, findings_present, or blocked/,
+      );
+    }
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "o/n", pr: 7, gate: "draft_gate", headSha: "a1".repeat(20), tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "an invalid bare-array verdict must not write a ledger before failing",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// normalizeVerdict coerces via String(), so an array-wrapped wrapper verdict
+// like ["clean"] stringifies to the bare string "clean" — without a typeof
+// guard BEFORE normalization this would silently pass as a valid wrapper
+// instead of being rejected as malformed.
+test("writeGateFindingsLog rejects an array-wrapped wrapper overallVerdict instead of string-coercing it", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-array-"));
+  try {
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 7,
+        gate: "draft_gate",
+        headSha: "a1".repeat(20),
+        verdict: "clean",
+        findings: JSON.stringify({ overallVerdict: ["clean"], findings: [] }),
         tmpRoot: tmpDir,
       }),
       /"overallVerdict" must be one of: clean, findings_present, or blocked/,

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1544,8 +1544,11 @@ test("#1641: CLI path — a direct write-gate-findings-log.mjs with a contradict
 
 // The contradiction-refusal tests above all drive the wrapper through inline
 // --findings; this one drives the SAME refusal through --findings-file (a
-// wrapper-shaped file), since the guard lives in resolveFindings/resolveFindingsInput
-// shared plumbing both flags route through, not in either flag's own parsing.
+// wrapper-shaped file). The refusal itself (both the caller-verdict domain
+// check and the wrapper-contradiction check) lives in writeGateFindingsLog,
+// not in resolveFindingsInput — resolveFindingsInput's shared plumbing only
+// parses and unwraps the wrapper identically for both flags, which is why the
+// same refusal reaches the findings-file path too.
 test("writeGateFindingsLog rejects a --verdict contradicting a --findings-file wrapper overallVerdict", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-ov-file-conflict-"));
   try {
@@ -1624,6 +1627,58 @@ test("writeGateFindingsLog rejects an invalid --verdict on a bare-array input (n
       /ENOENT/,
       "an invalid bare-array verdict must not write a ledger before failing",
     );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// The bare-array path (no overallVerdict wrapper) is the one the canonical-
+// persistence acceptance criterion actually changed: before this change the
+// ledger persisted the raw --verdict string unchanged on this path. Pinning
+// canonicalization only through a wrapper-shaped payload (as the test above
+// does) leaves this half unasserted — a regression that dropped the hoisted
+// normalization while keeping the hoisted rejection would still pass every
+// other test in this suite.
+test("#1641: writeGateFindingsLog canonicalizes a non-canonical caller --verdict on a bare-array input (no wrapper)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-bare-noncanonical-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "o/n",
+      pr: 7,
+      gate: "draft_gate",
+      headSha: "a1".repeat(20),
+      verdict: " Clean ",
+      findings: "[]",
+      tmpRoot: tmpDir,
+    });
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(parsed.verdict, "clean", "a bare-array write must persist the canonical verdict, not the raw caller casing/whitespace");
+    assert.ok(!("overallVerdict" in parsed), "a bare-array input must not synthesize an overallVerdict");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// The no-mutation clause: writeGateFindingsLog persists the canonical verdict
+// into the ledger without mutating the caller-supplied options object, since
+// a programmatic caller may reuse one options object across calls. A snapshot
+// comparison catches an in-place mutant (e.g. options.verdict = callerVerdict)
+// that would otherwise pass every other test in this suite unnoticed.
+test("#1641: writeGateFindingsLog does not mutate the caller-supplied options object", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-no-mutate-"));
+  try {
+    const options = {
+      repo: "o/n",
+      pr: 7,
+      gate: "draft_gate",
+      headSha: "a1".repeat(20),
+      verdict: " Clean ",
+      findings: "[]",
+      tmpRoot: tmpDir,
+    };
+    const snapshot = structuredClone(options);
+    await writeGateFindingsLog(options);
+    assert.deepEqual(options, snapshot, "writeGateFindingsLog must not mutate the caller-supplied options object");
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1639,7 +1639,7 @@ test("writeGateFindingsLog rejects an invalid --verdict on a bare-array input (n
 // does) leaves this half unasserted — a regression that dropped the hoisted
 // normalization while keeping the hoisted rejection would still pass every
 // other test in this suite.
-test("#1641: writeGateFindingsLog canonicalizes a non-canonical caller --verdict on a bare-array input (no wrapper)", async () => {
+test("writeGateFindingsLog canonicalizes a non-canonical caller --verdict on a bare-array input (no wrapper)", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-bare-noncanonical-"));
   try {
     const result = await writeGateFindingsLog({
@@ -1664,7 +1664,7 @@ test("#1641: writeGateFindingsLog canonicalizes a non-canonical caller --verdict
 // a programmatic caller may reuse one options object across calls. A snapshot
 // comparison catches an in-place mutant (e.g. options.verdict = callerVerdict)
 // that would otherwise pass every other test in this suite unnoticed.
-test("#1641: writeGateFindingsLog does not mutate the caller-supplied options object", async () => {
+test("writeGateFindingsLog does not mutate the caller-supplied options object", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-no-mutate-"));
   try {
     const options = {


### PR DESCRIPTION
## Summary

`writeGateFindingsLog` now validates the caller's `--verdict` on every input path. The contradiction-refusal change had placed the domain guard inside the wrapper branch only, so the bare-array path still accepted and persisted an unvalidated verdict, and the wrapper's `overallVerdict` was normalized without a typeof precondition — an array-wrapped value string-coerced past the malformed-wrapper check (a `clean` wrapped in an array stringified to `clean`). The guard is hoisted above the branch, both paths persist the canonical value, and the caller's options object is never mutated.

## Scope and context

Two files. `scripts/github/write-gate-findings-log.mjs`: the typeof-string + `normalizeVerdict` domain guard runs unconditionally before any comparison or write; the wrapper `overallVerdict` gets a typeof guard before normalization so any non-string shape rejects as a malformed wrapper; `persistedVerdict` defaults to the canonical caller verdict on both paths with no options mutation. `test/github/write-gate-findings-log.test.mjs`: an end-to-end contradiction-refusal test through `--findings-file` with a wrapper-shaped file, a bare-array-path domain-error pin, an array-wrapped-wrapper-verdict rejection pin, a bare-array canonical-persistence pin (whitespaced mixed-case verdict, ledger content asserted for the canonical value and for no synthesized wrapper key; the implementing run mutation-checked the persistence path against the pre-change shape), and a no-options-mutation pin (snapshot deep-equal after a programmatic call). All refusal message strings and exit codes unchanged (the contradiction string stays pinned verbatim by the consistency contract suite; the malformed-wrapper string stays pinned by regex assertions in the unit suite). The diff also carries two comment-correction passes as their own commits: the leading bare-array comment block rewritten to state the canonicalized-verdict behavior, and the persisted-verdict rationale comment relocated to the declaration it describes, then condensed further after review.

## Acceptance criteria

- [x] The verdict domain guard runs for BOTH wrapper and bare-array inputs before any comparison or write.
- [x] The wrapper overallVerdict is typeof-guarded before normalization; a non-string wrapper verdict rejects as malformed wrapper, never string-coerced.
- [x] The persisted ledger verdict is the canonical value on both paths, without mutating the caller-supplied options object.
- [x] A test drives the contradiction refusal end-to-end via `--findings-file` with a wrapper-shaped file.
- [x] Existing refusal messages and exit codes are unchanged.

## Definition of done

- [x] `node --test test/github/write-gate-findings-log.test.mjs` green (86 tests).
- [x] `node --test test/contracts/gate-verdict-consistency-contract.test.mjs` green (5 tests).
- [x] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Guard on both paths, before comparison/write | findings-log suite green (bare-array domain-error pin; wrapper pins) | no verdict-default derivation in the producer |
| Non-string wrapper verdict rejects as malformed | findings-log suite green (array-wrapped rejection pin) | — |
| Canonical persisted value, no options mutation | findings-log suite green; consistency contract suite green | upsert-checkpoint-verdict untouched |
| Findings-file e2e contradiction test | findings-log suite green; npm run verify green | — |
| Messages and exit codes unchanged | consistency contract suite green (verbatim pins) | — |

## Non-goals

- No verdict-default derivation in the producer.
- No upsert-checkpoint-verdict changes.

## Open questions

None.

## Validation

```sh
node --test test/github/write-gate-findings-log.test.mjs
node --test test/contracts/gate-verdict-consistency-contract.test.mjs
npm run verify
```

Closes #1744
