### PR TITLE
fix(gate): pin the judge-verdict vs wrapper overallVerdict contradiction contract

### DIFF
--- a/.claude/skills/docs/gate-review-comment-contract.md
+++ b/.claude/skills/docs/gate-review-comment-contract.md
@@ -141,6 +141,14 @@ a matching explicit value, and refuses a contradiction citing this rule. No
 override flag — a round whose verdict genuinely differs from the computed one
 is a consolidator bug to fix, not an operator decision to override.
 
+`write-gate-findings-log.mjs`'s write-time contradiction refusal always
+compares `--verdict` against the wrapper's `overallVerdict` — the
+consolidator's computed round verdict — whether or not `--judge-verdict` was
+also supplied. The judge only enriches findings with `act`/`defer`/`reject`
+dispositions (see [Checkpoint Review Chain Contract](./gate-review-sub-loop-contract.md#phase-35--judge-relevance-disposition-1525));
+it never revises the round verdict, so a `--judge-verdict` run is held to the
+exact same contradiction check as a run without one.
+
 ## Disposition ledger
 
 Durable-ledger sequencing and content are owned by `GATE-EXEC-DISPOSITION-LEDGER`

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1321,7 +1321,12 @@ verdict is derived from it by default (passing no `--verdict` is valid).
 time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
 a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first
-place.
+place. This write-time comparison is always against the wrapper's
+`overallVerdict` — the consolidator's computed round verdict — whether or not
+`--judge-verdict` (below) is also supplied on the same call: the judge only
+enriches findings with `act`/`defer`/`reject` dispositions and never revises
+the round verdict, so its presence does not change what `--verdict` is
+checked against.
 `post-gate-findings.mjs` unwraps and ignores `overallVerdict`. A finding with severity
 `low` or `nit` (or a legacy spelling, normalized on read) and no
 `disposition` gets `deferred` derived automatically by both tools. A

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1323,7 +1323,7 @@ a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first
 place. This write-time comparison is always against the wrapper's
 `overallVerdict` — the consolidator's computed round verdict — whether or not
-`--judge-verdict` (below) is also supplied on the same call: the judge only
+`--judge-verdict` (above, Phase 3.5) is also supplied on the same call: the judge only
 enriches findings with `act`/`defer`/`reject` dispositions and never revises
 the round verdict, so its presence does not change what `--verdict` is
 checked against.

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -485,8 +485,12 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     // comparison runs unconditionally against the wrapper's overallVerdict —
     // whether or not --judge-verdict was supplied above. The judge only
     // enriches findings with act/defer/reject dispositions; it never revises
-    // the consolidator's round verdict, so a --judge-verdict run is held to
-    // the exact same contradiction check as a run without one (#1745).
+    // the consolidator's round verdict, so this comparison itself never
+    // changes based on the judge artifact's content (#1745). A --judge-verdict
+    // run can still surface a different, earlier error first: the judge
+    // artifact is read, parsed, and applied before this point runs, so an
+    // unreadable, malformed, or out-of-range-index judge artifact throws its
+    // own parse error ahead of this contradiction check, not instead of it.
     if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
         `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md) — the consolidator's computed round verdict, which judge dispositions from --judge-verdict never alter`,

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -481,10 +481,15 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     normalizedOverallVerdict = verdict;
     // Fail closed on a caller-passed --verdict that contradicts the
     // consolidator's computed verdict, mirroring the consumer-side refusal in
-    // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES).
+    // upsert-checkpoint-verdict.mjs (#1616, GATE-COMMENT-VERDICT-VALUES). This
+    // comparison runs unconditionally against the wrapper's overallVerdict —
+    // whether or not --judge-verdict was supplied above. The judge only
+    // enriches findings with act/defer/reject dispositions; it never revises
+    // the consolidator's round verdict, so a --judge-verdict run is held to
+    // the exact same contradiction check as a run without one (#1745).
     if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
-        `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md)`,
+        `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md) — the consolidator's computed round verdict, which judge dispositions from --judge-verdict never alter`,
       );
     }
   }

