### PR TITLE
fix(gate): route the exported renderer through validation; refuse silent file-ref loss

### DIFF
--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -175,7 +175,7 @@ export function reviewerBudgetPreflight(dispatchGroups, availableReviewers, { co
 // finding via the fix loop, a question via never being auto-deferred) — it
 // outranks "medium"/"low", which both eventually defer. "nit" trails last:
 // it defers immediately, with no fixer cycle at all.
-export const SEVERITY_ORDER = ["high", "question", "medium", "low", "nit"];
+export const SEVERITY_ORDER = Object.freeze(["high", "question", "medium", "low", "nit"]);
 
 // The non-defect subset of SEVERITY_ORDER: a "question" is answered (never
 // fixed or deferred like a defect — see deriveDisposition), and a "nit"
@@ -191,7 +191,12 @@ export const NON_DEFECT_SEVERITIES = new Set(["question", "nit"]);
 // resolveFanoutGroups maps the same way; passing the marker name verbatim
 // resolves no groups and silently downgrades pairing enforcement.
 export const GATE_CONFIG_KEY = Object.freeze({ draft_gate: "draft", pre_approval_gate: "preApproval" });
-export const VALID_SEVERITIES = new Set(SEVERITY_ORDER);
+// Object.freeze on a Set only locks its OWN properties, not the add/delete
+// methods that mutate its internal collection — freezing is still applied
+// here for consistency with SEVERITY_ORDER and this file's other frozen
+// exports (GATE_CONFIG_KEY, LEGACY_SEVERITY_ALIASES, etc.), and it does stop
+// a caller from attaching a stray own property to the Set object itself.
+export const VALID_SEVERITIES = Object.freeze(new Set(SEVERITY_ORDER));
 
 // Pre-rename spellings. Old ledgers, markers, and configs still carry them;
 // every read boundary normalizes through this map. Every SANCTIONED producer

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -185,7 +185,7 @@ export const SEVERITY_ORDER = Object.freeze(["high", "question", "medium", "low"
 // partition so a consumer (e.g. config.mjs's BLOCKING_SEVERITY_SPELLINGS
 // vocabulary contract test) derives "defect severities" as
 // SEVERITY_ORDER minus this set, rather than re-hand-listing "question"/"nit".
-export const NON_DEFECT_SEVERITIES = new Set(["question", "nit"]);
+export const NON_DEFECT_SEVERITIES = Object.freeze(new Set(["question", "nit"]));
 
 // Marker gate name → gates.<key> config key. Owned here so every caller of
 // resolveFanoutGroups maps the same way; passing the marker name verbatim

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -185,6 +185,11 @@ export const SEVERITY_ORDER = Object.freeze(["high", "question", "medium", "low"
 // partition so a consumer (e.g. config.mjs's BLOCKING_SEVERITY_SPELLINGS
 // vocabulary contract test) derives "defect severities" as
 // SEVERITY_ORDER minus this set, rather than re-hand-listing "question"/"nit".
+// Object.freeze on a Set only locks its OWN properties, not the add/delete
+// methods that mutate its internal collection — freezing is still applied
+// here for consistency with SEVERITY_ORDER and this file's other frozen
+// exports (GATE_CONFIG_KEY, LEGACY_SEVERITY_ALIASES, etc.), and it does stop
+// a caller from attaching a stray own property to the Set object itself.
 export const NON_DEFECT_SEVERITIES = Object.freeze(new Set(["question", "nit"]));
 
 // Marker gate name → gates.<key> config key. Owned here so every caller of

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -29,9 +29,13 @@ import {
 
 // SEVERITY_ORDER, VALID_SEVERITIES, and NON_DEFECT_SEVERITIES must be frozen
 // like this file's other exported vocabulary constants (GATE_CONFIG_KEY,
-// LEGACY_SEVERITY_ALIASES, FANIN_SYNTHETIC_ANGLES, JUDGE_DISPOSITIONS) —
-// nothing in the repo mutates them today, but an unfrozen shared array/set is
-// a footgun a later change could silently corrupt for every consumer.
+// LEGACY_SEVERITY_ALIASES, FANIN_SYNTHETIC_ANGLES, JUDGE_DISPOSITIONS) — an
+// unfrozen shared array is a footgun a later change could silently corrupt
+// for every consumer. Object.freeze on VALID_SEVERITIES/NON_DEFECT_SEVERITIES
+// (both Sets) only locks their own properties, not Set.prototype.add/delete,
+// so it doesn't block content mutation the way it blocks Array.prototype.push
+// on SEVERITY_ORDER below — it's applied for export consistency and to stop
+// a stray own-property assignment on the Set object itself.
 test("SEVERITY_ORDER, VALID_SEVERITIES, and NON_DEFECT_SEVERITIES are frozen, matching their frozen sibling exports", () => {
   assert.equal(Object.isFrozen(SEVERITY_ORDER), true, "SEVERITY_ORDER must be frozen");
   assert.equal(Object.isFrozen(VALID_SEVERITIES), true, "VALID_SEVERITIES must be frozen");

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -23,7 +23,19 @@ import {
   tallySeverities,
   zeroSeverityCounts,
   SEVERITY_ORDER,
+  VALID_SEVERITIES,
 } from "../src/loop/gate-fanin.mjs";
+
+// SEVERITY_ORDER and VALID_SEVERITIES must be frozen like this file's other
+// exported vocabulary constants (GATE_CONFIG_KEY, LEGACY_SEVERITY_ALIASES,
+// FANIN_SYNTHETIC_ANGLES, JUDGE_DISPOSITIONS) — nothing in the repo mutates
+// them today, but an unfrozen shared array/set is a footgun a later change
+// could silently corrupt for every consumer.
+test("SEVERITY_ORDER and VALID_SEVERITIES are frozen, matching their frozen sibling exports", () => {
+  assert.equal(Object.isFrozen(SEVERITY_ORDER), true, "SEVERITY_ORDER must be frozen");
+  assert.equal(Object.isFrozen(VALID_SEVERITIES), true, "VALID_SEVERITIES must be frozen");
+  assert.throws(() => { SEVERITY_ORDER.push("bogus"); }, TypeError);
+});
 
 function cleanAngle(angle) {
   return { angle, verdict: "clean", findings: [] };

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -24,17 +24,29 @@ import {
   zeroSeverityCounts,
   SEVERITY_ORDER,
   VALID_SEVERITIES,
+  NON_DEFECT_SEVERITIES,
 } from "../src/loop/gate-fanin.mjs";
 
-// SEVERITY_ORDER and VALID_SEVERITIES must be frozen like this file's other
-// exported vocabulary constants (GATE_CONFIG_KEY, LEGACY_SEVERITY_ALIASES,
-// FANIN_SYNTHETIC_ANGLES, JUDGE_DISPOSITIONS) — nothing in the repo mutates
-// them today, but an unfrozen shared array/set is a footgun a later change
-// could silently corrupt for every consumer.
-test("SEVERITY_ORDER and VALID_SEVERITIES are frozen, matching their frozen sibling exports", () => {
+// SEVERITY_ORDER, VALID_SEVERITIES, and NON_DEFECT_SEVERITIES must be frozen
+// like this file's other exported vocabulary constants (GATE_CONFIG_KEY,
+// LEGACY_SEVERITY_ALIASES, FANIN_SYNTHETIC_ANGLES, JUDGE_DISPOSITIONS) —
+// nothing in the repo mutates them today, but an unfrozen shared array/set is
+// a footgun a later change could silently corrupt for every consumer.
+test("SEVERITY_ORDER, VALID_SEVERITIES, and NON_DEFECT_SEVERITIES are frozen, matching their frozen sibling exports", () => {
   assert.equal(Object.isFrozen(SEVERITY_ORDER), true, "SEVERITY_ORDER must be frozen");
   assert.equal(Object.isFrozen(VALID_SEVERITIES), true, "VALID_SEVERITIES must be frozen");
-  assert.throws(() => { SEVERITY_ORDER.push("bogus"); }, TypeError);
+  assert.equal(Object.isFrozen(NON_DEFECT_SEVERITIES), true, "NON_DEFECT_SEVERITIES must be frozen");
+  try {
+    assert.throws(() => { SEVERITY_ORDER.push("bogus"); }, TypeError);
+  } finally {
+    // If the freeze above ever regresses, the push actually succeeds BEFORE
+    // assert.throws fails — clean up the pushed entry so that regression
+    // fails only THIS test, instead of leaving "bogus" in the shared
+    // module-level SEVERITY_ORDER where every later order-dependent test in
+    // this file (zeroSeverityCounts/tallySeverities below) would fail too.
+    const bogusIndex = SEVERITY_ORDER.indexOf("bogus");
+    if (bogusIndex !== -1) SEVERITY_ORDER.splice(bogusIndex, 1);
+  }
 });
 
 function cleanAngle(angle) {

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -321,7 +321,9 @@ export const GITHUB_COMMENT_MAX_CHARS = 65536;
 // goes through: a value newly added to what gets rendered can never bypass
 // validation by calling this export directly instead of the bounded one.
 export function renderFindingsCommentBody({ gate, headSha, findings, omittedCounts = [], maxChars = GITHUB_COMMENT_MAX_CHARS }) {
-  ({ gate, headSha } = validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }));
+  ({ gate, headSha } = validateAndSanitizeRenderInputs({
+    gate, headSha, findings, omittedCounts, maxChars, entryPoint: "renderFindingsCommentBody",
+  }));
   const marker = buildFindingsMarker({ gate });
   const lines = [
     marker,
@@ -452,19 +454,25 @@ function describeInvalidValue(value) {
 }
 
 // Validates and sanitizes every caller-supplied value that
-// renderFindingsCommentBody renders, in ONE place, called from
-// renderFindingsCommentBody itself — so it also covers renderBoundedFindingsCommentBody,
-// which composes it rather than duplicating a render path — and a value newly
-// added to what gets rendered can never bypass validation by omission — four
-// consecutive review rounds each added one more one-off guard here before
-// this consolidation. Returns the comment's identity-key fields ready to
-// render: gate NORMALIZED (trim + lowercase, constrained to KNOWN_GATES —
-// never sanitized, since it is a closed two-value vocabulary, not free
-// text) and headSha SANITIZED (see sanitizeInline above; it is not a closed
-// set); findings are validated only here, since their own free-text fields
-// (summary/angle/files/disposition) are sanitized later, at render time, by
-// renderFindingsCommentBody itself.
-function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) {
+// renderFindingsCommentBody renders (including omittedCounts, its own
+// caller-supplied parameter — see summarizeDroppedBySeverity above), in ONE
+// place — called from renderFindingsCommentBody itself, and again from
+// renderBoundedFindingsCommentBody before it composes renderFindingsCommentBody,
+// so its own later use of the SAME gate/headSha (the fail-closed throw
+// further down) sees the normalized/sanitized values, never the caller's raw
+// input — so a value newly added to what gets rendered can never bypass
+// validation by omission on EITHER render entry point — four consecutive
+// review rounds each added one more one-off guard here before this
+// consolidation. `entryPoint` names the export that actually ran this call
+// (never hand-copied per throw site), so a rejection is always attributed to
+// the function the caller actually invoked, not a hardcoded stand-in.
+// Returns the comment's identity-key fields ready to render: gate NORMALIZED
+// (trim + lowercase, constrained to KNOWN_GATES — never sanitized, since it
+// is a closed two-value vocabulary, not free text) and headSha SANITIZED
+// (see sanitizeInline above; it is not a closed set); findings are validated
+// only here, since their own free-text fields (summary/angle/files/disposition)
+// are sanitized later, at render time, by renderFindingsCommentBody itself.
+function validateAndSanitizeRenderInputs({ gate, headSha, findings, omittedCounts, maxChars, entryPoint }) {
   // gate is the comment's IDENTITY key (buildFindingsMarker): an unvalidated
   // undefined/blank value would render `gate=undefined` and thereafter match
   // (and keep updating) that bogus marker on every later run. headSha is
@@ -478,17 +486,17 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
   // no collision surface between them left to sanitize away, so gate never
   // needs sanitizeInline at render time the way headSha does.
   if (typeof gate !== "string") {
-    throw new Error(`renderBoundedFindingsCommentBody: gate must be a non-empty string, got ${describeInvalidValue(gate)}`);
+    throw new Error(`${entryPoint}: gate must be a non-empty string, got ${describeInvalidValue(gate)}`);
   }
   const normalizedGate = gate.trim().toLowerCase();
   if (!KNOWN_GATES.has(normalizedGate)) {
-    throw new Error(`renderBoundedFindingsCommentBody: gate must be one of: ${[...KNOWN_GATES].join(", ")}, got ${describeInvalidValue(gate)}`);
+    throw new Error(`${entryPoint}: gate must be one of: ${[...KNOWN_GATES].join(", ")}, got ${describeInvalidValue(gate)}`);
   }
   if (typeof headSha !== "string" || headSha.trim().length === 0) {
-    throw new Error(`renderBoundedFindingsCommentBody: headSha must be a non-empty string, got ${describeInvalidValue(headSha)}`);
+    throw new Error(`${entryPoint}: headSha must be a non-empty string, got ${describeInvalidValue(headSha)}`);
   }
   if (!Array.isArray(findings)) {
-    throw new Error(`renderBoundedFindingsCommentBody: findings must be an array, got ${describeInvalidValue(findings)}`);
+    throw new Error(`${entryPoint}: findings must be an array, got ${describeInvalidValue(findings)}`);
   }
   // for...of (never .forEach, which SKIPS array holes) so a sparse findings
   // array produces the same named, index-bearing error as any other bad
@@ -499,10 +507,10 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
   let i = 0;
   for (const finding of findings) {
     if (!finding || typeof finding !== "object" || Array.isArray(finding)) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}] must be an object, got ${describeInvalidValue(finding)}`);
+      throw new Error(`${entryPoint}: findings[${i}] must be an object, got ${describeInvalidValue(finding)}`);
     }
     if (!SEVERITY_ORDER.includes(normalizeSeverity(finding.severity))) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].severity must be one of: ${SEVERITY_ORDER.join(", ")}, got ${describeInvalidValue(finding.severity)}`);
+      throw new Error(`${entryPoint}: findings[${i}].severity must be one of: ${SEVERITY_ORDER.join(", ")}, got ${describeInvalidValue(finding.severity)}`);
     }
     // angle/summary are rendered directly into the comment (as a code span /
     // bare prose respectively); an unvalidated caller passing neither would
@@ -513,16 +521,16 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
     // the raw string would let it through and render an empty code span /
     // empty prose run.
     if (typeof finding.angle !== "string" || finding.angle.trim().length === 0) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].angle must be a non-empty string, got ${describeInvalidValue(finding.angle)}`);
+      throw new Error(`${entryPoint}: findings[${i}].angle must be a non-empty string, got ${describeInvalidValue(finding.angle)}`);
     }
     if (sanitizeCodeSpan(finding.angle).length === 0) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].angle sanitizes to an empty code span, got ${describeInvalidValue(finding.angle)}`);
+      throw new Error(`${entryPoint}: findings[${i}].angle sanitizes to an empty code span, got ${describeInvalidValue(finding.angle)}`);
     }
     if (typeof finding.summary !== "string" || finding.summary.trim().length === 0) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].summary must be a non-empty string, got ${describeInvalidValue(finding.summary)}`);
+      throw new Error(`${entryPoint}: findings[${i}].summary must be a non-empty string, got ${describeInvalidValue(finding.summary)}`);
     }
     if (sanitizeInline(finding.summary).length === 0) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].summary sanitizes to an empty string, got ${describeInvalidValue(finding.summary)}`);
+      throw new Error(`${entryPoint}: findings[${i}].summary sanitizes to an empty string, got ${describeInvalidValue(finding.summary)}`);
     }
     // disposition is rendered directly into the comment (bare prose, for any
     // truthy value, when present — see renderFindingsCommentBody's own `?:`
@@ -536,7 +544,7 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
       finding.disposition !== undefined && finding.disposition !== null && finding.disposition !== ""
       && (typeof finding.disposition !== "string" || finding.disposition.trim().length === 0)
     ) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].disposition must be a non-empty string when present, got ${describeInvalidValue(finding.disposition)}`);
+      throw new Error(`${entryPoint}: findings[${i}].disposition must be a non-empty string when present, got ${describeInvalidValue(finding.disposition)}`);
     }
     // The render uses the SANITIZED disposition (sanitizeInline), never the
     // raw one, so a non-blank string that sanitizes to nothing (e.g. a bare
@@ -546,14 +554,32 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
       typeof finding.disposition === "string" && finding.disposition.trim().length > 0
       && sanitizeInline(finding.disposition).length === 0
     ) {
-      throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].disposition sanitizes to an empty string, got ${describeInvalidValue(finding.disposition)}`);
+      throw new Error(`${entryPoint}: findings[${i}].disposition sanitizes to an empty string, got ${describeInvalidValue(finding.disposition)}`);
+    }
+    // judgeDisposition is rendered directly into the comment (bare prose, for
+    // any truthy value, when present — see renderFindingsCommentBody's own
+    // judgeSuffix truthiness check), the exact same failure mode as
+    // disposition just above: an unvalidated truthy non-string is
+    // String-coerced by sanitizeInline and posted as junk, and a
+    // whitespace-only string collapses to an empty italic run.
+    if (
+      finding.judgeDisposition !== undefined && finding.judgeDisposition !== null && finding.judgeDisposition !== ""
+      && (typeof finding.judgeDisposition !== "string" || finding.judgeDisposition.trim().length === 0)
+    ) {
+      throw new Error(`${entryPoint}: findings[${i}].judgeDisposition must be a non-empty string when present, got ${describeInvalidValue(finding.judgeDisposition)}`);
+    }
+    if (
+      typeof finding.judgeDisposition === "string" && finding.judgeDisposition.trim().length > 0
+      && sanitizeInline(finding.judgeDisposition).length === 0
+    ) {
+      throw new Error(`${entryPoint}: findings[${i}].judgeDisposition sanitizes to an empty string, got ${describeInvalidValue(finding.judgeDisposition)}`);
     }
     // files entries are rendered directly as code-span file refs (see
     // renderFindingsCommentBody); an unvalidated element would otherwise post
     // the literal string "undefined"/"null"/"[object Object]" into the comment.
     if (finding.files !== undefined) {
       if (!Array.isArray(finding.files)) {
-        throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files must be an array, got ${describeInvalidValue(finding.files)}`);
+        throw new Error(`${entryPoint}: findings[${i}].files must be an array, got ${describeInvalidValue(finding.files)}`);
       }
       // for...of (never .forEach, which SKIPS array holes) — same rationale
       // as the outer findings loop above: a sparse files array must produce
@@ -561,7 +587,7 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
       let j = 0;
       for (const file of finding.files) {
         if (typeof file !== "string" || file.trim().length === 0) {
-          throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files[${j}] must be a non-empty string, got ${describeInvalidValue(file)}`);
+          throw new Error(`${entryPoint}: findings[${i}].files[${j}] must be a non-empty string, got ${describeInvalidValue(file)}`);
         }
         // The render uses the SANITIZED file ref (sanitizeCodeSpan), never
         // the raw one, and silently DROPS a ref that sanitizes to empty
@@ -570,15 +596,40 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
         // rejected here, matching angle/summary/disposition above, rather
         // than vanishing from the rendered comment with no trace.
         if (sanitizeCodeSpan(file).length === 0) {
-          throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files[${j}] sanitizes to an empty code span, got ${describeInvalidValue(file)}`);
+          throw new Error(`${entryPoint}: findings[${i}].files[${j}] sanitizes to an empty code span, got ${describeInvalidValue(file)}`);
         }
         j += 1;
       }
     }
     i += 1;
   }
+  // omittedCounts is a caller-supplied parameter of renderFindingsCommentBody
+  // (built internally by summarizeDroppedBySeverity for the production
+  // bounded path, but any direct caller can pass its own), rendered straight
+  // into the omission note's breakdown (`${count} ${SEVERITY_LABELS[severity]}`)
+  // with NO SEVERITY_LABELS fallback — an unknown severity would render the
+  // literal text "undefined" there, and a non-array truthy value would reach
+  // the note's own `.reduce` as an unnamed TypeError. Both are exactly the
+  // bypass-by-omission class this seam exists to close, so they are rejected
+  // here, by name, before that render is ever reached.
+  if (!Array.isArray(omittedCounts)) {
+    throw new Error(`${entryPoint}: omittedCounts must be an array, got ${describeInvalidValue(omittedCounts)}`);
+  }
+  let m = 0;
+  for (const entry of omittedCounts) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${entryPoint}: omittedCounts[${m}] must be an object, got ${describeInvalidValue(entry)}`);
+    }
+    if (!SEVERITY_ORDER.includes(entry.severity)) {
+      throw new Error(`${entryPoint}: omittedCounts[${m}].severity must be one of: ${SEVERITY_ORDER.join(", ")}, got ${describeInvalidValue(entry.severity)}`);
+    }
+    if (!Number.isFinite(entry.count) || entry.count < 0) {
+      throw new Error(`${entryPoint}: omittedCounts[${m}].count must be a finite non-negative number, got ${describeInvalidValue(entry.count)}`);
+    }
+    m += 1;
+  }
   if (!Number.isInteger(maxChars) || maxChars <= 0) {
-    throw new Error(`renderBoundedFindingsCommentBody: maxChars must be a positive integer, got ${describeInvalidValue(maxChars)}`);
+    throw new Error(`${entryPoint}: maxChars must be a positive integer, got ${describeInvalidValue(maxChars)}`);
   }
   return { gate: normalizedGate, headSha: sanitizeInline(headSha) };
 }
