### PR TITLE
fix(gate): judge polish — qualified read-only wording, followUpDraft shape validation, pure-seam coverage check

### DIFF
--- a/.claude/agents/judge.md
+++ b/.claude/agents/judge.md
@@ -18,7 +18,7 @@ You are the dedicated judge agent for the gate fan-out/fan-in chain. You hold th
 
 - You are **read-only over the repository**: you inspect code, the diff, the issue, and prior ledgers, but you never edit a tracked file. You have no `edit` tool.
 - The **only** thing you write is your own verdict artifact (to the deterministic path the conductor hands you, under `tmp/`). You do not write code, docs, comments, or any other file.
-- An actor that can fix will fix, and relevance judgment collapses into fixing. Your read-only boundary is what keeps relevance judgment independent of the fixing role.
+- An actor that can fix will fix, and relevance judgment collapses into fixing. Your read-only-over-the-repository boundary is what keeps relevance judgment independent of the fixing role.
 
 ## Inputs
 
@@ -66,7 +66,7 @@ Write a single JSON object to the deterministic path the conductor names (under 
 - **You do not soften `must-fix` on correctness grounds.** A real defect stays a real defect. You decide *where* it is fixed (this PR or a follow-up), not *whether* it is real. The fixer retains reproduction-based rejection; you do not override a finding's severity.
 - **You do not replace the severity-based disposition.** The severity-derived `disposition` (accepted-for-fix/deferred/needs-answer) stays intact; your `judgeDisposition` (act/defer/reject) is the relevance axis on top of it, not a replacement.
 - **You do not fix.** You have no `edit` tool and you write only your verdict artifact.
-- **You do not change reviewer fresh-context isolation.** Reviewers stay single-angle, read-only, and fresh-context by design.
+- **You do not change reviewer fresh-context isolation.** Reviewers stay single-angle, read-only over the repository, and fresh-context by design.
 
 ## Authority split (relevance vs reproduction)
 

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -171,8 +171,9 @@ dev-loops gate judge-pass --repo <owner/name> --pr <N> --gate <gate> --head-sha 
 ```
 
 The fix pass consumes ONLY `--out`'s act list (the judge's `act` findings); a `judge-pass` fail-closed
-(stale verdict head, malformed verdict, out-of-range index) means re-run the judge at the current head,
-never a silent severity-only fallback on a wired gate. See Gate Review Sub-Loop Contract Phase 3.5.
+(stale verdict head, malformed verdict, out-of-range index, undisposed finding) means re-run the judge at
+the current head, never a silent severity-only fallback on a wired gate. See Gate Review Sub-Loop Contract
+Phase 3.5.
 
 The cross-refs (`ANTIPATTERN-FANIN-WAIT` in [Anti-patterns](../docs/anti-patterns.md), [Gate Review Sub-Loop Contract](../docs/gate-review-sub-loop-contract.md) Phase 3) remain authoritative for the full refusal list and fail-closed cases; this inline emphasis exists so the sanctioned path is visible at the point of dispatch without following a link. A subagent that skipped the cross-ref and hand-rolled `Promise.all` + transcript-tailing burned ~189k tokens and had to be interrupted and restarted fresh — do not repeat that.
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1128,7 +1128,8 @@ The shape is validated by `validateJudgeVerdict` (`@dev-loops/core/loop/gate-fan
 
 **Merge seam.** The conductor enriches the consolidated findings with the judge's
 dispositions via `applyJudgeDispositions(findings, judgeVerdict)` (`@dev-loops/core/loop/gate-fanin`,
-pure, fail-closed on a malformed verdict or an out-of-range index), then writes the durable
+pure, fail-closed on a malformed verdict, an out-of-range index, or dispositions that do not
+cover every finding), then writes the durable
 ledger via `write-gate-findings-log.mjs --judge-verdict <path>`. The enriched findings carry
 `judgeDisposition` / `judgeRationale` / `judgeCriterion` / `followUpDraft` so the disposition
 ledger and the posted findings comment show what was consciously not acted on and why
@@ -1144,7 +1145,7 @@ never feed the fixer), applies the dispositions via `applyJudgeDispositions`, an
 exactly the findings the judge marked `act` (`--out`) plus the enriched ledger
 (`--ledger-out`). The conductor hands that act list — never the full unfiltered ledger —
 to the fixer pass (`GATE-EXEC-JUDGE-AUTHORITY-SPLIT`). If `judge-pass` fails closed (stale
-head, malformed verdict, out-of-range index), the conductor re-runs the judge at the
+head, malformed verdict, out-of-range index, undisposed finding), the conductor re-runs the judge at the
 current head rather than degrading to severity-only disposition for a wired gate.
 
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->

