### PR TITLE
test(contracts): share file-walking helpers between the shipped-surface scans

### DIFF
--- a/test/contracts/_walk-helpers.mjs
+++ b/test/contracts/_walk-helpers.mjs
@@ -1,0 +1,32 @@
+// Shared file-walking primitives for the contract tests that scan shipped
+// surfaces (referenced-scripts-shipped, referenced-slash-commands-shipped).
+// Underscore prefix keeps the module out of the `test/contracts/*.test.mjs`
+// runner glob, same as `_rule-helpers.mjs`.
+import fs from "node:fs";
+import path from "node:path";
+
+export const ALWAYS_EXCLUDED_DIR_NAMES = new Set(["node_modules", ".git"]);
+
+export function walkByExt(absDir, exts, out) {
+  if (!fs.existsSync(absDir)) return out;
+  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+    const absChild = path.join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      if (ALWAYS_EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+      walkByExt(absChild, exts, out);
+    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+      out.push(absChild);
+    }
+  }
+  return out;
+}
+
+// Non-recursive: every direct entry whose name ends in `ext`. Deliberately no
+// isFile() check — matches the inline readdir blocks it supersedes.
+export function flatDir(absDir, ext, out) {
+  if (!fs.existsSync(absDir)) return out;
+  for (const name of fs.readdirSync(absDir)) {
+    if (name.endsWith(ext)) out.push(path.join(absDir, name));
+  }
+  return out;
+}