@@ -599,10 +650,19 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
 // kept still cannot fit, so a round that truly cannot be posted is
 // never reported as a success.
 export function renderBoundedFindingsCommentBody({ gate, headSha, findings, maxChars = GITHUB_COMMENT_MAX_CHARS }) {
-  // renderFindingsCommentBody now runs validateAndSanitizeRenderInputs itself
-  // (see its own doc comment), so this first call both validates and
-  // normalizes gate/headSha; every later call in this function is idempotent
-  // against the same already-valid input.
+  // renderFindingsCommentBody runs validateAndSanitizeRenderInputs itself
+  // (see its own doc comment) on every call below, so that alone would be
+  // enough to keep the RENDERED body safe. But this function's OWN gate/headSha
+  // bindings must also be normalized/sanitized here, in this scope, before
+  // anything else reads them — the fail-closed throw further down interpolates
+  // them directly, and dropOrder/renderWithDropped below close over them too —
+  // so a caller-shaped (unnormalized/unsanitized) value never leaks into this
+  // function's own output. This call is idempotent against renderFindingsCommentBody's
+  // own re-validation below: gate/headSha are already normalized/sanitized by
+  // the time they reach it, so that second call can never reject them.
+  ({ gate, headSha } = validateAndSanitizeRenderInputs({
+    gate, headSha, findings, omittedCounts: [], maxChars, entryPoint: "renderBoundedFindingsCommentBody",
+  }));
   const body = renderFindingsCommentBody({ gate, headSha, findings, maxChars });
   if (body.length <= maxChars) {
     return { body, omittedCounts: [] };

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -315,7 +315,13 @@ export function sanitizeInline(value) {
 // number rather than a second hand-copied literal.
 export const GITHUB_COMMENT_MAX_CHARS = 65536;
 
+// This is the module's ONLY render entry point (renderBoundedFindingsCommentBody
+// below composes it rather than duplicating a render path), and it runs the
+// SAME validateAndSanitizeRenderInputs seam every caller — bounded or direct —
+// goes through: a value newly added to what gets rendered can never bypass
+// validation by calling this export directly instead of the bounded one.
 export function renderFindingsCommentBody({ gate, headSha, findings, omittedCounts = [], maxChars = GITHUB_COMMENT_MAX_CHARS }) {
+  ({ gate, headSha } = validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }));
   const marker = buildFindingsMarker({ gate });
   const lines = [
     marker,
@@ -446,7 +452,9 @@ function describeInvalidValue(value) {
 }
 
 // Validates and sanitizes every caller-supplied value that
-// renderBoundedFindingsCommentBody renders, in ONE place, so a value newly
+// renderFindingsCommentBody renders, in ONE place, called from
+// renderFindingsCommentBody itself — so it also covers renderBoundedFindingsCommentBody,
+// which composes it rather than duplicating a render path — and a value newly
 // added to what gets rendered can never bypass validation by omission — four
 // consecutive review rounds each added one more one-off guard here before
 // this consolidation. Returns the comment's identity-key fields ready to
@@ -547,11 +555,25 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
       if (!Array.isArray(finding.files)) {
         throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files must be an array, got ${describeInvalidValue(finding.files)}`);
       }
-      finding.files.forEach((file, j) => {
+      // for...of (never .forEach, which SKIPS array holes) — same rationale
+      // as the outer findings loop above: a sparse files array must produce
+      // the same named, index-bearing error as any other bad element.
+      let j = 0;
+      for (const file of finding.files) {
         if (typeof file !== "string" || file.trim().length === 0) {
           throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files[${j}] must be a non-empty string, got ${describeInvalidValue(file)}`);
         }
-      });
+        // The render uses the SANITIZED file ref (sanitizeCodeSpan), never
+        // the raw one, and silently DROPS a ref that sanitizes to empty
+        // (renderFindingsCommentBody's own files.filter) — so a raw ref that
+        // is non-blank but sanitizes to nothing (e.g. a bare "`") must be
+        // rejected here, matching angle/summary/disposition above, rather
+        // than vanishing from the rendered comment with no trace.
+        if (sanitizeCodeSpan(file).length === 0) {
+          throw new Error(`renderBoundedFindingsCommentBody: findings[${i}].files[${j}] sanitizes to an empty code span, got ${describeInvalidValue(file)}`);
+        }
+        j += 1;
+      }
     }
     i += 1;
   }
