### PR TITLE
refactor(gate): shared severity tally helpers; pin blocking-severity spellings

### DIFF
--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -231,7 +231,7 @@ const GateDynamicConfig = z.strictObject({
 // without updating this hand-listed trio (or a new legacy alias added
 // without a matching entry here) must fail that test rather than leaving
 // this enum silently stale.
-export const BLOCKING_SEVERITY_SPELLINGS = ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"];
+export const BLOCKING_SEVERITY_SPELLINGS = Object.freeze(["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]);
 const BLOCKING_SEVERITY_SPELLING_SET = new Set(BLOCKING_SEVERITY_SPELLINGS);
 
 // Render an offending config value for a refusal message without letting the

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -227,9 +227,10 @@ const GateDynamicConfig = z.strictObject({
 // Exported (not just module-internal) so the vocabulary contract test
 // (test/contracts/gate-severity-vocabulary-contract.test.mjs) can pin this
 // list against SEVERITY_ORDER + LEGACY_SEVERITY_ALIASES
-// (@dev-loops/core/loop/gate-fanin) — a severity added to SEVERITY_ORDER
-// without updating this canonical defect trio plus its legacy alias
-// spellings (or a new legacy alias added without a matching entry here)
+// (@dev-loops/core/loop/gate-fanin) — a DEFECT severity added to
+// SEVERITY_ORDER (one not also added to NON_DEFECT_SEVERITIES) without
+// updating this canonical defect trio plus its legacy alias spellings (or a
+// new defect-targeting legacy alias added without a matching entry here)
 // must fail that test rather than leaving this enum silently stale.
 export const BLOCKING_SEVERITY_SPELLINGS = Object.freeze(["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]);
 const BLOCKING_SEVERITY_SPELLING_SET = new Set(BLOCKING_SEVERITY_SPELLINGS);

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -224,7 +224,14 @@ const GateDynamicConfig = z.strictObject({
 // fail-closed guard exact-matches raw entries against the same list, so the
 // guard's accept set is byte-identical to the schema's (no trim/normalize
 // superset) and widening the enum can never leave the runtime guard behind.
-const BLOCKING_SEVERITY_SPELLINGS = ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"];
+// Exported (not just module-internal) so the vocabulary contract test
+// (test/contracts/gate-severity-vocabulary-contract.test.mjs) can pin this
+// list against SEVERITY_ORDER + LEGACY_SEVERITY_ALIASES
+// (@dev-loops/core/loop/gate-fanin) — a severity added to SEVERITY_ORDER
+// without updating this hand-listed trio (or a new legacy alias added
+// without a matching entry here) must fail that test rather than leaving
+// this enum silently stale.
+export const BLOCKING_SEVERITY_SPELLINGS = ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"];
 const BLOCKING_SEVERITY_SPELLING_SET = new Set(BLOCKING_SEVERITY_SPELLINGS);
 
 // Render an offending config value for a refusal message without letting the

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -228,9 +228,9 @@ const GateDynamicConfig = z.strictObject({
 // (test/contracts/gate-severity-vocabulary-contract.test.mjs) can pin this
 // list against SEVERITY_ORDER + LEGACY_SEVERITY_ALIASES
 // (@dev-loops/core/loop/gate-fanin) — a severity added to SEVERITY_ORDER
-// without updating this hand-listed trio (or a new legacy alias added
-// without a matching entry here) must fail that test rather than leaving
-// this enum silently stale.
+// without updating this canonical defect trio plus its legacy alias
+// spellings (or a new legacy alias added without a matching entry here)
+// must fail that test rather than leaving this enum silently stale.
 export const BLOCKING_SEVERITY_SPELLINGS = Object.freeze(["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]);
 const BLOCKING_SEVERITY_SPELLING_SET = new Set(BLOCKING_SEVERITY_SPELLINGS);
 

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -177,6 +177,16 @@ export function reviewerBudgetPreflight(dispatchGroups, availableReviewers, { co
 // it defers immediately, with no fixer cycle at all.
 export const SEVERITY_ORDER = ["high", "question", "medium", "low", "nit"];
 
+// The non-defect subset of SEVERITY_ORDER: a "question" is answered (never
+// fixed or deferred like a defect — see deriveDisposition), and a "nit"
+// always defers regardless of any gate's blockCleanOnFindingSeverities
+// config (see isDefaultDeferrableSeverity) — neither belongs in a
+// defect-only blocking vocabulary. Exported as the single source for that
+// partition so a consumer (e.g. config.mjs's BLOCKING_SEVERITY_SPELLINGS
+// vocabulary contract test) derives "defect severities" as
+// SEVERITY_ORDER minus this set, rather than re-hand-listing "question"/"nit".
+export const NON_DEFECT_SEVERITIES = new Set(["question", "nit"]);
+
 // Marker gate name → gates.<key> config key. Owned here so every caller of
 // resolveFanoutGroups maps the same way; passing the marker name verbatim
 // resolves no groups and silently downgrades pairing enforcement.
@@ -265,8 +275,11 @@ export function zeroSeverityCounts() {
  * (consolidateFanin validates every result's severity before this runs;
  * buildAngleMarker tallies consolidateFanin's own output), so this guard is a
  * defensive floor against future drift, not an escape hatch for accepting
- * unvalidated severities.
- * @param {Iterable<{severity: unknown}>} findings
+ * unvalidated severities. A nullish `findings` argument, and a nullish
+ * individual entry within it, both tally as zero rather than throwing — the
+ * same defensive-floor stance as the unknown-severity guard above, for a
+ * caller that has not yet validated its input shape.
+ * @param {Iterable<{severity: unknown}> | null | undefined} findings
  * @returns {Record<string, number>}
  */
 export function tallySeverities(findings) {

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -275,17 +275,18 @@ export function zeroSeverityCounts() {
  * (consolidateFanin validates every result's severity before this runs;
  * buildAngleMarker tallies consolidateFanin's own output), so this guard is a
  * defensive floor against future drift, not an escape hatch for accepting
- * unvalidated severities. A nullish `findings` argument, and a nullish
- * individual entry within it, both tally as zero rather than throwing — the
- * same defensive-floor stance as the unknown-severity guard above, for a
- * caller that has not yet validated its input shape.
- * @param {Iterable<{severity: unknown}> | null | undefined} findings
+ * unvalidated severities. `findings` and its entries are NOT nullish-tolerant:
+ * a nullish `findings` argument throws (not iterable), and a nullish
+ * individual entry throws reading `.severity` — no routed caller passes
+ * either shape, so a caller that does gets a loud failure instead of a
+ * silently wrong all-zero tally.
+ * @param {Iterable<{severity: unknown}>} findings
  * @returns {Record<string, number>}
  */
 export function tallySeverities(findings) {
   const counts = zeroSeverityCounts();
-  for (const f of findings ?? []) {
-    const severity = /** @type {string} */ (normalizeSeverity(f?.severity));
+  for (const f of findings) {
+    const severity = /** @type {string} */ (normalizeSeverity(f.severity));
     if (Object.hasOwn(counts, severity)) counts[severity] += 1;
   }
   return counts;

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -242,6 +242,43 @@ export function severityRank(severity) {
 }
 
 /**
+ * A zero-initialized severity→count map, one key per SEVERITY_ORDER entry, in
+ * SEVERITY_ORDER's order. The shared starting point every severity tally in
+ * this codebase (consolidateFanin's own `bySeverity`, consolidate-fanin.mjs's
+ * `buildAngleMarker`, reconcile-draft-gate.mjs's no-findings placeholder) used
+ * to hand-roll separately via `Object.fromEntries(SEVERITY_ORDER.map((s) =>
+ * [s, 0]))` — one copy here means a severity added to SEVERITY_ORDER is
+ * zero-initialized everywhere at once.
+ * @returns {Record<string, number>}
+ */
+export function zeroSeverityCounts() {
+  return Object.fromEntries(SEVERITY_ORDER.map((s) => [s, 0]));
+}
+
+/**
+ * Tally `findings` by (normalized) severity into a {@link zeroSeverityCounts}
+ * map. Each finding's severity is normalized through `normalizeSeverity`
+ * before counting, so a legacy spelling still lands on its canonical key. A
+ * finding whose normalized severity is not a recognized SEVERITY_ORDER member
+ * is silently excluded from the tally rather than inflating an unknown key —
+ * every routed call site here counts already-validated findings in practice
+ * (consolidateFanin validates every result's severity before this runs;
+ * buildAngleMarker tallies consolidateFanin's own output), so this guard is a
+ * defensive floor against future drift, not an escape hatch for accepting
+ * unvalidated severities.
+ * @param {Iterable<{severity: unknown}>} findings
+ * @returns {Record<string, number>}
+ */
+export function tallySeverities(findings) {
+  const counts = zeroSeverityCounts();
+  for (const f of findings ?? []) {
+    const severity = /** @type {string} */ (normalizeSeverity(f?.severity));
+    if (Object.hasOwn(counts, severity)) counts[severity] += 1;
+  }
+  return counts;
+}
+
+/**
  * Merge a severity→count map's legacy-spelled keys into their canonical keys
  * (summing counts) so both the CLI parser and direct programmatic callers of
  * the verdict poster share ONE merge rule. Values pass through unvalidated —
@@ -770,7 +807,6 @@ export function consolidateFanin({ angleResults, blockCleanOnFindingSeverities }
     if (err) malformed.push({ index, reason: err });
   });
 
-  const bySeverity = Object.fromEntries(SEVERITY_ORDER.map((s) => [s, 0]));
   /** @type {Array<{severity: string, angle: string, summary: string, file?: string, line?: number, recommendation?: string, disposition: string}>} */
   const findings = [];
   let blockingCount = 0;
@@ -782,7 +818,6 @@ export function consolidateFanin({ angleResults, blockCleanOnFindingSeverities }
         const severity = /** @type {string} */ (normalizeSeverity(f.severity));
         const isBlocking = blocking.has(severity);
         if (isBlocking) blockingCount += 1;
-        bySeverity[severity] += 1;
         const entry = {
           severity,
           angle,
@@ -810,6 +845,9 @@ export function consolidateFanin({ angleResults, blockCleanOnFindingSeverities }
     verdict = "clean";
   }
 
+  // `findings` already carries each entry's normalized severity, so tallying
+  // it directly (rather than incrementing a running map inside the loop
+  // above) reproduces the same counts via the one shared tally rule.
   return {
     verdict,
     findings,
@@ -817,7 +855,7 @@ export function consolidateFanin({ angleResults, blockCleanOnFindingSeverities }
       angles: results.length,
       findings: findings.length,
       blocking: blockingCount,
-      bySeverity,
+      bySeverity: tallySeverities(findings),
     },
     malformed,
   };

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -20,6 +20,9 @@ import {
   normalizeSeverity,
   applyJudgeDispositions,
   validateJudgeVerdict,
+  tallySeverities,
+  zeroSeverityCounts,
+  SEVERITY_ORDER,
 } from "../src/loop/gate-fanin.mjs";
 
 function cleanAngle(angle) {
@@ -64,6 +67,62 @@ describe("normalizeSeverity (trim, case-sensitive, before alias lookup)", () => 
 
   test("an unrecognized value still normalizes (trim only) so every caller sees the same rejected form", () => {
     assert.equal(normalizeSeverity(" Bogus "), "Bogus");
+  });
+});
+
+describe("zeroSeverityCounts", () => {
+  test("returns one zeroed key per SEVERITY_ORDER entry", () => {
+    assert.deepEqual(zeroSeverityCounts(), { high: 0, question: 0, medium: 0, low: 0, nit: 0 });
+  });
+
+  test("returns a fresh object on every call — mutating one call's result leaves the next call's result untouched", () => {
+    const first = zeroSeverityCounts();
+    first.high = 99;
+    const second = zeroSeverityCounts();
+    assert.equal(second.high, 0);
+    assert.notEqual(first, second);
+  });
+});
+
+describe("tallySeverities", () => {
+  test("an empty findings list tallies to the zero map", () => {
+    assert.deepEqual(tallySeverities([]), zeroSeverityCounts());
+  });
+
+  test("counts each finding under its already-canonical severity", () => {
+    const counts = tallySeverities([{ severity: "high" }, { severity: "high" }, { severity: "low" }]);
+    assert.deepEqual(counts, { high: 2, question: 0, medium: 0, low: 1, nit: 0 });
+  });
+
+  test("normalizes a legacy spelling onto its canonical bucket before counting", () => {
+    const counts = tallySeverities([
+      { severity: "must-fix" },
+      { severity: "worth-fixing-now" },
+      { severity: "nice-to-have" },
+      { severity: "defer" },
+    ]);
+    assert.deepEqual(counts, { high: 1, question: 0, medium: 1, low: 2, nit: 0 });
+  });
+
+  test("an unrecognized severity (after normalization) is excluded from the tally rather than inflating an unknown key", () => {
+    const counts = tallySeverities([{ severity: "bogus" }, { severity: "high" }]);
+    assert.deepEqual(counts, { high: 1, question: 0, medium: 0, low: 0, nit: 0 });
+    assert.deepEqual(Object.keys(counts).sort(), [...SEVERITY_ORDER].sort());
+  });
+
+  test("a nullish findings argument tallies to the zero map instead of throwing", () => {
+    assert.deepEqual(tallySeverities(undefined), zeroSeverityCounts());
+    assert.deepEqual(tallySeverities(null), zeroSeverityCounts());
+  });
+
+  test("a nullish individual finding is skipped instead of throwing", () => {
+    assert.deepEqual(tallySeverities([null, undefined, { severity: "nit" }]), {
+      high: 0,
+      question: 0,
+      medium: 0,
+      low: 0,
+      nit: 1,
+    });
   });
 });
 

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -110,19 +110,14 @@ describe("tallySeverities", () => {
     assert.deepEqual(Object.keys(counts).sort(), [...SEVERITY_ORDER].sort());
   });
 
-  test("a nullish findings argument tallies to the zero map instead of throwing", () => {
-    assert.deepEqual(tallySeverities(undefined), zeroSeverityCounts());
-    assert.deepEqual(tallySeverities(null), zeroSeverityCounts());
+  test("a nullish findings argument throws rather than tallying to a silent zero map", () => {
+    assert.throws(() => tallySeverities(undefined));
+    assert.throws(() => tallySeverities(null));
   });
 
-  test("a nullish individual finding is skipped instead of throwing", () => {
-    assert.deepEqual(tallySeverities([null, undefined, { severity: "nit" }]), {
-      high: 0,
-      question: 0,
-      medium: 0,
-      low: 0,
-      nit: 1,
-    });
+  test("a nullish individual finding throws rather than being silently skipped", () => {
+    assert.throws(() => tallySeverities([null, { severity: "nit" }]));
+    assert.throws(() => tallySeverities([undefined, { severity: "nit" }]));
   });
 });
 

--- a/scripts/github/reconcile-draft-gate.mjs
+++ b/scripts/github/reconcile-draft-gate.mjs
@@ -4,7 +4,7 @@ import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
-import { SEVERITY_ORDER } from "@dev-loops/core/loop/gate-fanin";
+import { zeroSeverityCounts } from "@dev-loops/core/loop/gate-fanin";
 import { detectCheckpointEvidence } from "./detect-checkpoint-evidence.mjs";
 import { upsertCheckpointVerdict } from "./upsert-checkpoint-verdict.mjs";
 // convertPrToDraft/markPrReady live in their own module (no dependency on this
@@ -253,7 +253,7 @@ export async function reconcileDraftGate(options, { env = process.env, ghCommand
       inlineReason: draftGateConfig.requireCi
         ? "reconcile-draft-gate: light-mode under-threshold PR, inline verdict (CI green)"
         : "reconcile-draft-gate: light-mode under-threshold PR, inline verdict (CI optional by config)",
-      findingsSeverityCounts: Object.fromEntries(SEVERITY_ORDER.map((s) => [s, 0])),
+      findingsSeverityCounts: zeroSeverityCounts(),
       findingsSummary: draftGateConfig.requireCi
         ? "Reconciled non-draft PR — draft gate auto-reconciled (CI green)."
         : "Reconciled non-draft PR — draft gate auto-reconciled (CI optional by config).",

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -362,7 +362,7 @@ function fitFindingsToRenderBudget(findingsJson) {
 function buildAngleMarker(a, verbose) {
   if (a.findings.length === 0) return a; // clean angle: nothing omitted
   // tallySeverities normalizes defensively, same as angleWorstSeverityRank's
-  // sibling normalization above: findingsJson is always consolidateFanin's
+  // sibling normalization below: findingsJson is always consolidateFanin's
   // own OUTPUT (already normalized) through every call site today, but this
   // function must not silently drop a differently-spelled severity from the
   // breakdown/representative selection (or, worse, leak a legacy spelling

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -62,7 +62,7 @@ import { isPostedCommentLimitError, normalizeStructuredFindings, renderStructure
 import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixes.mjs";
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
-import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, normalizeSeverity, severityRank, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
+import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, normalizeSeverity, severityRank, tallySeverities, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
 import { enforceCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { enforcePrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 
@@ -361,17 +361,13 @@ function fitFindingsToRenderBudget(findingsJson) {
 // always lossless or bare, never a mangled hybrid.
 function buildAngleMarker(a, verbose) {
   if (a.findings.length === 0) return a; // clean angle: nothing omitted
-  const bySeverity = Object.fromEntries(SEVERITY_ORDER.map((s) => [s, 0]));
-  // Normalized defensively, same as angleWorstSeverityRank's sibling
-  // normalization above: findingsJson is always consolidateFanin's own
-  // OUTPUT (already normalized) through every call site today, but this
+  // tallySeverities normalizes defensively, same as angleWorstSeverityRank's
+  // sibling normalization above: findingsJson is always consolidateFanin's
+  // own OUTPUT (already normalized) through every call site today, but this
   // function must not silently drop a differently-spelled severity from the
   // breakdown/representative selection (or, worse, leak a legacy spelling
   // into the posted marker text) if that upstream guarantee ever lapses.
-  for (const f of a.findings) {
-    const severity = normalizeSeverity(f.severity);
-    if (Object.hasOwn(bySeverity, severity)) bySeverity[severity] += 1;
-  }
+  const bySeverity = tallySeverities(a.findings);
   // Represent the angle by its own highest-severity dropped finding — same
   // severity+disposition pairing consolidateFanin already derived, so the
   // marker's "disposition" still matches every other findingsJson finding's

--- a/test/contracts/gate-severity-vocabulary-contract.test.mjs
+++ b/test/contracts/gate-severity-vocabulary-contract.test.mjs
@@ -1,14 +1,16 @@
-// #1592 doc-drift guard: the reviewer-facing severity vocabulary is owned by
-// SEVERITY_ORDER (@dev-loops/core/loop/gate-fanin). A partial future rename
-// (e.g. adding/renaming a severity in code without updating the reviewer
-// agent's own output schema or the sub-loop contract's classification list)
-// must fail CI, not silently drift the two apart.
+// Doc- and code-drift guard: the reviewer-facing severity vocabulary is
+// owned by SEVERITY_ORDER (@dev-loops/core/loop/gate-fanin). A partial
+// future rename (e.g. adding/renaming a severity in code without updating
+// the reviewer agent's own output schema, the sub-loop contract's
+// classification list, or config.mjs's blockCleanOnFindingSeverities enum
+// and resolveGateConfig's exact-match guard) must fail CI, not silently
+// drift the vocabulary's surfaces apart.
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { LEGACY_SEVERITY_ALIASES, SEVERITY_ORDER } from "@dev-loops/core/loop/gate-fanin";
+import { LEGACY_SEVERITY_ALIASES, NON_DEFECT_SEVERITIES, SEVERITY_ORDER } from "@dev-loops/core/loop/gate-fanin";
 import { BLOCKING_SEVERITY_SPELLINGS } from "@dev-loops/core/config";
 import { VALID_DISPOSITIONS } from "../../scripts/github/write-gate-findings-log.mjs";
 
@@ -45,23 +47,28 @@ test("skills/docs/gate-review-sub-loop-contract.md's classification list names e
   );
 });
 
-test("config.mjs's BLOCKING_SEVERITY_SPELLINGS matches SEVERITY_ORDER's defect severities + LEGACY_SEVERITY_ALIASES' keys (#1611)", () => {
+test("config.mjs's BLOCKING_SEVERITY_SPELLINGS matches SEVERITY_ORDER's defect severities + LEGACY_SEVERITY_ALIASES' keys", () => {
   // blockCleanOnFindingSeverities is a DEFECT-severity-only vocabulary
-  // ("question"/"nit" are non-defect categories that never block a clean
-  // verdict by severity — see the schema's own doc comment) plus every
-  // pre-rename legacy spelling those defect severities accept on read. This
-  // derives the expected list from the two single-source-of-truth exports
-  // (@dev-loops/core/loop/gate-fanin) instead of hand-copying it a third
-  // time, so a severity added to SEVERITY_ORDER (or a new legacy alias) that
-  // is not also added to BLOCKING_SEVERITY_SPELLINGS fails here rather than
-  // leaving the schema enum and resolveGateConfig's exact-match guard
-  // silently stale.
-  const defectSeverities = SEVERITY_ORDER.filter((s) => s !== "question" && s !== "nit");
-  const expected = [...defectSeverities, ...Object.keys(LEGACY_SEVERITY_ALIASES)];
+  // (NON_DEFECT_SEVERITIES are excluded — see the schema's own doc comment)
+  // plus every pre-rename legacy spelling whose CANONICAL target is a
+  // defect severity (an alias whose target is a non-defect severity must
+  // stay out of this defect-only enum). This derives the expected list from
+  // the single-source-of-truth exports (@dev-loops/core/loop/gate-fanin)
+  // instead of hand-copying the defect/non-defect partition a third time, so
+  // a defect severity added to SEVERITY_ORDER (or a new legacy alias
+  // resolving to one) that is not also added to BLOCKING_SEVERITY_SPELLINGS
+  // fails here rather than leaving the schema enum and resolveGateConfig's
+  // exact-match guard silently stale. A NON-defect severity added to
+  // SEVERITY_ORDER must NOT be added to BLOCKING_SEVERITY_SPELLINGS — this
+  // pin excludes it via NON_DEFECT_SEVERITIES rather than demanding it.
+  const defectSeverities = SEVERITY_ORDER.filter((s) => !NON_DEFECT_SEVERITIES.has(s));
+  const defectAliases = Object.keys(LEGACY_SEVERITY_ALIASES)
+    .filter((alias) => defectSeverities.includes(LEGACY_SEVERITY_ALIASES[alias]));
+  const expected = [...defectSeverities, ...defectAliases];
   assert.deepEqual(
     [...BLOCKING_SEVERITY_SPELLINGS].sort(),
     [...expected].sort(),
-    "config.mjs's BLOCKING_SEVERITY_SPELLINGS has drifted from SEVERITY_ORDER's defect severities + LEGACY_SEVERITY_ALIASES' keys",
+    "config.mjs's BLOCKING_SEVERITY_SPELLINGS has drifted from SEVERITY_ORDER's defect severities + their legacy aliases — widen BLOCKING_SEVERITY_SPELLINGS only for a new DEFECT severity or an alias resolving to one; a new NON-defect severity must stay excluded",
   );
 });
 

--- a/test/contracts/gate-severity-vocabulary-contract.test.mjs
+++ b/test/contracts/gate-severity-vocabulary-contract.test.mjs
@@ -8,7 +8,8 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { SEVERITY_ORDER } from "@dev-loops/core/loop/gate-fanin";
+import { LEGACY_SEVERITY_ALIASES, SEVERITY_ORDER } from "@dev-loops/core/loop/gate-fanin";
+import { BLOCKING_SEVERITY_SPELLINGS } from "@dev-loops/core/config";
 import { VALID_DISPOSITIONS } from "../../scripts/github/write-gate-findings-log.mjs";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
@@ -41,6 +42,26 @@ test("skills/docs/gate-review-sub-loop-contract.md's classification list names e
     missing,
     [],
     `skills/docs/gate-review-sub-loop-contract.md's classification bullet is missing SEVERITY_ORDER value(s): ${missing.join(", ")}`,
+  );
+});
+
+test("config.mjs's BLOCKING_SEVERITY_SPELLINGS matches SEVERITY_ORDER's defect severities + LEGACY_SEVERITY_ALIASES' keys (#1611)", () => {
+  // blockCleanOnFindingSeverities is a DEFECT-severity-only vocabulary
+  // ("question"/"nit" are non-defect categories that never block a clean
+  // verdict by severity — see the schema's own doc comment) plus every
+  // pre-rename legacy spelling those defect severities accept on read. This
+  // derives the expected list from the two single-source-of-truth exports
+  // (@dev-loops/core/loop/gate-fanin) instead of hand-copying it a third
+  // time, so a severity added to SEVERITY_ORDER (or a new legacy alias) that
+  // is not also added to BLOCKING_SEVERITY_SPELLINGS fails here rather than
+  // leaving the schema enum and resolveGateConfig's exact-match guard
+  // silently stale.
+  const defectSeverities = SEVERITY_ORDER.filter((s) => s !== "question" && s !== "nit");
+  const expected = [...defectSeverities, ...Object.keys(LEGACY_SEVERITY_ALIASES)];
+  assert.deepEqual(
+    [...BLOCKING_SEVERITY_SPELLINGS].sort(),
+    [...expected].sort(),
+    "config.mjs's BLOCKING_SEVERITY_SPELLINGS has drifted from SEVERITY_ORDER's defect severities + LEGACY_SEVERITY_ALIASES' keys",
   );
 });
 

--- a/test/contracts/gate-severity-vocabulary-contract.test.mjs
+++ b/test/contracts/gate-severity-vocabulary-contract.test.mjs
@@ -59,8 +59,11 @@ test("config.mjs's BLOCKING_SEVERITY_SPELLINGS matches SEVERITY_ORDER's defect s
   // resolving to one) that is not also added to BLOCKING_SEVERITY_SPELLINGS
   // fails here rather than leaving the schema enum and resolveGateConfig's
   // exact-match guard silently stale. A NON-defect severity added to
-  // SEVERITY_ORDER must NOT be added to BLOCKING_SEVERITY_SPELLINGS — this
-  // pin excludes it via NON_DEFECT_SEVERITIES rather than demanding it.
+  // SEVERITY_ORDER must ALSO be added to NON_DEFECT_SEVERITIES (the
+  // hand-listed Set in gate-fanin.mjs) — only then does this pin exclude it
+  // from BLOCKING_SEVERITY_SPELLINGS; until that second edit lands, the
+  // severity is still classified as a defect below and this pin demands its
+  // addition to BLOCKING_SEVERITY_SPELLINGS instead.
   const defectSeverities = SEVERITY_ORDER.filter((s) => !NON_DEFECT_SEVERITIES.has(s));
   const defectAliases = Object.keys(LEGACY_SEVERITY_ALIASES)
     .filter((alias) => defectSeverities.includes(LEGACY_SEVERITY_ALIASES[alias]));

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -2196,6 +2196,13 @@ test("a narrow angle keeps its real finding instead of a longer marker when a wi
     // "style" (the actual cause of the overflow) IS collapsed to a marker.
     const styleFinding = byAngle.get("style").findings[0];
     assert.match(styleFinding.summary, /^300 finding\(s\) omitted from this comment/);
+    // All 300 findings are "nice-to-have" (normalizes to "low") — the
+    // breakdown must count them there, in SEVERITY_ORDER, not leave a
+    // zeroed/mis-tallied parenthesized section.
+    assert.ok(
+      styleFinding.summary.includes("(high: 0, question: 0, medium: 0, low: 300, nit: 0)"),
+      `expected the severity breakdown to tally all 300 findings under "low", got: ${styleFinding.summary}`,
+    );
     assertRendersWithoutThrowing(result.findingsJson);
   });
 });
@@ -2321,6 +2328,12 @@ test("a fan-in with enough angles that not all can afford the verbose marker kee
       if (summary === `${FINDINGS_PER_ANGLE} omitted — in ledger`) {
         bareCount += 1;
       } else if (summary.startsWith(`${FINDINGS_PER_ANGLE} finding(s) omitted from this comment`) && summary.endsWith("— in the disposition ledger")) {
+        // Every finding here is "worth-fixing-now" (normalizes to "medium") —
+        // the parenthesized breakdown must tally all of them there.
+        assert.ok(
+          summary.includes(`(high: 0, question: 0, medium: ${FINDINGS_PER_ANGLE}, low: 0, nit: 0)`),
+          `expected the severity breakdown to tally all ${FINDINGS_PER_ANGLE} findings under "medium", got: ${summary}`,
+        );
         verboseCount += 1;
       } else {
         assert.fail(`marker summary is neither the whole verbose sentence nor the whole bare one (half-truncated?): ${summary}`);


### PR DESCRIPTION
## Summary

Dedupes the severity tally/zero-counts construction behind one helper pair and pins the `blockCleanOnFindingSeverities` spelling list against the severity vocabulary's single source. Both items were dry-angle findings deferred out of the vocabulary-rename PR.

## Scope and context

Seven files. `packages/core/src/loop/gate-fanin.mjs`: new `zeroSeverityCounts()` and `tallySeverities(findings)` beside `severityRank` (the tally keeps `buildAngleMarker`'s existing `Object.hasOwn` guard, a no-op safety net where severities are pre-validated; neither helper tolerates nullish input — nullish arguments throw naturally); `consolidateFanin`'s own zero-init + increment routed through the helper; `NON_DEFECT_SEVERITIES` exported as the single source for the defect/non-defect partition. `packages/core/test/gate-fanin.test.mjs`: direct unit pins for both helpers (empty list, mixed severities, legacy-spelling normalization, an unrecognized severity excluded, and nullish argument/entry each throwing rather than silently tallying to zero). `test/loop/consolidate-fanin.test.mjs`: two assertions that a posted marker's severity breakdown reflects the real per-severity counts. `scripts/loop/consolidate-fanin.mjs`: `buildAngleMarker`'s tally routed through `tallySeverities`. `scripts/github/reconcile-draft-gate.mjs`: the static all-zero placeholder becomes `zeroSeverityCounts()`. The issue named `upsert-checkpoint-verdict.mjs` as a fourth site, but on current main it has no from-scratch tally block — its one `SEVERITY_ORDER` use (`buildStructuredFindingsDigest`) sums an already-built counts object, and its blocking-severity presence check (`scanBlockingFindings`) is a Set built from the config-derived blocking list, never `SEVERITY_ORDER` (different contracts) — so it is deliberately not routed. `packages/core/src/config/config.mjs`: `BLOCKING_SEVERITY_SPELLINGS` exported for the pin. `test/contracts/gate-severity-vocabulary-contract.test.mjs`: a test derives the expected spellings from `SEVERITY_ORDER`'s defect severities plus the legacy alias map's keys that resolve to one of those defect severities (an alias resolving to a non-defect severity is excluded, not included wholesale) and asserts set-equality — adding a severity to `SEVERITY_ORDER` without updating the spelling list fails this pin (mutation-checked with a fake severity, which also trips the pre-existing review-agent doc-drift pin). The exported `BLOCKING_SEVERITY_SPELLINGS` is wrapped in `Object.freeze`.

## Acceptance criteria

- [x] One shared helper owns the severity tally / zero-counts construction; the fitting sites call it rather than re-implementing it (the poster's severity uses are different contracts, documented above, and stay).
- [x] `blockCleanOnFindingSeverities`' accepted values are contract-test-pinned against `SEVERITY_ORDER` and the legacy alias map.
- [x] A future severity added to `SEVERITY_ORDER` cannot leave either surface silently stale — a test fails (mutation-checked).
- [x] No behavior change: the same values are accepted and the same counts produced as today.

## Definition of done

- [x] Touched suites green: gate-fanin, consolidate-fanin, upsert-checkpoint-verdict, reconcile-draft-gate, gate-severity-vocabulary contract — all pass locally; the head-stamped `npm run verify` aggregate is the recorded whole-repo evidence.
- [x] `npm run schema:check` green (no schema change).
- [x] `npm run verify` green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Shared tally/zero-counts helper | gate-fanin, consolidate-fanin, reconcile-draft-gate suites green | severity vocabulary unchanged |
| Spelling list pinned against the vocabulary source | vocabulary contract suite green (set-equality pin) | ui-review lens severity domain untouched |
| Future severity cannot drift silently | mutation-checked pin; npm run verify green | — |
| No behavior change | all touched suites green unchanged; schema:check green | — |

## Non-goals

- Changing the severity vocabulary, the disposition model, or any accepted config value.
- Touching the ui-review lens severity domain, which is deliberately separate.

## Open questions

None.

## Validation

```sh
node --test packages/core/test/gate-fanin.test.mjs test/loop/consolidate-fanin.test.mjs test/github/upsert-checkpoint-verdict.test.mjs test/github/reconcile-draft-gate.test.mjs test/contracts/gate-severity-vocabulary-contract.test.mjs
npm run schema:check
npm run verify
```

Closes #1611