--- a/agents/judge.agent.md
+++ b/agents/judge.agent.md
@@ -21,7 +21,7 @@ You are the dedicated judge agent for the gate fan-out/fan-in chain. You hold th
 
 - You are **read-only over the repository**: you inspect code, the diff, the issue, and prior ledgers, but you never edit a tracked file. You have no `edit` tool.
 - The **only** thing you write is your own verdict artifact (to the deterministic path the conductor hands you, under `tmp/`). You do not write code, docs, comments, or any other file.
-- An actor that can fix will fix, and relevance judgment collapses into fixing. Your read-only boundary is what keeps relevance judgment independent of the fixing role.
+- An actor that can fix will fix, and relevance judgment collapses into fixing. Your read-only-over-the-repository boundary is what keeps relevance judgment independent of the fixing role.
 
 ## Inputs
 
@@ -69,7 +69,7 @@ Write a single JSON object to the deterministic path the conductor names (under 
 - **You do not soften `must-fix` on correctness grounds.** A real defect stays a real defect. You decide *where* it is fixed (this PR or a follow-up), not *whether* it is real. The fixer retains reproduction-based rejection; you do not override a finding's severity.
 - **You do not replace the severity-based disposition.** The severity-derived `disposition` (accepted-for-fix/deferred/needs-answer) stays intact; your `judgeDisposition` (act/defer/reject) is the relevance axis on top of it, not a replacement.
 - **You do not fix.** You have no `edit` tool and you write only your verdict artifact.
-- **You do not change reviewer fresh-context isolation.** Reviewers stay single-angle, read-only, and fresh-context by design.
+- **You do not change reviewer fresh-context isolation.** Reviewers stay single-angle, read-only over the repository, and fresh-context by design.
 
 ## Authority split (relevance vs reproduction)
 

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -1016,7 +1016,10 @@ export function validateJudgeVerdict(verdict) {
  *
  * Pure. Fails closed (throws) when a disposition references an out-of-range
  * index — a judge verdict that names a finding that is not in the ledger is a
- * mismatch, never a silent enrichment.
+ * mismatch, never a silent enrichment — and when the dispositions do not
+ * cover every finding: an undisposed finding must never be silently dropped
+ * from the fixer's act list. An empty findings array with an empty
+ * dispositions array is vacuously covered and returns without error.
  *
  * @param {Array<object>} findings — the flat consolidated findings array
  * @param {object} judgeVerdict — the validated judge verdict artifact
@@ -1039,6 +1042,15 @@ export function applyJudgeDispositions(findings, judgeVerdict) {
     if (d.disposition === "defer" && d.followUpDraft) {
       target.followUpDraft = d.followUpDraft;
     }
+  }
+  const uncovered = enriched.reduce((positions, f, i) => {
+    if (!f.judgeDisposition) positions.push(i);
+    return positions;
+  }, /** @type {number[]} */ ([]));
+  if (uncovered.length > 0) {
+    throw new Error(
+      `judge verdict does not dispose ${uncovered.length} finding(s) (indexes: ${uncovered.join(", ")}) — fail closed; an undisposed finding must never be silently dropped from the fixer act list`
+    );
   }
   return { findings: enriched, scopeDrift: validated.scopeDrift };
 }

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -1034,6 +1034,13 @@ export function applyJudgeDispositions(findings, judgeVerdict) {
       throw new Error(`judge disposition index ${d.index} is out of range (findings has ${enriched.length} entries)`);
     }
     const target = enriched[d.index];
+    // Reset judge-owned fields before the re-merge: a pre-enriched finding
+    // (already-enriched from a prior round, re-disposed by THIS verdict)
+    // must not let stale judgeCriterion/followUpDraft survive a
+    // defer -> act/reject re-disposition — the merged copy carries only
+    // what the current disposition provides, never prior-round residue.
+    delete target.judgeCriterion;
+    delete target.followUpDraft;
     target.judgeDisposition = d.disposition;
     target.judgeRationale = d.rationale;
     if (typeof d.criterion === "string" && d.criterion.trim().length > 0) {

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -1043,8 +1043,14 @@ export function applyJudgeDispositions(findings, judgeVerdict) {
       target.followUpDraft = d.followUpDraft;
     }
   }
-  const uncovered = enriched.reduce((positions, f, i) => {
-    if (!f.judgeDisposition) positions.push(i);
+  // Coverage is judged against THIS verdict's disposed-index set, not field
+  // presence on the merged copy — an already-enriched ledger (a finding that
+  // already carries judgeDisposition from a prior round) must not let a
+  // verdict that disposes nothing pass silently. validateJudgeVerdict already
+  // rejects duplicate indexes, so the Set is exact.
+  const disposed = new Set(validated.dispositions.map((d) => d.index));
+  const uncovered = enriched.reduce((positions, _f, i) => {
+    if (!disposed.has(i)) positions.push(i);
     return positions;
   }, /** @type {number[]} */ ([]));
   if (uncovered.length > 0) {

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -1255,6 +1255,19 @@ describe("applyJudgeDispositions (#1525)", () => {
     );
   });
 
+  test("re-disposing a pre-enriched defer-with-draft finding to act drops the stale followUpDraft", () => {
+    const alreadyEnriched = baseFindings.map((f, i) => (i === 1
+      ? { ...f, judgeDisposition: "defer", judgeRationale: "prior round", judgeCriterion: "NG-2", followUpDraft: { title: "stale", body: "stale body" } }
+      : { ...f }));
+    const verdict = judgeVerdict([
+      { index: 0, disposition: "act", rationale: "in-scope", criterion: "AC-1" },
+      { index: 1, disposition: "act", rationale: "now in-scope, no longer deferred", criterion: "AC-2" },
+    ]);
+    const { findings } = applyJudgeDispositions(alreadyEnriched, verdict);
+    assert.equal(findings[1].judgeDisposition, "act");
+    assert.equal(findings[1].followUpDraft, undefined);
+  });
+
   test("an empty findings array with an empty dispositions array is vacuously covered", () => {
     const verdict = judgeVerdict([]);
     const { findings } = applyJudgeDispositions([], verdict);

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -1238,6 +1238,23 @@ describe("applyJudgeDispositions (#1525)", () => {
     );
   });
 
+  test("fails closed when a disposition leaves two findings uncovered, listing both positions", () => {
+    const verdict = judgeVerdict([]);
+    assert.throws(
+      () => applyJudgeDispositions(baseFindings, verdict),
+      /does not dispose 2 finding\(s\) \(indexes: 0, 1\)/,
+    );
+  });
+
+  test("fails closed on a pre-enriched ledger when the current verdict disposes nothing (coverage is judged against THIS verdict, not field presence)", () => {
+    const alreadyEnriched = baseFindings.map((f) => ({ ...f, judgeDisposition: "act", judgeRationale: "prior round" }));
+    const verdict = judgeVerdict([]);
+    assert.throws(
+      () => applyJudgeDispositions(alreadyEnriched, verdict),
+      /does not dispose 2 finding\(s\) \(indexes: 0, 1\)/,
+    );
+  });
+
   test("an empty findings array with an empty dispositions array is vacuously covered", () => {
     const verdict = judgeVerdict([]);
     const { findings } = applyJudgeDispositions([], verdict);

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -1129,6 +1129,7 @@ describe("applyJudgeDispositions (#1525)", () => {
   test("a finding acted on against a named criterion gets judgeDisposition act", () => {
     const verdict = judgeVerdict([
       { index: 0, disposition: "act", rationale: "fixes the null-deref named in AC criterion 1", criterion: "AC-1: parser must not crash on null input" },
+      { index: 1, disposition: "reject", rationale: "style-only rename, out of scope", criterion: "Non-goal 3" },
     ]);
     const { findings, scopeDrift } = applyJudgeDispositions(baseFindings, verdict);
     assert.equal(findings[0].judgeDisposition, "act");
@@ -1164,7 +1165,10 @@ describe("applyJudgeDispositions (#1525)", () => {
 
   test("scope-drift verdict is raised when the diff exceeds the declared scope", () => {
     const verdict = judgeVerdict(
-      [{ index: 0, disposition: "act", rationale: "in-scope", criterion: "AC-1" }],
+      [
+        { index: 0, disposition: "act", rationale: "in-scope", criterion: "AC-1" },
+        { index: 1, disposition: "reject", rationale: "style-only rename, out of scope", criterion: "Non-goal 3" },
+      ],
       { verdict: "drift_detected", rationale: "the diff adds a new CLI flag not in any acceptance criterion; criterion 4 limits scope to the parser", driftedAreas: ["cli surface"] },
     );
     const { scopeDrift } = applyJudgeDispositions(baseFindings, verdict);
@@ -1222,5 +1226,21 @@ describe("applyJudgeDispositions (#1525)", () => {
     const logShape = toFindingsLogShape(baseFindings);
     assert.equal(logShape[0].judgeDisposition, undefined);
     assert.equal(logShape[0].followUpDraft, undefined);
+  });
+
+  test("fails closed when a disposition leaves a finding uncovered, naming its 0-based array position", () => {
+    const verdict = judgeVerdict([
+      { index: 0, disposition: "act", rationale: "in-scope", criterion: "AC-1" },
+    ]);
+    assert.throws(
+      () => applyJudgeDispositions(baseFindings, verdict),
+      /does not dispose 1 finding\(s\) \(indexes: 1\)/,
+    );
+  });
+
+  test("an empty findings array with an empty dispositions array is vacuously covered", () => {
+    const verdict = judgeVerdict([]);
+    const { findings } = applyJudgeDispositions([], verdict);
+    assert.deepEqual(findings, []);
   });
 });

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -159,6 +159,14 @@ function validateFindingsArray(parsed, flagLabel) {
       entry.judgeCriterion = f.judgeCriterion.trim();
     }
     if (f.followUpDraft && typeof f.followUpDraft === "object" && !Array.isArray(f.followUpDraft)) {
+      // Mirrors validateJudgeVerdict's followUpDraft shape rule
+      // (packages/core/src/loop/gate-fanin.mjs): a non-empty title string and
+      // a body string, so this trust boundary never passes through a
+      // malformed draft that would surface later as a broken follow-up file.
+      const draft = f.followUpDraft;
+      if (typeof draft.title !== "string" || draft.title.trim().length === 0 || typeof draft.body !== "string") {
+        throw parseError(`${flagLabel}[${i}].followUpDraft must have a non-empty title and a body string`);
+      }
       entry.followUpDraft = f.followUpDraft;
     }
     return entry;

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -35,8 +35,9 @@ Optional:
                                  enriched with the judge's relevance-based dispositions (judgeDisposition /
                                  judgeRationale / judgeCriterion / followUpDraft) via applyJudgeDispositions before
                                  the ledger is written, so the durable ledger and posted findings comment carry what
-                                 was consciously not acted on and why (#1525). Optional; when absent the ledger
-                                 writes byte-identically to before.
+                                 was consciously not acted on and why (#1525). The verdict must dispose every finding
+                                 (one disposition per 0-based ledger position) or the run FAILS CLOSED and writes no
+                                 ledger. Optional; when absent the ledger writes byte-identically to before.
   --tmp-root <path>              Root tmp directory (default: tmp/)
 
 ${JQ_OUTPUT_USAGE}
@@ -158,12 +159,13 @@ function validateFindingsArray(parsed, flagLabel) {
     if (typeof f.judgeCriterion === "string" && f.judgeCriterion.trim().length > 0) {
       entry.judgeCriterion = f.judgeCriterion.trim();
     }
-    if (f.followUpDraft) {
+    if (f.followUpDraft !== undefined && f.followUpDraft !== null) {
       // Mirrors validateJudgeVerdict's followUpDraft shape rule
-      // (packages/core/src/loop/gate-fanin.mjs): gate on presence first — a
-      // truthy non-object draft (string/array/number/boolean) is rejected
-      // here rather than silently dropped, then require a non-empty title
-      // string and a body string, so this trust boundary never passes
+      // (packages/core/src/loop/gate-fanin.mjs): gate on presence, carving
+      // out only nullish (undefined/null) as absent, so a present-but-falsy
+      // draft ("", 0, false) is rejected as a non-object rather than silently
+      // dropped like every other malformed draft, then require a non-empty
+      // title string and a body string, so this trust boundary never passes
       // through, or loses without a diagnostic, a malformed draft that would
       // surface later as a broken follow-up file.
       if (typeof f.followUpDraft !== "object" || Array.isArray(f.followUpDraft)) {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -158,15 +158,25 @@ function validateFindingsArray(parsed, flagLabel) {
     if (typeof f.judgeCriterion === "string" && f.judgeCriterion.trim().length > 0) {
       entry.judgeCriterion = f.judgeCriterion.trim();
     }
-    if (f.followUpDraft && typeof f.followUpDraft === "object" && !Array.isArray(f.followUpDraft)) {
+    if (f.followUpDraft) {
       // Mirrors validateJudgeVerdict's followUpDraft shape rule
-      // (packages/core/src/loop/gate-fanin.mjs): a non-empty title string and
-      // a body string, so this trust boundary never passes through a
-      // malformed draft that would surface later as a broken follow-up file.
+      // (packages/core/src/loop/gate-fanin.mjs): gate on presence first — a
+      // truthy non-object draft (string/array/number/boolean) is rejected
+      // here rather than silently dropped, then require a non-empty title
+      // string and a body string, so this trust boundary never passes
+      // through, or loses without a diagnostic, a malformed draft that would
+      // surface later as a broken follow-up file.
+      if (typeof f.followUpDraft !== "object" || Array.isArray(f.followUpDraft)) {
+        throw parseError(`${flagLabel}[${i}].followUpDraft must be an object`);
+      }
       const draft = f.followUpDraft;
       if (typeof draft.title !== "string" || draft.title.trim().length === 0 || typeof draft.body !== "string") {
         throw parseError(`${flagLabel}[${i}].followUpDraft must have a non-empty title and a body string`);
       }
+      // Validated against the trimmed title but stored raw (untrimmed): this
+      // mirrors validateJudgeVerdict's own raw pass-through, so a
+      // well-formed draft passes through unchanged rather than being
+      // silently renormalized.
       entry.followUpDraft = f.followUpDraft;
     }
     return entry;
@@ -431,7 +441,8 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // judge's relevance-based dispositions (act/defer/reject + rationale +
   // follow-up drafts) before writing the ledger (#1525). The judge runs after
   // fan-in and before the fix pass; applyJudgeDispositions is the pure merge
-  // seam that fails closed on a malformed verdict or an out-of-range index.
+  // seam that fails closed on a malformed verdict, an out-of-range index, or
+  // dispositions that do not cover every finding.
   let findings = rawFindings;
   let scopeDrift;
   if (options.judgeVerdict) {
@@ -497,8 +508,9 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
     // changes based on the judge artifact's content (#1745). A --judge-verdict
     // run can still surface a different, earlier error first: the judge
     // artifact is read, parsed, and applied before this point runs, so an
-    // unreadable, malformed, or out-of-range-index judge artifact throws its
-    // own parse error ahead of this contradiction check, not instead of it.
+    // unreadable, malformed, out-of-range-index, or incomplete-coverage judge
+    // artifact throws its own parse error ahead of this contradiction check,
+    // not instead of it.
     if (callerVerdict !== normalizedOverallVerdict) {
       throw parseError(
         `--verdict ${JSON.stringify(callerVerdict)} contradicts the wrapper's "overallVerdict" ${JSON.stringify(normalizedOverallVerdict)} (GATE-COMMENT-VERDICT-VALUES; skills/docs/gate-review-comment-contract.md) — the consolidator's computed round verdict, which judge dispositions from --judge-verdict never alter`,

--- a/scripts/loop/judge-pass.mjs
+++ b/scripts/loop/judge-pass.mjs
@@ -209,7 +209,7 @@ export function validateCliArgs(options) {
  *     (trim+lowercase) or the pass fails closed — a stale verdict staged from an
  *     earlier head must never feed the fixer's act list
  *   - applies the judge's relevance dispositions via `applyJudgeDispositions`
- *     (fail-closed on an out-of-range index)
+ *     (fail-closed on an out-of-range index and on undisposed findings)
  *
  * The fix pass consumes ONLY the returned `act` list (`GATE-EXEC-JUDGE-AUTHORITY-SPLIT`);
  * the returned `enriched` ledger carries `judgeDisposition` / `judgeRationale` /
@@ -231,17 +231,11 @@ export function runJudgePass(findings, judgeVerdict, headSha) {
       `judge verdict headSha ${JSON.stringify(validated.headSha)} does not match current head ${JSON.stringify(headSha)} — refuse a stale verdict; re-run the judge at the current head`
     );
   }
+  // applyJudgeDispositions fails closed on both an out-of-range index and an
+  // undisposed finding (the coverage check lives in that shared pure seam),
+  // so runJudgePass inherits fail-closed coverage without restating it here.
   const applied = applyJudgeDispositions(findings, judgeVerdict);
   const enriched = applied.findings;
-  // Fail closed when the judge verdict does not dispose every finding: an
-  // undisposed finding would otherwise be silently dropped from the fixer's act
-  // list (it only lingers in the enriched ledger without a disposition).
-  const uncovered = enriched.filter((f) => !f.judgeDisposition);
-  if (uncovered.length > 0) {
-    throw new Error(
-      `judge verdict does not dispose ${uncovered.length} finding(s) (indexes: ${uncovered.map((f) => f.index).join(", ")}) — fail closed; an undisposed finding must never be silently dropped from the fixer act list`
-    );
-  }
   const act = enriched.filter((f) => f.judgeDisposition === "act");
   const counts = { act: 0, defer: 0, reject: 0 };
   for (const f of enriched) {

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -194,8 +194,9 @@ dev-loops gate judge-pass --repo <owner/name> --pr <N> --gate <gate> --head-sha 
 ```
 
 The fix pass consumes ONLY `--out`'s act list (the judge's `act` findings); a `judge-pass` fail-closed
-(stale verdict head, malformed verdict, out-of-range index) means re-run the judge at the current head,
-never a silent severity-only fallback on a wired gate. See Gate Review Sub-Loop Contract Phase 3.5.
+(stale verdict head, malformed verdict, out-of-range index, undisposed finding) means re-run the judge at
+the current head, never a silent severity-only fallback on a wired gate. See Gate Review Sub-Loop Contract
+Phase 3.5.
 
 The cross-refs (`ANTIPATTERN-FANIN-WAIT` in [Anti-patterns](../docs/anti-patterns.md), [Gate Review Sub-Loop Contract](../docs/gate-review-sub-loop-contract.md) Phase 3) remain authoritative for the full refusal list and fail-closed cases; this inline emphasis exists so the sanctioned path is visible at the point of dispatch without following a link. A subagent that skipped the cross-ref and hand-rolled `Promise.all` + transcript-tailing burned ~189k tokens and had to be interrupted and restarted fresh — do not repeat that.
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1128,7 +1128,8 @@ The shape is validated by `validateJudgeVerdict` (`@dev-loops/core/loop/gate-fan
 
 **Merge seam.** The conductor enriches the consolidated findings with the judge's
 dispositions via `applyJudgeDispositions(findings, judgeVerdict)` (`@dev-loops/core/loop/gate-fanin`,
-pure, fail-closed on a malformed verdict or an out-of-range index), then writes the durable
+pure, fail-closed on a malformed verdict, an out-of-range index, or dispositions that do not
+cover every finding), then writes the durable
 ledger via `write-gate-findings-log.mjs --judge-verdict <path>`. The enriched findings carry
 `judgeDisposition` / `judgeRationale` / `judgeCriterion` / `followUpDraft` so the disposition
 ledger and the posted findings comment show what was consciously not acted on and why
@@ -1144,7 +1145,7 @@ never feed the fixer), applies the dispositions via `applyJudgeDispositions`, an
 exactly the findings the judge marked `act` (`--out`) plus the enriched ledger
 (`--ledger-out`). The conductor hands that act list — never the full unfiltered ledger —
 to the fixer pass (`GATE-EXEC-JUDGE-AUTHORITY-SPLIT`). If `judge-pass` fails closed (stale
-head, malformed verdict, out-of-range index), the conductor re-runs the judge at the
+head, malformed verdict, out-of-range index, undisposed finding), the conductor re-runs the judge at the
 current head rather than degrading to severity-only disposition for a wired gate.
 
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -493,6 +493,51 @@ test("writeGateFindingsLog rejects a followUpDraft with a non-string body", asyn
   }, /\[0\]\.followUpDraft must have a non-empty title and a body string/);
 });
 
+test("writeGateFindingsLog rejects a followUpDraft with a missing title", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { body: "b" } },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must have a non-empty title and a body string/);
+});
+
+test("writeGateFindingsLog rejects a non-object (string) followUpDraft instead of silently dropping it", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: "see the follow-up" },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must be an object/);
+});
+
+test("writeGateFindingsLog rejects an array-wrapped followUpDraft instead of silently dropping it", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: ["t", "b"] },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must be an object/);
+});
+
 test("writeGateFindingsLog passes a well-formed followUpDraft through unchanged", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-followup-"));
   try {
@@ -1816,6 +1861,49 @@ test("writeGateFindingsLog enriches findings from --judge-verdict and records sc
     assert.equal(parsed.findings[1].judgeDisposition, "reject");
     assert.equal(parsed.scopeDrift.verdict, "drift_detected");
     assert.deepEqual(parsed.scopeDrift.driftedAreas, ["cli surface"]);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// The --judge-verdict path inherits applyJudgeDispositions's coverage
+// fail-closed check the same as the pure seam and runJudgePass: a verdict
+// that leaves a finding undisposed must abort the write rather than persist
+// a ledger with a silently-dropped finding.
+test("writeGateFindingsLog --judge-verdict fails closed when the verdict does not dispose every finding and writes no ledger", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-judge-coverage-"));
+  try {
+    const headSha = "d4".repeat(20);
+    const judgeVerdictPath = path.join(tmpDir, "judge-verdict.json");
+    await writeFile(judgeVerdictPath, JSON.stringify({
+      headSha,
+      scopeDrift: { verdict: "within_scope", rationale: "matches the briefed AC set", driftedAreas: [] },
+      dispositions: [
+        { index: 0, disposition: "act", rationale: "fixes the defect named in AC-1", criterion: "AC-1" },
+      ],
+    }), "utf8");
+
+    await assert.rejects(
+      () => writeGateFindingsLog({
+        repo: "o/n",
+        pr: 23,
+        gate: "draft_gate",
+        headSha,
+        verdict: "findings_present",
+        findings: JSON.stringify([
+          { severity: "must-fix", angle: "correctness", summary: "null deref", disposition: "accepted-for-fix" },
+          { severity: "low", angle: "docs", summary: "rename variable", disposition: "deferred" },
+        ]),
+        judgeVerdict: judgeVerdictPath,
+        tmpRoot: tmpDir,
+      }),
+      /does not dispose 1 finding\(s\) \(indexes: 1\)/,
+    );
+    await assert.rejects(
+      () => readFile(buildLogPath({ repo: "o/n", pr: 23, gate: "draft_gate", headSha, tmpRoot: tmpDir }), "utf8"),
+      /ENOENT/,
+      "an undisposed-finding verdict must not write a ledger",
+    );
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -463,6 +463,57 @@ test("writeGateFindingsLog rejects empty-string resolvedIn", async () => {
   }, /resolvedIn must be a non-empty string/);
 });
 
+test("writeGateFindingsLog rejects a followUpDraft with an empty title", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { title: "", body: "b" } },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must have a non-empty title and a body string/);
+});
+
+test("writeGateFindingsLog rejects a followUpDraft with a non-string body", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { title: "t", body: 42 } },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must have a non-empty title and a body string/);
+});
+
+test("writeGateFindingsLog passes a well-formed followUpDraft through unchanged", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-followup-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { title: "t", body: "b" } },
+      ]),
+      tmpRoot: tmpDir,
+    });
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.deepEqual(parsed.findings[0].followUpDraft, { title: "t", body: "b" });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("writeGateFindingsLog includes an optional positive-integer line when present", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-test-"));
   try {

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -538,6 +538,42 @@ test("writeGateFindingsLog rejects an array-wrapped followUpDraft instead of sil
   }, /\[0\]\.followUpDraft must be an object/);
 });
 