@@ -577,7 +599,10 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }) 
 // kept still cannot fit, so a round that truly cannot be posted is
 // never reported as a success.
 export function renderBoundedFindingsCommentBody({ gate, headSha, findings, maxChars = GITHUB_COMMENT_MAX_CHARS }) {
-  ({ gate, headSha } = validateAndSanitizeRenderInputs({ gate, headSha, findings, maxChars }));
+  // renderFindingsCommentBody now runs validateAndSanitizeRenderInputs itself
+  // (see its own doc comment), so this first call both validates and
+  // normalizes gate/headSha; every later call in this function is idempotent
+  // against the same already-valid input.
   const body = renderFindingsCommentBody({ gate, headSha, findings, maxChars });
   if (body.length <= maxChars) {
     return { body, omittedCounts: [] };

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -495,6 +495,14 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, omittedCount
   if (typeof headSha !== "string" || headSha.trim().length === 0) {
     throw new Error(`${entryPoint}: headSha must be a non-empty string, got ${describeInvalidValue(headSha)}`);
   }
+  // The render uses the SANITIZED headSha (sanitizeInline), never the raw
+  // one, so a non-blank string that sanitizes to nothing (e.g. a bare
+  // "```") must be rejected here too — matching angle/summary/disposition/
+  // judgeDisposition/files above — otherwise the identity line renders as
+  // the silently-empty "Reviewed head: " with the value gone.
+  if (sanitizeInline(headSha).length === 0) {
+    throw new Error(`${entryPoint}: headSha sanitizes to an empty string, got ${describeInvalidValue(headSha)}`);
+  }
   if (!Array.isArray(findings)) {
     throw new Error(`${entryPoint}: findings must be an array, got ${describeInvalidValue(findings)}`);
   }
@@ -623,8 +631,8 @@ function validateAndSanitizeRenderInputs({ gate, headSha, findings, omittedCount
     if (!SEVERITY_ORDER.includes(entry.severity)) {
       throw new Error(`${entryPoint}: omittedCounts[${m}].severity must be one of: ${SEVERITY_ORDER.join(", ")}, got ${describeInvalidValue(entry.severity)}`);
     }
-    if (!Number.isFinite(entry.count) || entry.count < 0) {
-      throw new Error(`${entryPoint}: omittedCounts[${m}].count must be a finite non-negative number, got ${describeInvalidValue(entry.count)}`);
+    if (!Number.isInteger(entry.count) || entry.count <= 0) {
+      throw new Error(`${entryPoint}: omittedCounts[${m}].count must be a positive integer, got ${describeInvalidValue(entry.count)}`);
     }
     m += 1;
   }

--- a/test/github/post-gate-findings.test.mjs
+++ b/test/github/post-gate-findings.test.mjs
@@ -805,8 +805,8 @@ test("renderFindingsCommentBody rejects an omittedCounts element that is not an 
   );
 });
 
-test("renderFindingsCommentBody rejects a non-finite or negative omittedCounts entry count", () => {
-  for (const badCount of [-1, NaN, Infinity, "3", null, undefined]) {
+test("renderFindingsCommentBody rejects a non-positive-integer omittedCounts entry count", () => {
+  for (const badCount of [0, -1, 2.5, NaN, Infinity, "3", null, undefined]) {
     assert.throws(
       () => renderFindingsCommentBody({
         gate: "draft_gate",
@@ -814,7 +814,7 @@ test("renderFindingsCommentBody rejects a non-finite or negative omittedCounts e
         findings: [],
         omittedCounts: [{ severity: "nit", count: badCount }],
       }),
-      /omittedCounts\[0\]\.count must be a finite non-negative number/,
+      /omittedCounts\[0\]\.count must be a positive integer/,
       `expected count ${String(badCount)} to be rejected`,
     );
   }
@@ -1567,6 +1567,25 @@ test("renderBoundedFindingsCommentBody rejects a missing/blank gate or headSha i
   assert.throws(
     () => renderBoundedFindingsCommentBody({ gate: "draft_gate", headSha: "  ", findings }),
     /headSha must be a non-empty string/,
+  );
+});
+
+test("renderBoundedFindingsCommentBody rejects a headSha that is non-empty raw but sanitizes to nothing, instead of rendering the bare line \"Reviewed head: \"", () => {
+  // "```" survives the raw non-empty check (trim().length > 0) but
+  // sanitizeInline strips every backtick, leaving "" — without this guard,
+  // the identity line would silently render as "Reviewed head: " with the
+  // value gone, and the throw (if any) would misattribute to
+  // renderFindingsCommentBody even when the caller invoked the bounded
+  // export, since the bounded export's own re-validation would have already
+  // passed the RAW value through unsanitized.
+  const findings = [{ severity: "high", angle: "scope", summary: "x" }];
+  assert.throws(
+    () => renderBoundedFindingsCommentBody({ gate: "draft_gate", headSha: "```", findings }),
+    /renderBoundedFindingsCommentBody: headSha sanitizes to an empty string, got "```"/,
+  );
+  assert.throws(
+    () => renderFindingsCommentBody({ gate: "draft_gate", headSha: "```", findings }),
+    /renderFindingsCommentBody: headSha sanitizes to an empty string, got "```"/,
   );
 });
 

--- a/test/github/post-gate-findings.test.mjs
+++ b/test/github/post-gate-findings.test.mjs
@@ -454,6 +454,23 @@ test("sanitizeCodeSpan leaves a bracketed path verbatim inside its code span; sa
   assert.ok(body.includes("Route param mismatch in app/&#91;id]/page.tsx"), "the same value in bare prose must still be neutralized");
 });
 
+// angle's own bracketed-path legibility pin (mirrors the files pin above):
+// angle is rendered inside its own code span via the same sanitizeCodeSpan,
+// so a bracketed path there must also survive verbatim, not get entity-encoded.
+test("angle bracketed-path legibility pin: sanitizeCodeSpan leaves a bracketed-path angle verbatim inside its own code span", () => {
+  const findings = parseFindings(JSON.stringify([
+    {
+      severity: "must-fix",
+      angle: "app/[id]/page.tsx",
+      summary: "Route param mismatch",
+    },
+  ]));
+  const body = renderFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings });
+  const angleLine = body.split("\n").find(line => line.startsWith("- `"));
+  assert.ok(angleLine, "expected a rendered list line for the finding");
+  assert.equal(angleLine, "- `app/[id]/page.tsx`: Route param mismatch");
+});
+
 // ---------------------------------------------------------------------------
 // Idempotent create / update via stubbed gh
 // ---------------------------------------------------------------------------
@@ -738,6 +755,22 @@ test("findings comment and verdict body are mutually unclaimable (#1514)", async
   // packages/core/test/copilot-helpers.test.mjs).
   const { isGateMachineArtifactBody } = await import("@dev-loops/core/github/copilot-helpers");
   assert.equal(isGateMachineArtifactBody(findingsBody), true);
+});
+
+// No exported render entry point may bypass validation: renderFindingsCommentBody
+// is itself exported and directly reachable (see the many direct calls
+// above), so it must run the SAME validateAndSanitizeRenderInputs guard as
+// renderBoundedFindingsCommentBody, not just when reached through that
+// wrapper — otherwise a direct caller could post `gate=undefined` markers.
+test("renderFindingsCommentBody (the direct export) rejects invalid input the same way renderBoundedFindingsCommentBody does, instead of rendering unguarded", () => {
+  assert.throws(
+    () => renderFindingsCommentBody({ gate: undefined, headSha: "abc1234", findings: [] }),
+    /gate must be a non-empty string, got undefined/,
+  );
+  assert.throws(
+    () => renderFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings: [{ severity: "high", summary: "no angle" }] }),
+    /findings\[0\]\.angle must be a non-empty string, got undefined/,
+  );
 });
 
 test("renderFindingsCommentBody states that only the latest round is shown (#AC2 stated replacement)", () => {
@@ -1333,6 +1366,23 @@ test("renderBoundedFindingsCommentBody reports a named error for a sparse (hole-
   );
 });
 
+test("renderBoundedFindingsCommentBody reports a named error for a sparse (hole-containing) files array, matching the outer findings loop's own hole-handling rule", () => {
+  const files = [];
+  files[1] = "src/a.mjs";
+  // files[0] is a genuine array HOLE, not `undefined` explicitly stored —
+  // .forEach would silently SKIP it, letting an unvalidated hole reach the
+  // render unchecked; for...of (like the outer findings loop) must visit it
+  // and report it by its own index.
+  assert.throws(
+    () => renderBoundedFindingsCommentBody({
+      gate: "draft_gate",
+      headSha: "abc1234",
+      findings: [{ severity: "high", angle: "scope", summary: "x", files }],
+    }),
+    /findings\[0\]\.files\[0\] must be a non-empty string, got undefined/,
+  );
+});
+
 test("renderBoundedFindingsCommentBody rejects a non-string/blank disposition instead of rendering a fabricated one (\"[object Object]\"/\"42\"/\"true\"/an empty italic run)", () => {
   for (const badDisposition of [{}, 42, true, [1, 2]]) {
     assert.throws(
@@ -1362,6 +1412,23 @@ test("renderBoundedFindingsCommentBody rejects a disposition that is non-empty r
       findings: [{ severity: "low", angle: "scope", summary: "x", disposition: "```" }],
     }),
     /findings\[0\]\.disposition sanitizes to an empty string/,
+  );
+});
+
+test("renderBoundedFindingsCommentBody rejects a files entry that is non-empty raw but sanitizes to nothing, instead of silently dropping the file reference", () => {
+  // "`" survives the raw non-empty check (trim().length > 0) but
+  // sanitizeCodeSpan strips every backtick, leaving "" — without this guard,
+  // renderFindingsCommentBody's own files.filter(f => f.length > 0) would
+  // silently drop the reference from the rendered comment with no trace that
+  // a file was ever lost, rather than refusing to render at all (matching
+  // the angle/summary/disposition sanitize-to-empty guards above).
+  assert.throws(
+    () => renderBoundedFindingsCommentBody({
+      gate: "draft_gate",
+      headSha: "abc1234",
+      findings: [{ severity: "low", angle: "scope", summary: "x", files: ["`"] }],
+    }),
+    /findings\[0\]\.files\[0\] sanitizes to an empty code span/,
   );
 });
 

--- a/test/github/post-gate-findings.test.mjs
+++ b/test/github/post-gate-findings.test.mjs
@@ -773,6 +773,99 @@ test("renderFindingsCommentBody (the direct export) rejects invalid input the sa
   );
 });
 