--- a/skills/docs/gate-review-comment-contract.md
+++ b/skills/docs/gate-review-comment-contract.md
@@ -141,6 +141,14 @@ a matching explicit value, and refuses a contradiction citing this rule. No
 override flag — a round whose verdict genuinely differs from the computed one
 is a consolidator bug to fix, not an operator decision to override.
 
+`write-gate-findings-log.mjs`'s write-time contradiction refusal always
+compares `--verdict` against the wrapper's `overallVerdict` — the
+consolidator's computed round verdict — whether or not `--judge-verdict` was
+also supplied. The judge only enriches findings with `act`/`defer`/`reject`
+dispositions (see [Checkpoint Review Chain Contract](./gate-review-sub-loop-contract.md#phase-35--judge-relevance-disposition-1525));
+it never revises the round verdict, so a `--judge-verdict` run is held to the
+exact same contradiction check as a run without one.
+
 ## Disposition ledger
 
 Durable-ledger sequencing and content are owned by `GATE-EXEC-DISPOSITION-LEDGER`

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1321,7 +1321,12 @@ verdict is derived from it by default (passing no `--verdict` is valid).
 time: when the `--findings`/`--findings-file` wrapper carries `overallVerdict`,
 a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first
-place.
+place. This write-time comparison is always against the wrapper's
+`overallVerdict` — the consolidator's computed round verdict — whether or not
+`--judge-verdict` (below) is also supplied on the same call: the judge only
+enriches findings with `act`/`defer`/`reject` dispositions and never revises
+the round verdict, so its presence does not change what `--verdict` is
+checked against.
 `post-gate-findings.mjs` unwraps and ignores `overallVerdict`. A finding with severity
 `low` or `nit` (or a legacy spelling, normalized on read) and no
 `disposition` gets `deferred` derived automatically by both tools. A

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1323,7 +1323,7 @@ a caller-passed `--verdict` that contradicts it is refused before any ledger
 is written, so a contradicting pair never reaches the durable log in the first
 place. This write-time comparison is always against the wrapper's
 `overallVerdict` — the consolidator's computed round verdict — whether or not
-`--judge-verdict` (below) is also supplied on the same call: the judge only
+`--judge-verdict` (above, Phase 3.5) is also supplied on the same call: the judge only
 enriches findings with `act`/`defer`/`reject` dispositions and never revises
 the round verdict, so its presence does not change what `--verdict` is
 checked against.

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1774,9 +1774,11 @@ test("writeGateFindingsLog enriches findings from --judge-verdict and records sc
 // call. The judge only enriches findings with act/defer/reject dispositions
 // (applyJudgeDispositions); it never revises the round verdict, so the
 // write-time contradiction refusal ALWAYS compares --verdict against the
-// wrapper's overallVerdict — regardless of what the judge artifact says (a
-// judge that flags every finding "reject" still leaves overallVerdict, and
-// this check, untouched).
+// wrapper's overallVerdict. Arm (b)'s judge artifact is adversarial: it
+// rejects the only finding, agreeing with the caller's contradicting "clean"
+// verdict rather than the wrapper's "findings_present" — a judge-consulting
+// implementation would accept "clean" here, so the refusal firing anyway
+// proves the comparison never falls back to the judge artifact's content.
 test("#1745: writeGateFindingsLog with wrapper overallVerdict + --judge-verdict: matching --verdict succeeds with enrichment, contradicting --verdict refuses against the wrapper regardless of the judge artifact", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-judge-verdict-conflict-"));
   try {
@@ -1813,18 +1815,31 @@ test("#1745: writeGateFindingsLog with wrapper overallVerdict + --judge-verdict:
     assert.equal(parsed.findings[0].judgeDisposition, "act");
 
     // (b) A contradicting --verdict refuses, naming the wrapper's
-    // overallVerdict as the consolidator's authoritative round verdict, even
-    // though the same judge artifact is attached (a judge verdict never
-    // overrides the round verdict).
+    // overallVerdict as the consolidator's authoritative round verdict. This
+    // arm's judge artifact is adversarial: it dispositions the only finding
+    // "reject" (out of scope), which agrees with the caller's contradicting
+    // "clean" verdict, not with the wrapper's "findings_present". A
+    // judge-consulting implementation would derive "no actionable findings"
+    // from that and accept "clean"; this pin proves the refusal still fires
+    // and still names the wrapper as its source regardless of the judge.
+    const headShaB = "d4".repeat(20);
+    const judgeVerdictPathB = path.join(tmpDir, "judge-verdict-adversarial.json");
+    await writeFile(judgeVerdictPathB, JSON.stringify({
+      headSha: headShaB,
+      scopeDrift: { verdict: "within_scope", rationale: "matches the briefed AC set", driftedAreas: [] },
+      dispositions: [
+        { index: 0, disposition: "reject", rationale: "out of scope against non-goal 3", criterion: "Non-goal 3" },
+      ],
+    }), "utf8");
     await assert.rejects(
       () => writeGateFindingsLog({
         repo: "o/n",
         pr: 22,
         gate: "draft_gate",
-        headSha: "d4".repeat(20),
+        headSha: headShaB,
         verdict: "clean",
         findings,
-        judgeVerdict: judgeVerdictPath,
+        judgeVerdict: judgeVerdictPathB,
         tmpRoot: tmpDir,
       }),
       (err) => {
@@ -1836,7 +1851,7 @@ test("#1745: writeGateFindingsLog with wrapper overallVerdict + --judge-verdict:
       },
     );
     await assert.rejects(
-      () => readFile(buildLogPath({ repo: "o/n", pr: 22, gate: "draft_gate", headSha: "d4".repeat(20), tmpRoot: tmpDir }), "utf8"),
+      () => readFile(buildLogPath({ repo: "o/n", pr: 22, gate: "draft_gate", headSha: headShaB, tmpRoot: tmpDir }), "utf8"),
       /ENOENT/,
       "a contradicting pair must not write a ledger before failing, even with --judge-verdict attached",
     );

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -1769,3 +1769,78 @@ test("writeGateFindingsLog enriches findings from --judge-verdict and records sc
     await rm(tmpDir, { recursive: true, force: true });
   }
 });
+
+// #1745: a wrapper carrying overallVerdict PLUS --judge-verdict on the same
+// call. The judge only enriches findings with act/defer/reject dispositions
+// (applyJudgeDispositions); it never revises the round verdict, so the
+// write-time contradiction refusal ALWAYS compares --verdict against the
+// wrapper's overallVerdict — regardless of what the judge artifact says (a
+// judge that flags every finding "reject" still leaves overallVerdict, and
+// this check, untouched).
+test("#1745: writeGateFindingsLog with wrapper overallVerdict + --judge-verdict: matching --verdict succeeds with enrichment, contradicting --verdict refuses against the wrapper regardless of the judge artifact", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-judge-verdict-conflict-"));
+  try {
+    const headSha = "c3".repeat(20);
+    const judgeVerdictPath = path.join(tmpDir, "judge-verdict.json");
+    await writeFile(judgeVerdictPath, JSON.stringify({
+      headSha,
+      scopeDrift: { verdict: "within_scope", rationale: "matches the briefed AC set", driftedAreas: [] },
+      dispositions: [
+        { index: 0, disposition: "act", rationale: "fixes the defect named in AC-1", criterion: "AC-1" },
+      ],
+    }), "utf8");
+    const findings = JSON.stringify({
+      overallVerdict: "findings_present",
+      findings: [
+        { severity: "must-fix", angle: "correctness", summary: "null deref", disposition: "accepted-for-fix" },
+      ],
+    });
+
+    // (a) A matching --verdict succeeds and judge enrichment is applied.
+    const result = await writeGateFindingsLog({
+      repo: "o/n",
+      pr: 21,
+      gate: "draft_gate",
+      headSha,
+      verdict: "findings_present",
+      findings,
+      judgeVerdict: judgeVerdictPath,
+      tmpRoot: tmpDir,
+    });
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(parsed.overallVerdict, "findings_present");
+    assert.equal(parsed.findings[0].judgeDisposition, "act");
+
+    // (b) A contradicting --verdict refuses, naming the wrapper's
+    // overallVerdict as the consolidator's authoritative round verdict, even
+    // though the same judge artifact is attached (a judge verdict never
+    // overrides the round verdict).
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 22,
+        gate: "draft_gate",
+        headSha: "d4".repeat(20),
+        verdict: "clean",
+        findings,
+        judgeVerdict: judgeVerdictPath,
+        tmpRoot: tmpDir,
+      }),
+      (err) => {
+        assert.match(err.message, /--verdict "clean"/);
+        assert.match(err.message, /"overallVerdict" "findings_present"/);
+        assert.match(err.message, /consolidator's computed round verdict/);
+        assert.match(err.message, /GATE-COMMENT-VERDICT-VALUES/);
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "o/n", pr: 22, gate: "draft_gate", headSha: "d4".repeat(20), tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "a contradicting pair must not write a ledger before failing, even with --judge-verdict attached",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Decides and pins the open contract question: when `--judge-verdict` is attached, which value must `--verdict` agree with? The consolidator's wrapper `overallVerdict` is the round verdict and stays authoritative — judge dispositions (act/defer/reject enrichment) never alter it, so the write-time contradiction refusal always compares against the wrapper's `overallVerdict`, judge artifact present or not. The refusal message now names that source explicitly ("the consolidator's computed round verdict"), the decision is documented in both gate contracts, and a test pins the combined wrapper-plus-judge shape.

## Scope and context

Four files (plus two vendored mirrors). `scripts/github/write-gate-findings-log.mjs`: the contradiction refusal message names the consolidator's computed round verdict as the comparison source; a comment states the comparison is unconditional regardless of `--judge-verdict`. `skills/docs/gate-review-comment-contract.md` and `skills/docs/gate-review-sub-loop-contract.md`: one clarification each recording that the write-time check always compares against the wrapper's overallVerdict; the sub-loop contract's clarification additionally records the write ordering (the judge-pass enriched ledger is written after the findings log, with a pointer to its Phase 3.5 section). Vendored `.claude` mirrors regenerated. `test/github/write-gate-findings-log.test.mjs`: a pin driving `writeGateFindingsLog` with a wrapper carrying `overallVerdict` plus `--judge-verdict` — a matching verdict succeeds with judge enrichment applied; a contradicting verdict refuses with the message naming the consolidator source even when the judge artifact's own dispositions agree with the caller's contradicting verdict instead of the wrapper's (the second arm's judge artifact rejects the only finding, matching the caller's clean rather than the wrapper's findings_present — a judge-consulting implementation would accept, and the mutation check confirmed the pin fails such a variant). The existing verbatim contradiction-string pin stays green (the new clause trails the citation so the pin's proximity window is preserved).

## Acceptance criteria

- [ ] The contract decision (which verdict source the write-time refusal compares against when `--judge-verdict` is present) is recorded in gate-review-comment-contract.md and gate-review-sub-loop-contract.md.
- [ ] A test covers writeGateFindingsLog with a wrapper carrying overallVerdict plus `--judge-verdict`, pinning the decided behavior.
- [ ] The refusal message names the verdict source it compared against.

## Definition of done

- [ ] `node --test test/github/write-gate-findings-log.test.mjs` green (87 tests).
- [ ] `npm run test:docs` and `npm run assets:check` green after the doc edits.
- [ ] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Decision recorded in both contracts | test:docs green; assets:check green (mirrors regenerated) | no judge-pass or consolidate-fanin behavior change |
| Wrapper + judge-verdict pin | findings-log suite green (both arms of the new pin) | — |
| Refusal names its comparison source | findings-log suite green; consistency contract suite green (existing verbatim pin preserved); npm run verify green (full-suite confirmation) | — |

## Non-goals

- No change to judge-pass or consolidate-fanin behavior; producer-side contract only.

## Open questions

None.

## Validation

```sh
node --test test/github/write-gate-findings-log.test.mjs
node --test test/contracts/gate-verdict-consistency-contract.test.mjs
npm run test:docs
npm run verify
```

Closes #1745