--- a/test/contracts/referenced-scripts-shipped.test.mjs
+++ b/test/contracts/referenced-scripts-shipped.test.mjs
@@ -20,11 +20,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { ALWAYS_EXCLUDED_DIR_NAMES, flatDir, walkByExt } from "./_walk-helpers.mjs";
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 // ── Packed file set (pure, no `npm pack`) ──────────────────────────
-
-const ALWAYS_EXCLUDED_DIR_NAMES = new Set(["node_modules", ".git"]);
 
 function walkFiles(absDir, repoRoot, out) {
   for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
@@ -61,20 +61,6 @@ function expandPackedFileSet(repoRoot) {
 
 // ── Referenced-script collection ───────────────────────────────────
 
-function walkByExt(absDir, exts, out) {
-  if (!fs.existsSync(absDir)) return out;
-  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
-    const absChild = path.join(absDir, entry.name);
-    if (entry.isDirectory()) {
-      if (ALWAYS_EXCLUDED_DIR_NAMES.has(entry.name)) continue;
-      walkByExt(absChild, exts, out);
-    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
-      out.push(absChild);
-    }
-  }
-  return out;
-}
-
 // Matches a whole path-like token ending in `scripts/...mjs`, including any
 // leading relative segments (e.g. `../dev-loop/scripts/foo.mjs`) — matching
 // only the literal `scripts/[A-Za-z0-9_/.-]+\.mjs` suffix would silently
@@ -84,12 +70,8 @@ const SCRIPT_REFERENCE_RE = /[A-Za-z0-9_.\-/]*scripts\/[A-Za-z0-9_/.-]+\.mjs/g;
 function surfaceFiles(repoRoot) {
   return [
     ...walkByExt(path.join(repoRoot, "skills"), [".md"], []),
-    ...fs.readdirSync(path.join(repoRoot, "commands"))
-      .filter((name) => name.endsWith(".md"))
-      .map((name) => path.join(repoRoot, "commands", name)),
-    ...fs.readdirSync(path.join(repoRoot, "agents"))
-      .filter((name) => name.endsWith(".md"))
-      .map((name) => path.join(repoRoot, "agents", name)),
+    ...flatDir(path.join(repoRoot, "commands"), ".md", []),
+    ...flatDir(path.join(repoRoot, "agents"), ".md", []),
     ...walkByExt(path.join(repoRoot, ".claude"), [".md"], []),
     path.join(repoRoot, "scripts/loop/resolve-dev-loop-startup.mjs"),
     path.join(repoRoot, "scripts/loop/build-handoff-envelope.mjs"),

--- a/test/contracts/referenced-slash-commands-shipped.test.mjs
+++ b/test/contracts/referenced-slash-commands-shipped.test.mjs
@@ -23,31 +23,9 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { flatDir, walkByExt } from "./_walk-helpers.mjs";
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-
-const ALWAYS_EXCLUDED_DIR_NAMES = new Set(["node_modules", ".git"]);
-
-function walkByExt(absDir, exts, out) {
-  if (!fs.existsSync(absDir)) return out;
-  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
-    const absChild = path.join(absDir, entry.name);
-    if (entry.isDirectory()) {
-      if (ALWAYS_EXCLUDED_DIR_NAMES.has(entry.name)) continue;
-      walkByExt(absChild, exts, out);
-    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
-      out.push(absChild);
-    }
-  }
-  return out;
-}
-
-function flatDir(absDir, ext, out) {
-  if (!fs.existsSync(absDir)) return out;
-  for (const name of fs.readdirSync(absDir)) {
-    if (name.endsWith(ext)) out.push(path.join(absDir, name));
-  }
-  return out;
-}
 
 function surfaceFiles(repoRoot) {
   return [


### PR DESCRIPTION
## Summary

Extracts the file-walking primitives duplicated between the two shipped-surface contract tests into a shared `test/contracts/_walk-helpers.mjs`, so the scans share one implementation and cannot drift. `ALWAYS_EXCLUDED_DIR_NAMES` and `walkByExt` were byte-identical in both files; the scripts test's inline `commands/`/`agents/` readdir blocks are replaced by the `flatDir` form the slash test already used.

## Scope and context

Three files. `test/contracts/_walk-helpers.mjs` (new): exports `ALWAYS_EXCLUDED_DIR_NAMES`, `walkByExt`, and `flatDir`, behavior identical to the copies they replace on every existing path, with one declared delta: `flatDir` early-returns on a missing directory, so the scripts test's `commands/`/`agents/` roots now fail open (empty list) where the inline `readdirSync` blocks threw ENOENT — both dirs exist, and a per-root non-emptiness guard is tracked as a follow-up (`flatDir` also deliberately keeps no `isFile()` check, matching the inline blocks it supersedes); the module is never executed as a test because it lacks the `.test.mjs` suffix the runner glob (`test/contracts/*.test.mjs`) selects on; the underscore prefix is a naming convention following the `_rule-helpers.mjs` precedent, not the exclusion mechanism. `test/contracts/referenced-slash-commands-shipped.test.mjs`: local copies deleted, imports from `./_walk-helpers.mjs`. `test/contracts/referenced-scripts-shipped.test.mjs`: local `ALWAYS_EXCLUDED_DIR_NAMES`/`walkByExt` deleted, imports added, and the inline `commands/`/`agents/` readdir blocks in `surfaceFiles` replaced with `flatDir`. `walkFiles` stays local to the scripts test (it feeds the packed-set expansion, accumulates repo-relative paths into a Set, and applies no extension filter — different semantics). Each test's `surfaceFiles` resolves the same file set as before: same surface roots, extensions, and pinned files.

## Acceptance criteria

- [x] `test/contracts/_walk-helpers.mjs` exists and exports `ALWAYS_EXCLUDED_DIR_NAMES`, `walkByExt`, and `flatDir`.
- [x] Neither test defines a local `ALWAYS_EXCLUDED_DIR_NAMES`, `walkByExt`, or `flatDir`; both import from `./_walk-helpers.mjs`.
- [x] `referenced-scripts-shipped.test.mjs` builds its `commands/` and `agents/` surface entries via the shared `flatDir`.
- [x] `walkFiles` remains local to `referenced-scripts-shipped.test.mjs`, unchanged.
- [x] Each test's `surfaceFiles` resolves to the same file set as before the extraction.
- [x] All existing tests in both files pass unchanged, including the negative self-tests.
- [x] `grep -rn "function walkByExt" test/` yields exactly one definition, in `_walk-helpers.mjs`.

## Definition of done

- [x] `node --test test/contracts/referenced-scripts-shipped.test.mjs test/contracts/referenced-slash-commands-shipped.test.mjs` passes (6 tests).
- [x] `npm run test:doc-guard` passes (278 tests; full `test/contracts/*.test.mjs` glob — confirms the helper module trips no other contract and is not picked up as a test).
- [x] Lint: the repo ships no `npm run lint` script (the issue's DoD line predates that); `npm run verify` covers the equivalent checks and CI runs it on this PR.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| AC1: shared module exists with all three exports | DoD 1 (contract suites) | no semantics improvements (no isFile() on flatDir) |
| AC2: no local copies; both tests import | Validation grep + DoD 1 | — |
| AC3: commands/agents via flatDir | DoD 1 (scripts-test suite) | surface set unchanged |
| AC4: walkFiles stays local | DoD 1 (scripts-test suite) | no walkFiles/expandPackedFileSet extraction |
| AC5: same resolved surface sets | DoD 1 (both suites incl. negative self-tests) | no surfaceFiles sharing |
| AC6: existing tests pass unchanged incl. negative self-tests | DoD 1 + DoD 3 (verify) | — |
| AC7: single walkByExt definition in test/ | Validation grep | — |
| Derived: helper not run as a test | DoD 2 (test:doc-guard full glob) | no _rule-helpers.mjs refactor |

## Non-goals

- Changing either test's scanned surface set.
- Sharing `surfaceFiles` itself; the two tests scan different surfaces by design.
- Extracting `walkFiles` or the packed-set expansion (`expandPackedFileSet`); different semantics.
- Improving helper semantics (for example adding an `isFile()` check to `flatDir`); behavior stays byte-identical.
- Refactoring `_rule-helpers.mjs` or merging it with the new module.

## Validation

```sh
node --test test/contracts/referenced-scripts-shipped.test.mjs test/contracts/referenced-slash-commands-shipped.test.mjs
npm run test:doc-guard
grep -rn "function walkByExt" test/
```

Closes #1668