+// omittedCounts is a parameter of the guarded export itself (built internally
+// by renderBoundedFindingsCommentBody, but any direct caller of
+// renderFindingsCommentBody can pass its own) — it is rendered into the
+// omission note but was never validated, so an unknown severity used to
+// render the literal text "undefined" and a non-array value crashed with an
+// unnamed TypeError. Both must now be refused by name instead.
+test("renderFindingsCommentBody rejects an omittedCounts entry with an unknown severity instead of rendering the literal text \"undefined\"", () => {
+  assert.throws(
+    () => renderFindingsCommentBody({
+      gate: "draft_gate",
+      headSha: "abc1234",
+      findings: [],
+      omittedCounts: [{ severity: "catastrophic", count: 3 }],
+    }),
+    /omittedCounts\[0\]\.severity must be one of.*got "catastrophic"/,
+  );
+});
+
+test("renderFindingsCommentBody rejects a non-array omittedCounts instead of crashing with an unnamed TypeError", () => {
+  assert.throws(
+    () => renderFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings: [], omittedCounts: "bogus" }),
+    /omittedCounts must be an array, got "bogus"/,
+  );
+});
+
+test("renderFindingsCommentBody rejects an omittedCounts element that is not an object", () => {
+  assert.throws(
+    () => renderFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings: [], omittedCounts: [null] }),
+    /omittedCounts\[0\] must be an object, got null/,
+  );
+});
+
+test("renderFindingsCommentBody rejects a non-finite or negative omittedCounts entry count", () => {
+  for (const badCount of [-1, NaN, Infinity, "3", null, undefined]) {
+    assert.throws(
+      () => renderFindingsCommentBody({
+        gate: "draft_gate",
+        headSha: "abc1234",
+        findings: [],
+        omittedCounts: [{ severity: "nit", count: badCount }],
+      }),
+      /omittedCounts\[0\]\.count must be a finite non-negative number/,
+      `expected count ${String(badCount)} to be rejected`,
+    );
+  }
+});
+
+// judgeDisposition is a per-finding field rendered the same way disposition
+// is (bare prose, for any truthy value) but was never validated — the exact
+// bypass-by-omission class the sibling disposition guards above exist to
+// prevent.
+test("renderFindingsCommentBody rejects a non-string/blank judgeDisposition instead of rendering fabricated junk", () => {
+  for (const bad of [{}, 42, true, [1, 2]]) {
+    assert.throws(
+      () => renderFindingsCommentBody({
+        gate: "draft_gate",
+        headSha: "abc1234",
+        findings: [{ severity: "low", angle: "scope", summary: "x", judgeDisposition: bad }],
+      }),
+      /findings\[0\]\.judgeDisposition must be a non-empty string when present/,
+    );
+  }
+  assert.throws(
+    () => renderFindingsCommentBody({
+      gate: "draft_gate",
+      headSha: "abc1234",
+      findings: [{ severity: "low", angle: "scope", summary: "x", judgeDisposition: "   " }],
+    }),
+    /findings\[0\]\.judgeDisposition must be a non-empty string when present/,
+  );
+});
+
+test("renderFindingsCommentBody rejects a judgeDisposition that is non-empty raw but sanitizes to nothing, instead of rendering the empty italic run \" — judge: __\"", () => {
+  assert.throws(
+    () => renderFindingsCommentBody({
+      gate: "draft_gate",
+      headSha: "abc1234",
+      findings: [{ severity: "low", angle: "scope", summary: "x", judgeDisposition: "```" }],
+    }),
+    /findings\[0\]\.judgeDisposition sanitizes to an empty string/,
+  );
+});
+
+test("renderFindingsCommentBody accepts a null or absent judgeDisposition unchanged (no judge suffix rendered)", () => {
+  const body = renderFindingsCommentBody({
+    gate: "draft_gate",
+    headSha: "abc1234",
+    findings: [{ severity: "low", angle: "scope", summary: "x", judgeDisposition: null }],
+  });
+  assert.ok(body.includes("`scope`: x"));
+  assert.ok(!body.includes("judge:"));
+});
+
 test("renderFindingsCommentBody states that only the latest round is shown (#AC2 stated replacement)", () => {
   const body = renderFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings: [] });
   assert.ok(body.includes("only the latest posted round"));
