### PR TITLE
test(contracts): vacuous-pass guard for the slash-command surface scan

### DIFF
--- a/test/contracts/referenced-slash-commands-shipped.test.mjs
+++ b/test/contracts/referenced-slash-commands-shipped.test.mjs
@@ -116,6 +116,11 @@ function collectFailures(repoRoot) {
 }
 
 test("no shipped surface instructs a bare /loop-* slash command without the namespaced alternative", () => {
+  // Vacuous-pass guard (mirrors referenced-scripts-shipped.test.mjs's
+  // references.length check): an empty scanned surface set would let the
+  // contract pass without scanning anything.
+  const scannedSurfaces = surfaceFiles(REPO_ROOT).filter((surfaceFile) => fs.existsSync(surfaceFile));
+  assert.ok(scannedSurfaces.length > 0, "expected the scanned surface set to be non-empty (vacuous-pass guard)");
   const failures = collectFailures(REPO_ROOT);
   assert.deepEqual(failures, [], `bare /loop-* slash references without a namespaced alternative:\n${failures.join("\n")}`);
 });

--- a/test/contracts/referenced-slash-commands-shipped.test.mjs
+++ b/test/contracts/referenced-slash-commands-shipped.test.mjs
@@ -117,9 +117,12 @@ function collectFailures(repoRoot) {
 
 test("no shipped surface instructs a bare /loop-* slash command without the namespaced alternative", () => {
   // Vacuous-pass guard (mirrors referenced-scripts-shipped.test.mjs's
-  // references.length check): an empty scanned surface set would let the
-  // contract pass without scanning anything.
-  const scannedSurfaces = surfaceFiles(REPO_ROOT).filter((surfaceFile) => fs.existsSync(surfaceFile));
+  // references.length check): counts the files the scan actually inspects —
+  // existing and not allowlisted — so neither an empty surface set nor an
+  // all-allowlisted one can pass the contract without scanning anything.
+  const scannedSurfaces = surfaceFiles(REPO_ROOT).filter(
+    (surfaceFile) => fs.existsSync(surfaceFile) && !isAllowlisted(REPO_ROOT, surfaceFile),
+  );
   assert.ok(scannedSurfaces.length > 0, "expected the scanned surface set to be non-empty (vacuous-pass guard)");
   const failures = collectFailures(REPO_ROOT);
   assert.deepEqual(failures, [], `bare /loop-* slash references without a namespaced alternative:\n${failures.join("\n")}`);


### PR DESCRIPTION
## Summary

Adds the vacuous-pass guard the draft-gate coverage review of the slash-command contract test asked for: the main scan test now asserts the scanned surface set is non-empty — counting exactly the files the scan inspects, existing and not allowlisted — before checking failures, so neither an empty `surfaceFiles()` result nor an all-allowlisted surface set can pass the contract without scanning anything. Mirrors the sibling scripts-shipped contract at the file-selection level (the sibling asserts on extracted scan-output tokens; this guard asserts on the selected, inspected file set).

## Scope and context

One file. `test/contracts/referenced-slash-commands-shipped.test.mjs`: the main scan test gains a small guard — filter `surfaceFiles(REPO_ROOT)` to existing, non-allowlisted files (the exact set `collectFailures` inspects) and `assert.ok(scannedSurfaces.length > 0, ...)` — plus a comment naming the mirrored sibling guard. The surface set itself, `collectFailures`, and the negative self-tests are unchanged.

## Acceptance criteria

- [x] Main scan test asserts a non-empty scanned surface set (vacuous-pass guard).
- [x] `npm run test:doc-guard` green.

## Definition of done

- [x] `node --test test/contracts/referenced-slash-commands-shipped.test.mjs` green.
- [x] `npm run test:doc-guard` green (278 tests).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| Non-empty scanned surface set asserted | contract test green (4 tests) | surface set unchanged |
| doc-guard suite green | test:doc-guard green (278 tests) | — |

## Non-goals

- Changing the surface set itself.

## Validation

```sh
node --test test/contracts/referenced-slash-commands-shipped.test.mjs
npm run test:doc-guard
```

Closes #1667