+test("writeGateFindingsLog rejects a whitespace-only followUpDraft title", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { title: "   ", body: "b" } },
+      ]),
+    });
+  }, /\[0\]\.followUpDraft must have a non-empty title and a body string/);
+});
+
+test("writeGateFindingsLog stores a padded followUpDraft title raw (validated trimmed, stored untrimmed)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-followup-raw-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "clean",
+      findings: JSON.stringify([
+        { severity: "low", angle: "docs", summary: "x", followUpDraft: { title: "  ok  ", body: "" } },
+      ]),
+      tmpRoot: tmpDir,
+    });
+    const parsed = JSON.parse(await readFile(result.path, "utf8"));
+    assert.deepEqual(parsed.findings[0].followUpDraft, { title: "  ok  ", body: "" });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("writeGateFindingsLog passes a well-formed followUpDraft through unchanged", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "gate-findings-followup-"));
   try {

--- a/test/loop/judge-pass.test.mjs
+++ b/test/loop/judge-pass.test.mjs
@@ -106,11 +106,14 @@ test("runJudgePass fails closed on an out-of-range disposition index", () => {
 });
 
 test("runJudgePass fails closed when the verdict does not dispose every finding (#1658)", () => {
-  // Disposition covers index 0 only; index 1 is undisposed and must fail closed
-  // rather than silently drop out of the fixer act list.
-  const findings = ledger(finding({ index: 0 }), finding({ index: 1, summary: "undisposed" }));
+  // Disposition covers array position 0 only; position 1 is undisposed and
+  // must fail closed rather than silently drop out of the fixer act list.
+  // The findings' own vestigial `index` fields are deliberately set to NOT
+  // coincide with array position, so a regression that reports the stale
+  // `f.index` field instead of the 0-based array position is caught here.
+  const findings = ledger(finding({ index: 7 }), finding({ index: 9, summary: "undisposed" }));
   const v = verdict({ dispositions: [{ index: 0, disposition: "act", rationale: "in scope" }] });
-  assert.throws(() => runJudgePass(findings, v, HEAD), /does not dispose 1 finding\(s\)/);
+  assert.throws(() => runJudgePass(findings, v, HEAD), /does not dispose 1 finding\(s\) \(indexes: 1\)/);
 });
 
 test("validateCliArgs accepts a full invocation and canonicalizes the gate", () => {


### PR DESCRIPTION
## Summary

Lands the three polish items deferred from the judge-agent gate review: the judge doc's remaining bare "read-only" mentions are qualified as read-only over the repository (the tmp/ verdict artifact stays the sole permitted write); `validateFindingsArray` now validates a `followUpDraft`'s inner shape at the trust boundary (title non-empty string, body string) instead of accepting any object; and the judge-disposition coverage check moves from `runJudgePass` into the pure `applyJudgeDispositions` seam, failing closed for every caller and reporting uncovered findings by 0-based array position instead of a nonexistent `index` field.

## Scope and context

Twelve files (nine sources plus three regenerated .claude mirrors). `agents/judge.agent.md` (+ regenerated `.claude/agents/judge.md` mirror): prose-only qualification of two bare "read-only" mentions; frontmatter untouched. `scripts/github/write-gate-findings-log.mjs`: `validateFindingsArray` rejects a malformed or non-object `followUpDraft` via `parseError` naming the `[i].followUpDraft` path (presence-gated with a nullish-only carve-out, so a present-but-falsy draft is rejected rather than silently dropped), mirroring `validateJudgeVerdict`'s rule (which itself is unchanged); the `--judge-verdict` USAGE entry states the fail-closed dispose-every-finding precondition. `packages/core/src/loop/gate-fanin.mjs`: `applyJudgeDispositions` derives coverage from the verdict's own disposed-index set — an already-enriched ledger cannot satisfy the check by carried fields — throws when any finding is left undisposed (0-based positions), resets judge-owned fields (`followUpDraft`/`judgeCriterion`) before re-merge so a re-disposition drops stale prior-round state, and still passes empty findings with empty dispositions. `scripts/loop/judge-pass.mjs`: the local coverage check is removed; `runJudgePass` inherits the fail-closed behavior through the seam with the same error message. `skills/docs/gate-review-sub-loop-contract.md` and `skills/dev-loop/SKILL.md` (+ regenerated mirrors): the documented fail-closed enumerations gain the undisposed-finding trigger. Tests across `packages/core/test/gate-fanin.test.mjs`, `test/github/write-gate-findings-log.test.mjs`, and `test/loop/judge-pass.test.mjs`: coverage-gap throws (single and plural), vacuous empty-array pass, pre-enriched-ledger regression, stale-draft-reset regression, inherited `--judge-verdict` coverage throw with no ledger written, malformed/non-object/whitespace-title `followUpDraft` rejections, raw-store pass-through pin, and the judge-pass position-reporting regex extended through its indexes tail with non-coincident fixture indexes.

## Acceptance criteria

- [x] Every "read-only" describing the judge in `agents/judge.agent.md` is qualified as read-only over the repository; the tmp/ verdict artifact remains the sole permitted write.
- [x] `validateFindingsArray` rejects a `followUpDraft` whose `title` is not a non-empty string or whose `body` is not a string, throwing via `parseError` and naming the `[i].followUpDraft` path.
- [x] A well-formed `followUpDraft` passes through `validateFindingsArray` unchanged.
- [x] `applyJudgeDispositions` throws when dispositions do not cover every finding; empty findings + empty dispositions return without error.
- [x] The coverage error lists uncovered findings by 0-based array position.
- [x] `runJudgePass` keeps failing closed on an uncovered verdict through the shared seam; its local duplicate check is removed; the existing coverage test still passes.
- [x] New tests exist for the changed behavior: coverage-gap throws, empty-array pass, pre-enriched and stale-draft regressions (gate-fanin); followUpDraft rejections, pass-through, and inherited coverage-throw pins (write-gate-findings-log).

## Definition of done

- [x] `node --test packages/core/test/gate-fanin.test.mjs` passes (119 tests).
- [x] `node --test test/github/write-gate-findings-log.test.mjs` passes (96 tests).
- [x] `node --test test/loop/judge-pass.test.mjs` passes (11 tests).
- [x] Root `npm test` aggregate green (`npm run verify` covers the same suites; CI runs it on this PR).

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| AC1: judge doc wording qualified | DoD 4 (verify aggregate covers test:assets, incl. mirror reproducibility) | no frontmatter change |
| AC2: malformed followUpDraft rejected | DoD 2 | validateJudgeVerdict unchanged |
| AC3: well-formed draft passes through | DoD 2 | no schema change |
| AC4: pure-seam coverage throw + vacuous pass | DoD 1 | no verdict-semantics change |
| AC5: 0-based positions in the error | DoD 1 | — |
| AC6: runJudgePass inherits fail-closed | DoD 3 | non-goal 4: no re-doing the runJudgePass-layer check |
| AC7: new tests exist for the changed behavior | DoD 1 + DoD 2 | — |

## Non-goals

- Any change to the judge's authority split or the gate verdict semantics.
- Changing the judge's frontmatter `tools:` list; prose only.
- Changing the judge verdict artifact schema or `validateJudgeVerdict` itself.
- Re-doing the `runJudgePass`-layer coverage check; this relocates it into the pure seam and fixes its message.

## Validation

```sh
node --test packages/core/test/gate-fanin.test.mjs
node --test test/github/write-gate-findings-log.test.mjs
node --test test/loop/judge-pass.test.mjs
npm run verify
```

Closes #1656