@@ -1189,6 +1282,19 @@ test("renderBoundedFindingsCommentBody fails closed when even the fully-degraded
   assert.throws(
     () => renderBoundedFindingsCommentBody({ gate: "draft_gate", headSha: "abc1234", findings, maxChars: 10 }),
     /cannot be rendered within/,
+  );
+});
+
+// renderBoundedFindingsCommentBody's own gate/headSha bindings must be
+// NORMALIZED/SANITIZED in this function's own scope before the fail-closed
+// throw below interpolates them — not left raw, which would make the same
+// logical input (padded/mixed-case gate, whitespace-bearing headSha) report
+// different refusal text depending on caller formatting.
+test("renderBoundedFindingsCommentBody's fail-closed throw reports the NORMALIZED gate and SANITIZED headSha, not the caller's raw input", () => {
+  const findings = parseFindings(JSON.stringify([{ severity: "high", angle: "scope", summary: "irrelevant" }]));
+  assert.throws(
+    () => renderBoundedFindingsCommentBody({ gate: " Draft_Gate ", headSha: "  abc1234  ", findings, maxChars: 10 }),
+    /Gate findings comment for gate "draft_gate" at head abc1234 cannot be rendered within/,
   );
 });
 


### PR DESCRIPTION
## Summary

Hardening batch for the gate-findings renderer, closing the five actionable items deferred from the gate-surface sweep: the exported render entry point can no longer bypass input validation, a file reference that survives validation can no longer vanish silently, angle rendering gains the same legibility pin files has, the function's stated hole-handling rule now holds throughout the function, and the severity vocabulary exports are frozen like their siblings.

## Scope and context

Four files. `scripts/github/post-gate-findings.mjs`: `renderFindingsCommentBody` (kept exported — no caller outside the module and its own test file) now routes through the same `validateAndSanitizeRenderInputs` seam, and is the module's only render path (`renderBoundedFindingsCommentBody` composes it and re-runs the seam in its own scope so its closures see normalized values); the seam now also validates the caller-supplied `omittedCounts` (known severity, positive integer count) and each finding's `judgeDisposition`, and rejects a `headSha` that sanitizes to an empty string — completing the sanitize-to-empty guard family this diff itself builds out (angle/summary/disposition were guarded before it; the `files`, `judgeDisposition`, and `headSha` guards are all introduced here); every refusal names the entry point actually invoked (an `entryPoint` parameter replaces the hardcoded function name at every throw site); the inner `files` loop converted to `for...of` per the function's own hole-handling comment. `packages/core/src/loop/gate-fanin.mjs`: `SEVERITY_ORDER`, `NON_DEFECT_SEVERITIES`, and `VALID_SEVERITIES` frozen to match their frozen siblings, with a comment noting `Object.freeze` does not block Set mutation methods (done for consistency; nothing mutates any of the three exports, and the renderer's spread-copy-before-reverse stays). Tests (fourteen added): a direct-export bypass pin, a files-sanitizes-to-empty refusal pin, a headSha-sanitizes-to-empty refusal pin (both entry points), a sparse-files-array hole pin, an angle bracketed-path legibility pin mirroring the files pin, frozen-export pins, four omittedCounts pins (unknown severity, non-array, non-object element, non-positive-integer count), three judgeDisposition pins (non-string or blank, sanitizes-to-empty, null accepted unchanged), and a bounded-path pin asserting the fail-closed re-validation. Mutation checks ran for the guard routing (twenty tests fail on revert), the files and headSha sanitize-to-empty refusals, the hole-handling conversion, the omittedCounts and judgeDisposition validation blocks, the bounded-path re-validation, and both freezes — each revert failed its pin and each restore was verified byte-identical.

## Acceptance criteria

- [x] No exported render entry point can be called in a way that bypasses input validation, or the unguarded export is removed.
- [x] A file reference that survives validation cannot vanish silently from the rendered comment.
- [x] `angle` rendering is pinned the same way `files` rendering is.
- [x] The hole-handling rule stated in the function's own comment is applied consistently within that function.
- [x] The severity vocabulary exports are frozen consistently with their siblings.

## Definition of done

- [x] `npm run verify` green with zero new failures.
- [x] Each change carries a test that fails when the behavior is reverted (mutation-checked across the batch: guard routing, files and headSha sanitize-to-empty refusals, hole-handling conversion, omittedCounts and judgeDisposition validation blocks, bounded-path re-validation, and both freezes).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Export cannot bypass validation | post-gate-findings suite green (direct-export pin; 20 tests fail on revert) | renderer output format unchanged |
| No silent file-ref loss | post-gate-findings suite green (sanitize-empty refusal pin) | no placeholder rendering added (refusal chosen per file convention) |
| Angle legibility pinned | post-gate-findings suite green (bracketed-path pin) | — |
| Consistent hole handling | post-gate-findings suite green (sparse-array pin) | — |
| Frozen vocabulary exports | gate-fanin suite green (frozen pins); npm run verify green | Set mutation methods not blockable by freeze (noted in comment) |
| Seam completeness: omittedCounts validated (gate-round addition under the first criterion) | post-gate-findings suite green (four omittedCounts pins, mutation-checked) | — |
| Seam completeness: judgeDisposition validated (gate-round addition under the first criterion) | post-gate-findings suite green (three judgeDisposition pins, mutation-checked) | — |
| Seam completeness: headSha sanitize-to-empty refusal (gate-round addition under the first criterion) | post-gate-findings suite green (both-entry-point pin, mutation-checked) | — |
| Refusal attribution names the invoked entry point (gate-round addition under the first criterion) | post-gate-findings suite green (misattribution pin via the bounded path) | — |

## Non-goals

- The issue's item six nits (delimiter padding, degradation boundary, the comment-size literal) stay skipped as recorded there.
- No renderer output-format changes.

## Open questions

None.

## Validation

```sh
node --test test/github/post-gate-findings.test.mjs packages/core/test/gate-fanin.test.mjs
npm run verify
```

Closes #1615


