### PR TITLE
feat(gate): size-budget computation module + gates.size config (phase 1 of #1480)

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -283,6 +283,7 @@ const SUBCOMMAND_ROUTES = {
     "capture-threads":    "scripts/github/capture-review-threads.mjs",
     "reply-resolve":      "scripts/github/reply-resolve-review-threads.mjs",
     "offer-human-handoff": "scripts/github/offer-human-handoff.mjs",
+    "size-budget":        "scripts/loop/check-size-budget.mjs",
   },
   loop: {
     startup:        "scripts/loop/resolve-dev-loop-startup.mjs",
@@ -372,6 +373,7 @@ const SUBCOMMAND_DESCRIPTIONS = {
     "capture-threads": "Capture review threads",
     "reply-resolve": "Reply and resolve review threads",
     "offer-human-handoff": "Offer to assign PR to a human reviewer/assignee",
+    "size-budget": "Compute PR size/tier budget outcome (pass/escalate/block; pure computation, no enforcement)",
   },
   loop: {
     startup: "Resolve dev-loop startup bundle",

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -350,8 +350,37 @@ function rejectDuplicateFanoutGroupNames(val, ctx) {
   }
 }
 
+// Fail-closed PR size budget (Phase 1 of the escalate-don't-chop size gate:
+// this schema plus check-size-budget.mjs's pure computation only — no
+// enforcement wiring yet). `patterns` classifies a changed file into t1/t3
+// by path glob; the default tier is implicit for every file matching
+// neither, so it carries no `patterns` field of its own. `sliceHardLoc`
+// (t1 only) caps the T1-slice LOC, not the whole-PR LOC.
+const SizeTierConfig = z.strictObject({
+  patterns: z.array(z.string().trim().min(1)).optional().describe("Glob-style path patterns; a changed file matching one resolves to this tier."),
+  softLoc: z.number().int().positive().nullable().optional().describe("Escalate above this many logic LOC; null disables the soft threshold for this tier."),
+  waiverLoc: z.number().int().positive().nullable().optional().describe("Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier."),
+  sliceHardLoc: z.number().int().positive().optional().describe("T1 only: block above this many T1-slice logic LOC unless waived by a named human approver."),
+});
+
+const SizeTiersConfig = z.strictObject({
+  default: SizeTierConfig.omit({ patterns: true, sliceHardLoc: true }).default({ softLoc: 400, waiverLoc: 1500 }).describe("Fallback tier applied to every changed file that matches no t1/t3 pattern."),
+  t1: SizeTierConfig.optional().describe("Risk-slice tier (money/auth/shared/ungated paths). Empty by default — a repo defines its own patterns; the T1 slice is computed separately from whole-PR LOC."),
+  t3: SizeTierConfig.optional().describe("Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies."),
+});
+
+const SizeConfig = z.strictObject({
+  testDiscount: z.number().min(0).max(1).default(0.25).describe("Weight applied to test LOC when computing logicLoc = code + testDiscount * test."),
+  absoluteHardLoc: z.number().int().positive().default(2000).describe("Whole-PR logic-LOC ceiling; blocks with no waiver possible above this, for any tier."),
+  tiers: SizeTiersConfig.default({}).describe("Per-tier soft/waiver/slice thresholds and path patterns."),
+});
+
 const GatesConfig = z.strictObject({
   draft: GateConfig.optional(),
+  // Fail-closed PR size/tier budget (active by default). Computation lives in
+  // scripts/loop/check-size-budget.mjs; this config carries only the
+  // thresholds and tier patterns it reads.
+  size: SizeConfig.optional(),
   // `requireCi` is honored on both gates: default true keeps CI a precondition,
   // false is an opt-out escape hatch so a repo with no CI is not held at the
   // gate. The pre-approval gate mirrors the draft gate's `requireCi` semantics —
@@ -778,6 +807,7 @@ const FileGatesConfig = z.strictObject({
   draft: GateConfig.partial().describe("Draft gate config (runs before a PR leaves draft).").optional(),
   preApproval: GateConfig.partial().describe("Pre-approval gate config (final re-review before the merge handoff).").optional(),
   spike: GateConfig.partial().describe("Relaxed spike gate profile; applies only to spike-mode work.").optional(),
+  size: SizeConfig.partial().describe("Fail-closed PR size/tier budget: testDiscount, absoluteHardLoc, and per-tier soft/waiver/slice thresholds + patterns.").optional(),
   requireFanoutEvidence: z.boolean().describe("Require fan-out/fan-in review evidence on gate verdicts; inline single-agent verdicts are rejected except under the strict light-mode exception (under-threshold scope, no gate:full label, recorded inline reason).").optional(),
   requireFanoutProvenance: z.boolean().describe("Additionally require recorded, internally-consistent fan-out provenance (distinct reviewer count + per-angle dispatch).").optional(),
   maxFanoutReviewers: z.number().int().min(1).max(64).describe("SUPERSEDED by gates.fanout.maxConcurrent (#1601, ADR 0048): no longer governs fan-out dispatch — the conductor dispatches wave-by-wave at most gates.fanout.maxConcurrent (M) dispatch units per wave via scheduleFanoutWaves (the wave plan emitted by write-gate-context.mjs). Kept for back-compat; setting it has no dispatch effect.").optional(),

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -356,6 +356,14 @@ function rejectDuplicateFanoutGroupNames(val, ctx) {
 // by path glob; the default tier is implicit for every file matching
 // neither, so it carries no `patterns` field of its own. `sliceHardLoc`
 // (t1 only) caps the T1-slice LOC, not the whole-PR LOC.
+//
+// Per-tier `softLoc`/`waiverLoc` on t1/t3, and `sliceHardLoc` on t3, are a
+// later phase's escalation surface (e.g. a t3 "relaxed" tier with its own
+// softLoc, or a t1 slice with its own waiver ceiling) — not honored by
+// computeSizeBudget yet, so they are parked out of the schema for Phase 1
+// rather than shipped as inert accepted-but-ignored knobs. Only the
+// default tier's softLoc/waiverLoc and t1's sliceHardLoc drive Phase 1's
+// outcome; see check-size-budget.mjs.
 const SizeTierConfig = z.strictObject({
   patterns: z.array(z.string().trim().min(1)).optional().describe("Glob-style path patterns; a changed file matching one resolves to this tier."),
   softLoc: z.number().int().positive().nullable().optional().describe("Escalate above this many logic LOC; null disables the soft threshold for this tier."),
@@ -365,8 +373,8 @@ const SizeTierConfig = z.strictObject({
 
 const SizeTiersConfig = z.strictObject({
   default: SizeTierConfig.omit({ patterns: true, sliceHardLoc: true }).default({ softLoc: 400, waiverLoc: 1500 }).describe("Fallback tier applied to every changed file that matches no t1/t3 pattern."),
-  t1: SizeTierConfig.optional().describe("Risk-slice tier (money/auth/shared/ungated paths). Empty by default — a repo defines its own patterns; the T1 slice is computed separately from whole-PR LOC."),
-  t3: SizeTierConfig.optional().describe("Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies."),
+  t1: SizeTierConfig.omit({ softLoc: true, waiverLoc: true }).optional().describe("Risk-slice tier (money/auth/shared/ungated paths). Empty by default — a repo defines its own patterns; the T1 slice is computed separately from whole-PR LOC."),
+  t3: SizeTierConfig.pick({ patterns: true }).optional().describe("Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies. Per-tier soft/waiver thresholds are not yet honored (Phase 1)."),
 });
 
 const SizeConfig = z.strictObject({

--- a/packages/core/src/config/extension-defaults.yaml
+++ b/packages/core/src/config/extension-defaults.yaml
@@ -165,6 +165,17 @@ gates:
     #     - name: docs-only
     #       match: { kinds: [docs] }
     #       angles: [pr-description, link-check, gate-evidence]
+  # Fail-closed PR size/tier budget (Phase 1: computation only, via
+  # scripts/loop/check-size-budget.mjs — not yet wired into any gate). Empty
+  # t1/t3 — no shipped tier patterns; a repo defines its own risk-slice
+  # (money/auth/shared) and relaxed (scaffold/template) globs in .devloops.
+  size:
+    testDiscount: 0.25
+    absoluteHardLoc: 2000
+    tiers:
+      default:
+        softLoc: 400
+        waiverLoc: 1500
   # The gate round's verdict review already carries every finding, so the
   # consolidated findings comment is opt-in duplication — keep it off.
   postFindingsComments: false

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -545,6 +545,37 @@ describe("schema validation", () => {
     }).success);
   });
 
+  // gates.size (fail-closed PR size/tier budget, Phase 1 — check-size-budget.mjs's
+  // pure computation; no enforcement wiring yet). See extension-defaults.yaml
+  // for the shipped defaults and BUILT_IN_DEFAULTS tests below for AC7.
+  test("S37: gates.size accepts full tier config (t1 patterns + sliceHardLoc, t3 patterns)", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: {
+        size: {
+          testDiscount: 0.25,
+          absoluteHardLoc: 2000,
+          tiers: {
+            default: { softLoc: 400, waiverLoc: 1500 },
+            t1: { patterns: ["app/models/subscription*", "config/routes.rb"], sliceHardLoc: 400 },
+            t3: { patterns: ["app/frontends/*"], softLoc: null },
+          },
+        },
+      },
+    });
+    assert.ok(result.success);
+    assert.deepEqual(result.data.gates.size.tiers.t1.patterns, ["app/models/subscription*", "config/routes.rb"]);
+    assert.equal(result.data.gates.size.tiers.t3.softLoc, null);
+  });
+
+  test("S38: gates.size rejects an unknown key (strict schema)", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { size: { testDiscount: 0.25, bogusKey: true } },
+    });
+    assert.ok(!result.success);
+  });
+
 });
 
 // ============================================================================
@@ -648,6 +679,22 @@ describe("loader — graceful degradation", () => {
       assert.ok(result.config);
       assert.equal(result.config.version, 1);
       assert.ok(result.warnings.length > 0, "should warn about missing config");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("L1b: gates.size shipped defaults are active with empty t1/t3 (AC7)", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "devloop-config-size-budget-"));
+    try {
+      const { loadDevLoopConfig } = await import("../src/config/config.mjs");
+      const result = await loadDevLoopConfig({ repoRoot: tmpDir });
+      assert.deepEqual(result.errors, []);
+      assert.deepEqual(result.config.gates.size, {
+        testDiscount: 0.25,
+        absoluteHardLoc: 2000,
+        tiers: { default: { softLoc: 400, waiverLoc: 1500 } },
+      });
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -558,14 +558,29 @@ describe("schema validation", () => {
           tiers: {
             default: { softLoc: 400, waiverLoc: 1500 },
             t1: { patterns: ["app/models/subscription*", "config/routes.rb"], sliceHardLoc: 400 },
-            t3: { patterns: ["app/frontends/*"], softLoc: null },
+            t3: { patterns: ["app/frontends/*"] },
           },
         },
       },
     });
     assert.ok(result.success);
     assert.deepEqual(result.data.gates.size.tiers.t1.patterns, ["app/models/subscription*", "config/routes.rb"]);
-    assert.equal(result.data.gates.size.tiers.t3.softLoc, null);
+    assert.deepEqual(result.data.gates.size.tiers.t3.patterns, ["app/frontends/*"]);
+  });
+
+  test("S37b: gates.size rejects t1/t3 per-tier softLoc/waiverLoc, and t3 sliceHardLoc (not honored in Phase 1)", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { size: { tiers: { t1: { patterns: ["app/models/*"], softLoc: 400 } } } },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { size: { tiers: { t3: { patterns: ["app/frontends/*"], softLoc: null } } } },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      gates: { size: { tiers: { t3: { patterns: ["app/frontends/*"], sliceHardLoc: 400 } } } },
+    }).success);
   });
 
   test("S38: gates.size rejects an unknown key (strict schema)", () => {

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -794,30 +794,6 @@
                         "minLength": 1
                       }
                     },
-                    "softLoc": {
-                      "description": "Escalate above this many logic LOC; null disables the soft threshold for this tier.",
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "waiverLoc": {
-                      "description": "Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier.",
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "sliceHardLoc": {
                       "description": "T1 only: block above this many T1-slice logic LOC unless waived by a named human approver.",
                       "type": "integer",
@@ -827,7 +803,7 @@
                   "additionalProperties": false
                 },
                 "t3": {
-                  "description": "Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies.",
+                  "description": "Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies. Per-tier soft/waiver thresholds are not yet honored (Phase 1).",
                   "type": "object",
                   "properties": {
                     "patterns": {
@@ -837,35 +813,6 @@
                         "type": "string",
                         "minLength": 1
                       }
-                    },
-                    "softLoc": {
-                      "description": "Escalate above this many logic LOC; null disables the soft threshold for this tier.",
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "waiverLoc": {
-                      "description": "Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier.",
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "sliceHardLoc": {
-                      "description": "T1 only: block above this many T1-slice logic LOC unless waived by a named human approver.",
-                      "type": "integer",
-                      "exclusiveMinimum": 0
                     }
                   },
                   "additionalProperties": false

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -726,6 +726,157 @@
           "additionalProperties": false,
           "description": "Relaxed spike gate profile; applies only to spike-mode work."
         },
+        "size": {
+          "type": "object",
+          "properties": {
+            "testDiscount": {
+              "default": 0.25,
+              "description": "Weight applied to test LOC when computing logicLoc = code + testDiscount * test.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "absoluteHardLoc": {
+              "default": 2000,
+              "description": "Whole-PR logic-LOC ceiling; blocks with no waiver possible above this, for any tier.",
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "tiers": {
+              "default": {},
+              "description": "Per-tier soft/waiver/slice thresholds and path patterns.",
+              "type": "object",
+              "properties": {
+                "default": {
+                  "default": {
+                    "softLoc": 400,
+                    "waiverLoc": 1500
+                  },
+                  "description": "Fallback tier applied to every changed file that matches no t1/t3 pattern.",
+                  "type": "object",
+                  "properties": {
+                    "softLoc": {
+                      "description": "Escalate above this many logic LOC; null disables the soft threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "waiverLoc": {
+                      "description": "Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "t1": {
+                  "description": "Risk-slice tier (money/auth/shared/ungated paths). Empty by default — a repo defines its own patterns; the T1 slice is computed separately from whole-PR LOC.",
+                  "type": "object",
+                  "properties": {
+                    "patterns": {
+                      "description": "Glob-style path patterns; a changed file matching one resolves to this tier.",
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "softLoc": {
+                      "description": "Escalate above this many logic LOC; null disables the soft threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "waiverLoc": {
+                      "description": "Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sliceHardLoc": {
+                      "description": "T1 only: block above this many T1-slice logic LOC unless waived by a named human approver.",
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "t3": {
+                  "description": "Relaxed tier (e.g. scaffold/template clones). Empty by default — a repo defines its own patterns; the absolute ceiling still applies.",
+                  "type": "object",
+                  "properties": {
+                    "patterns": {
+                      "description": "Glob-style path patterns; a changed file matching one resolves to this tier.",
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "softLoc": {
+                      "description": "Escalate above this many logic LOC; null disables the soft threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "waiverLoc": {
+                      "description": "Block (waiver required) above this many logic LOC, up to absoluteHardLoc; null disables the waiver threshold for this tier.",
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sliceHardLoc": {
+                      "description": "T1 only: block above this many T1-slice logic LOC unless waived by a named human approver.",
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Fail-closed PR size/tier budget: testDiscount, absoluteHardLoc, and per-tier soft/waiver/slice thresholds + patterns."
+        },
         "requireFanoutEvidence": {
           "type": "boolean",
           "description": "Require fan-out/fan-in review evidence on gate verdicts; inline single-agent verdicts are rejected except under the strict light-mode exception (under-threshold scope, no gate:full label, recorded inline reason)."

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+/**
+ * check-size-budget
+ *
+ * Fail-closed PR size/tier budget — Phase 1: PURE COMPUTATION ONLY. This
+ * module has no enforcement wiring (that is a later phase's `readyForReview()`
+ * / `pre-pr-ready-gate.mjs` change); it computes `logicLoc`, resolves the
+ * file→tier mapping from `gates.size` config, and emits an outcome
+ * (`pass` | `escalate` | `block`) plus the reasons that produced it.
+ *
+ * `logicLoc = code + testDiscount * test`, summed from the existing diff
+ * classifier's per-file category (@dev-loops/core/analysis/diff-analyzer):
+ * only files that classify as `code` or `test` contribute — a file
+ * classifying as `config`/`docs`/`ci`/`unknown` (which already covers
+ * lockfiles and other generated/non-review-worthy content) contributes 0,
+ * reusing the classifier's own signal rather than re-deriving one.
+ *
+ * The T1-slice LOC is the same computation restricted to files whose path
+ * resolves to the `t1` tier (via configured glob patterns) — computed
+ * separately from the whole-PR total so a large PR with a small, isolated
+ * risk slice does not get penalized for its bulk, and a small PR with an
+ * oversize risk slice cannot hide inside an otherwise-small diff.
+ */
+import { execFileSync } from "node:child_process";
+import { parseArgs } from "node:util";
+
+import { analyzeDiff, classifyFile } from "@dev-loops/core/analysis/diff-analyzer";
+import { loadDevLoopConfig } from "@dev-loops/core/config";
+
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { gitEnvWithoutDirOverrides } from "../github/write-gate-context.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage: check-size-budget.mjs --base <ref> [--head <ref>] [--waived] [--approved-by <name>]
+
+Fail-closed PR size/tier budget: PURE COMPUTATION only (no enforcement —
+this script does not block \`gh pr ready\`; a later phase wires it into
+readyForReview()/pre-pr-ready-gate.mjs). Reads gates.size config, computes
+logicLoc = code + testDiscount * test from the existing diff classifier
+(generated/lockfile content excluded via the classifier's own category
+signal), resolves each changed file's tier from configured path patterns,
+and emits pass | escalate | block.
+
+Required:
+  --base <ref>          Git ref to diff against (git diff <ref>...<head>)
+
+Optional:
+  --head <ref>          Git ref for the PR head (default: HEAD)
+  --waived              Record that a size-budget waiver was granted for
+                         this computation (the ready-for-review.mjs waiver
+                         CLI surface itself is a later phase; this flag only
+                         feeds the outcome computation)
+  --approved-by <name>  Named human approver; REQUIRED for a valid T1-slice
+                         waiver (a default-tier waiver needs only --waived)
+  --help, -h             Show this help
+
+Output (stdout, JSON):
+  {
+    "ok": true|false,
+    "outcome": "pass"|"escalate"|"block",
+    "wholeLogicLoc": 120,
+    "t1SliceLoc": 0,
+    "tierLogicLoc": { "default": 120, "t1": 0, "t3": 0 },
+    "thresholds": { "testDiscount": 0.25, "absoluteHardLoc": 2000,
+                     "default": { "softLoc": 400, "waiverLoc": 1500 },
+                     "t1": null },
+    "ambiguous": false,
+    "configErrorCount": 0,
+    "waiver": { "requested": false, "approvedBy": null, "t1Valid": false, "defaultValid": false },
+    "reasons": []
+  }
+
+${JQ_OUTPUT_USAGE}
+
+Exit codes:
+  0  outcome: pass
+  1  outcome: escalate or block
+  2  Argument/runtime error, or invalid --jq filter`;
+
+const parseError = buildParseError(USAGE);
+
+// ---------------------------------------------------------------------------
+// Glob-style path-pattern matching (gates.size.tiers.{t1,t3}.patterns).
+// A minimal shell-glob subset: "**" matches across "/" (any depth), a single
+// "*" matches within one path segment, everything else is literal. This is
+// deliberately not a full glob library — the config's own examples
+// ("app/models/subscription*", "config/routes.rb") only need this subset,
+// and no glob dependency is installed in this repo.
+// ---------------------------------------------------------------------------
+
+function escapeGlobLiteral(ch) {
+  return /[.*+?^${}()|[\]\\]/.test(ch) ? `\\${ch}` : ch;
+}
+
+function globToRegExp(pattern) {
+  let re = "";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      if (pattern[i + 1] === "*") {
+        re += ".*";
+        i += 1;
+      } else {
+        re += "[^/]*";
+      }
+    } else {
+      re += escapeGlobLiteral(ch);
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+export function matchesGlob(filePath, pattern) {
+  if (typeof filePath !== "string" || typeof pattern !== "string" || pattern.length === 0) return false;
+  return globToRegExp(pattern).test(filePath);
+}
+
+function matchesAnyPattern(filePath, patterns) {
+  return Array.isArray(patterns) && patterns.some((p) => matchesGlob(filePath, p));
+}
+
+/**
+ * Resolve a changed file's size-budget tier from `gates.size.tiers`. t1 wins
+ * over t3 when a file (implausibly) matches both, since t1 is the risk-slice
+ * tier the absolute/slice caps are meant to catch. A file matching neither
+ * configured tier's patterns falls through to `default` — the implicit
+ * catch-all tier, which is why `tiers.default` carries no `patterns` field
+ * of its own.
+ */
+export function resolveFileTier(filePath, tiers = {}) {
+  if (matchesAnyPattern(filePath, tiers?.t1?.patterns)) return "t1";
+  if (matchesAnyPattern(filePath, tiers?.t3?.patterns)) return "t3";
+  return "default";
+}
+
+// ---------------------------------------------------------------------------
+// `git diff --numstat -z` parsing: NUL-separated records give an unambiguous
+// per-file added/deleted count without reimplementing hunk-level LOC counting
+// (git already computes it). A rename record's third tab-separated field is
+// empty, signaling that the next two NUL-separated tokens are the old and new
+// paths instead of one; a binary file reports "-" for both counts (mapped to
+// 0 — binary content carries no logic-LOC signal, and its diff bytes are not
+// reviewable line-by-line anyway).
+// ---------------------------------------------------------------------------
+
+export function parseNumstatZ(output) {
+  if (typeof output !== "string" || output.length === 0) return [];
+  const tokens = output.split("\0");
+  const files = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const tok = tokens[i];
+    if (tok === "") { i += 1; continue; }
+    const m = /^(\d+|-)\t(\d+|-)\t([\s\S]*)$/.exec(tok);
+    if (!m) { i += 1; continue; }
+    const [, addedRaw, deletedRaw, rest] = m;
+    const added = addedRaw === "-" ? 0 : Number(addedRaw);
+    const deleted = deletedRaw === "-" ? 0 : Number(deletedRaw);
+    if (rest !== "") {
+      files.push({ path: rest, added, deleted });
+      i += 1;
+    } else {
+      // Rename: this record's path is split across the next two NUL-separated
+      // tokens (old, new); the new path is what classifyFile/resolveFileTier
+      // must see (content lands under the new name).
+      const newPath = tokens[i + 2] ?? tokens[i + 1] ?? "";
+      if (newPath) files.push({ path: newPath, added, deleted });
+      i += 3;
+    }
+  }
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Pure computation
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TEST_DISCOUNT = 0.25;
+const DEFAULT_ABSOLUTE_HARD_LOC = 2000;
+const DEFAULT_TIER_DEFAULTS = Object.freeze({ softLoc: 400, waiverLoc: 1500 });
+
+/**
+ * Compute the size-budget outcome for one diff. Pure — no git, no config I/O
+ * — so fixtures can drive every branch directly.
+ *
+ * @param {object} input
+ * @param {string} [input.nameStatusOutput] — `git diff --name-status` output
+ * @param {string} [input.diffOutput] — full unified diff (feeds the change
+ *   classifier's ambiguity detection; per-file LOC comes from numstatOutput)
+ * @param {string} [input.numstatOutput] — `git diff --numstat -z` output
+ * @param {{ testDiscount?: number, absoluteHardLoc?: number, tiers?: { default?: object, t1?: object, t3?: object } }} [input.sizeConfig]
+ * @param {Array<unknown>} [input.configErrors] — `loadDevLoopConfig` errors; non-empty blocks with no waiver
+ * @param {boolean} [input.waived] — a size-budget waiver was granted (grant
+ *   surface itself is a later phase; this is the computation-facing input)
+ * @param {string|null} [input.approvedBy] — named human approver; required
+ *   for a valid T1-slice waiver
+ */
+export function computeSizeBudget({
+  nameStatusOutput = "",
+  diffOutput = "",
+  numstatOutput = "",
+  sizeConfig = {},
+  configErrors = [],
+  waived = false,
+  approvedBy = null,
+} = {}) {
+  const testDiscount = typeof sizeConfig?.testDiscount === "number" ? sizeConfig.testDiscount : DEFAULT_TEST_DISCOUNT;
+  const absoluteHardLoc = typeof sizeConfig?.absoluteHardLoc === "number" ? sizeConfig.absoluteHardLoc : DEFAULT_ABSOLUTE_HARD_LOC;
+  const tiers = sizeConfig?.tiers ?? {};
+  const defaultTier = { ...DEFAULT_TIER_DEFAULTS, ...(tiers.default ?? {}) };
+  const t1Tier = tiers.t1 ?? null;
+
+  const diffAnalysis = analyzeDiff({ nameStatusOutput, diffOutput });
+  const files = parseNumstatZ(numstatOutput);
+
+  let wholeLoc = 0;
+  let t1SliceLoc = 0;
+  const tierLoc = { default: 0, t1: 0, t3: 0 };
+  for (const file of files) {
+    const category = classifyFile(file.path);
+    let logic = 0;
+    if (category === "code") logic = file.added + file.deleted;
+    else if (category === "test") logic = testDiscount * (file.added + file.deleted);
+    else continue; // docs/config/ci/unknown excluded — covers generated/lockfile content
+    const tier = resolveFileTier(file.path, tiers);
+    tierLoc[tier] += logic;
+    wholeLoc += logic;
+    if (tier === "t1") t1SliceLoc += logic;
+  }
+  wholeLoc = Math.round(wholeLoc);
+  t1SliceLoc = Math.round(t1SliceLoc);
+
+  const reasons = [];
+  let outcome = "pass";
+
+  const configErrorCount = Array.isArray(configErrors) ? configErrors.length : 0;
+  if (configErrorCount > 0) {
+    outcome = "block";
+    reasons.push(`config errors present (${configErrorCount}) from loadDevLoopConfig; a broken .devloops must not silently weaken the size gate — no waiver possible`);
+  }
+  if (diffAnalysis.ambiguous) {
+    outcome = "block";
+    reasons.push("diff is unclassifiable (ambiguous change categories); size budget cannot be computed safely — no waiver possible");
+  }
+  if (wholeLoc > absoluteHardLoc) {
+    outcome = "block";
+    reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds absoluteHardLoc (${absoluteHardLoc}); no waiver possible`);
+  }
+
+  let t1WaiverValid = false;
+  if (t1Tier && typeof t1Tier.sliceHardLoc === "number" && t1SliceLoc > t1Tier.sliceHardLoc) {
+    t1WaiverValid = waived === true && typeof approvedBy === "string" && approvedBy.trim().length > 0;
+    if (t1WaiverValid) {
+      reasons.push(`T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); waived by ${approvedBy.trim()}`);
+    } else {
+      outcome = "block";
+      reasons.push(
+        waived === true
+          ? `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); a T1 waiver requires --approved-by naming a human approver`
+          : `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); not waived`,
+      );
+    }
+  }
+
+  let defaultWaiverValid = false;
+  if (typeof defaultTier.waiverLoc === "number" && wholeLoc > defaultTier.waiverLoc) {
+    defaultWaiverValid = waived === true;
+    if (defaultWaiverValid) {
+      reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); waived`);
+    } else {
+      outcome = "block";
+      reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); not waived`);
+    }
+  }
+
+  if (outcome !== "block" && typeof defaultTier.softLoc === "number" && wholeLoc > defaultTier.softLoc) {
+    outcome = "escalate";
+    reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds default.softLoc (${defaultTier.softLoc}); escalating review requirements`);
+  }
+
+  return {
+    ok: outcome === "pass",
+    outcome,
+    wholeLogicLoc: wholeLoc,
+    t1SliceLoc,
+    tierLogicLoc: { default: Math.round(tierLoc.default), t1: Math.round(tierLoc.t1), t3: Math.round(tierLoc.t3) },
+    thresholds: {
+      testDiscount,
+      absoluteHardLoc,
+      default: { softLoc: defaultTier.softLoc ?? null, waiverLoc: defaultTier.waiverLoc ?? null },
+      t1: t1Tier ? { sliceHardLoc: t1Tier.sliceHardLoc ?? null } : null,
+    },
+    ambiguous: diffAnalysis.ambiguous,
+    configErrorCount,
+    waiver: {
+      requested: waived === true,
+      approvedBy: typeof approvedBy === "string" && approvedBy.trim().length > 0 ? approvedBy.trim() : null,
+      t1Valid: t1WaiverValid,
+      defaultValid: defaultWaiverValid,
+    },
+    reasons,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Git capture + CLI
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the three diff views this check needs against `${base}...${head}`:
+ * name-status + full diff (feed the shared classifier's ambiguity check) and
+ * `--numstat -z` (feeds per-file LOC — see parseNumstatZ). Isolated from
+ * ambient git config the same way captureDiffFromBase is (see
+ * scripts/github/write-gate-context.mjs) so the byte-for-byte diff/LOC counts
+ * a run produces don't depend on the operator's local git config.
+ */
+function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), maxBuffer = 64 * 1024 * 1024 }) {
+  const range = `${base}...${head}`;
+  const isolation = [
+    "-c", "color.ui=false",
+    "-c", "color.diff=false",
+    "-c", "core.pager=cat",
+    "-c", "diff.noprefix=false",
+    "-c", "diff.mnemonicPrefix=false",
+    "-c", "diff.renames=true",
+    "-c", "diff.algorithm=myers",
+    "-c", "diff.context=3",
+    "-c", "core.abbrev=12",
+    "-c", "core.autocrlf=false",
+  ];
+  const runGit = (args) => execFileSync("git", [...isolation, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer,
+    env: gitEnvWithoutDirOverrides(),
+  });
+  try {
+    return {
+      nameStatusOutput: runGit(["diff", "--no-ext-diff", "--name-status", range]),
+      diffOutput: runGit(["diff", "--no-ext-diff", range]),
+      numstatOutput: runGit(["diff", "--no-ext-diff", "--numstat", "-z", range]),
+    };
+  } catch (err) {
+    throw new Error(`git diff against --base ${JSON.stringify(base)} failed: ${err?.message ?? err}`);
+  }
+}
+
+export function parseCheckSizeBudgetCliArgs(argv) {
+  const options = { help: false, base: null, head: null, waived: false, approvedBy: null };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      base: { type: "string" },
+      head: { type: "string" },
+      waived: { type: "boolean" },
+      "approved-by": { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") { options.help = true; return options; }
+    if (token.name === "base") { options.base = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "head") { options.head = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "waived") { options.waived = true; continue; }
+    if (token.name === "approved-by") { options.approvedBy = requireTokenValue(token, parseError).trim(); continue; }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (!options.base) throw parseError("check-size-budget requires --base <ref>");
+  // Same denylist rationale as write-gate-context.mjs's normalizeBaseRef: the
+  // git call runs via execFileSync's argv array (no shell), so this only
+  // needs to reject shapes that are unsafe/malformed for OUR "<base>...<head>"
+  // construction, not enumerate every valid git revision grammar.
+  if (options.base.length === 0 || options.base.startsWith("-") || options.base.includes("..")) {
+    throw parseError("--base must be a plausible git ref (no leading '-', no '..')");
+  }
+  return options;
+}
+
+export async function runCli(argv = process.argv.slice(2), { repoRoot = process.cwd() } = {}) {
+  const options = parseCheckSizeBudgetCliArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return { ok: true, help: true };
+  }
+  const { config, errors: configErrors } = await loadDevLoopConfig({ repoRoot });
+  const sizeConfig = config?.gates?.size ?? {};
+  const { nameStatusOutput, diffOutput, numstatOutput } = captureSizeBudgetDiff({
+    base: options.base,
+    head: options.head ?? "HEAD",
+    repoRoot,
+  });
+  const result = computeSizeBudget({
+    nameStatusOutput,
+    diffOutput,
+    numstatOutput,
+    sizeConfig,
+    configErrors,
+    waived: options.waived,
+    approvedBy: options.approvedBy,
+  });
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent });
+  return result;
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error, { usage: USAGE })}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -20,6 +20,12 @@
  * separately from the whole-PR total so a large PR with a small, isolated
  * risk slice does not get penalized for its bulk, and a small PR with an
  * oversize risk slice cannot hide inside an otherwise-small diff.
+ *
+ * The classifier's `code`/`test` extension coverage is JS/TS-only; a diff
+ * whose changed lines are substantially outside that coverage (non-JS
+ * source, or a configured t1/t3 pattern matching a file that classifies
+ * outside code/test) cannot be measured, so it blocks rather than silently
+ * computing a zero — see `substantiallyUnclassified` below.
  */
 import { execFileSync } from "node:child_process";
 import { parseArgs } from "node:util";
@@ -179,6 +185,12 @@ export function parseNumstatZ(output) {
 const DEFAULT_TEST_DISCOUNT = 0.25;
 const DEFAULT_ABSOLUTE_HARD_LOC = 2000;
 const DEFAULT_TIER_DEFAULTS = Object.freeze({ softLoc: 400, waiverLoc: 1500 });
+// Fail-closed threshold for the "substantially unclassified" case: the
+// shared classifier only recognizes JS/TS as `code` (see diff-analyzer.mjs),
+// so a non-JS-source PR (e.g. Ruby) classifies every file `unknown` and would
+// otherwise silently compute logicLoc:0 and pass. Majority-unclassified
+// changed lines means the budget cannot be measured, full stop.
+const UNCLASSIFIED_BLOCK_RATIO = 0.5;
 
 /**
  * Compute the size-budget outcome for one diff. Pure — no git, no config I/O
@@ -217,12 +229,27 @@ export function computeSizeBudget({
   let wholeLoc = 0;
   let t1SliceLoc = 0;
   const tierLoc = { default: 0, t1: 0, t3: 0 };
+  let totalChangedLines = 0;
+  let unclassifiedChangedLines = 0;
+  // A configured t1/t3 pattern is an explicit operator signal that a path is
+  // risk-slice/relaxed-tier; a matching file that classifies outside
+  // code/test still drops its LOC to 0 (docs/config/ci/unknown all excluded
+  // above), which would silently defeat that signal rather than the intended
+  // "code the classifier does not recognize" gap.
+  let tierPatternDroppedToZero = false;
+  const tierPatterns = [...(tiers.t1?.patterns ?? []), ...(tiers.t3?.patterns ?? [])];
   for (const file of files) {
     const category = classifyFile(file.path);
+    const changedLines = file.added + file.deleted;
+    totalChangedLines += changedLines;
     let logic = 0;
-    if (category === "code") logic = file.added + file.deleted;
-    else if (category === "test") logic = testDiscount * (file.added + file.deleted);
-    else continue; // docs/config/ci/unknown excluded — covers generated/lockfile content
+    if (category === "code") logic = changedLines;
+    else if (category === "test") logic = testDiscount * changedLines;
+    else {
+      if (category === "unknown") unclassifiedChangedLines += changedLines;
+      if (changedLines > 0 && matchesAnyPattern(file.path, tierPatterns)) tierPatternDroppedToZero = true;
+      continue; // docs/config/ci/unknown excluded — covers generated/lockfile content
+    }
     const tier = resolveFileTier(file.path, tiers);
     tierLoc[tier] += logic;
     wholeLoc += logic;
@@ -230,6 +257,8 @@ export function computeSizeBudget({
   }
   wholeLoc = Math.round(wholeLoc);
   t1SliceLoc = Math.round(t1SliceLoc);
+  const unclassifiedRatio = totalChangedLines > 0 ? unclassifiedChangedLines / totalChangedLines : 0;
+  const substantiallyUnclassified = unclassifiedRatio > UNCLASSIFIED_BLOCK_RATIO || tierPatternDroppedToZero;
 
   const reasons = [];
   let outcome = "pass";
@@ -243,34 +272,54 @@ export function computeSizeBudget({
     outcome = "block";
     reasons.push("diff is unclassifiable (ambiguous change categories); size budget cannot be computed safely — no waiver possible");
   }
+  if (substantiallyUnclassified) {
+    outcome = "block";
+    reasons.push(
+      tierPatternDroppedToZero
+        ? "a configured t1/t3 pattern matched a file that classifies outside code/test (its logic LOC would silently drop to 0); size budget cannot be computed safely — no waiver possible"
+        : `substantial unclassified/non-JS source (${Math.round(unclassifiedRatio * 100)}% of changed lines); size budget cannot be computed safely — no waiver possible`,
+    );
+  }
   if (wholeLoc > absoluteHardLoc) {
     outcome = "block";
     reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds absoluteHardLoc (${absoluteHardLoc}); no waiver possible`);
   }
 
+  // Every branch above blocks with no waiver possible; a waiver flag must
+  // never read true once one of them has already fired, or a Phase-2
+  // consumer keying off waiver.*Valid could mis-record a hard-blocked PR.
+  const unwaivableBlock = configErrorCount > 0 || diffAnalysis.ambiguous || substantiallyUnclassified || wholeLoc > absoluteHardLoc;
+
   let t1WaiverValid = false;
   if (t1Tier && typeof t1Tier.sliceHardLoc === "number" && t1SliceLoc > t1Tier.sliceHardLoc) {
-    t1WaiverValid = waived === true && typeof approvedBy === "string" && approvedBy.trim().length > 0;
+    const waiverRequestValid = waived === true && typeof approvedBy === "string" && approvedBy.trim().length > 0;
+    t1WaiverValid = waiverRequestValid && !unwaivableBlock;
     if (t1WaiverValid) {
       reasons.push(`T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); waived by ${approvedBy.trim()}`);
     } else {
       outcome = "block";
       reasons.push(
-        waived === true
-          ? `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); a T1 waiver requires --approved-by naming a human approver`
-          : `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); not waived`,
+        waiverRequestValid && unwaivableBlock
+          ? `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); no waiver possible alongside an unwaivable block`
+          : waived === true
+            ? `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); a T1 waiver requires --approved-by naming a human approver`
+            : `T1-slice logic LOC (${t1SliceLoc}) exceeds t1.sliceHardLoc (${t1Tier.sliceHardLoc}); not waived`,
       );
     }
   }
 
   let defaultWaiverValid = false;
   if (typeof defaultTier.waiverLoc === "number" && wholeLoc > defaultTier.waiverLoc) {
-    defaultWaiverValid = waived === true;
+    defaultWaiverValid = waived === true && !unwaivableBlock;
     if (defaultWaiverValid) {
       reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); waived`);
     } else {
       outcome = "block";
-      reasons.push(`whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); not waived`);
+      reasons.push(
+        waived === true && unwaivableBlock
+          ? `whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); no waiver possible alongside an unwaivable block`
+          : `whole-PR logic LOC (${wholeLoc}) exceeds default.waiverLoc (${defaultTier.waiverLoc}); not waived`,
+      );
     }
   }
 
@@ -346,6 +395,12 @@ function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), 
   }
 }
 
+function assertPlausibleRef(ref, label, onError) {
+  if (ref.length === 0 || ref.startsWith("-") || ref.includes("..")) {
+    throw onError(`${label} must be a plausible git ref (no leading '-', no '..')`);
+  }
+}
+
 export function parseCheckSizeBudgetCliArgs(argv) {
   const options = { help: false, base: null, head: null, waived: false, approvedBy: null };
   const { tokens } = parseArgs({
@@ -377,10 +432,10 @@ export function parseCheckSizeBudgetCliArgs(argv) {
   // Same denylist rationale as write-gate-context.mjs's normalizeBaseRef: the
   // git call runs via execFileSync's argv array (no shell), so this only
   // needs to reject shapes that are unsafe/malformed for OUR "<base>...<head>"
-  // construction, not enumerate every valid git revision grammar.
-  if (options.base.length === 0 || options.base.startsWith("-") || options.base.includes("..")) {
-    throw parseError("--base must be a plausible git ref (no leading '-', no '..')");
-  }
+  // construction, not enumerate every valid git revision grammar. --head feeds
+  // the identical range construction, so it gets the same denylist.
+  assertPlausibleRef(options.base, "--base", parseError);
+  if (options.head) assertPlausibleRef(options.head, "--head", parseError);
   return options;
 }
 

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -88,38 +88,63 @@ const parseError = buildParseError(USAGE);
 
 // ---------------------------------------------------------------------------
 // Glob-style path-pattern matching (gates.size.tiers.{t1,t3}.patterns).
-// A minimal shell-glob subset: "**" matches across "/" (any depth), a single
-// "*" matches within one path segment, everything else is literal. This is
-// deliberately not a full glob library — the config's own examples
-// ("app/models/subscription*", "config/routes.rb") only need this subset,
-// and no glob dependency is installed in this repo.
+// A minimal shell-glob subset, standard globstar semantics: a "**/" sequence
+// matches zero-or-more whole path segments (so "src/**/foo.js" matches both
+// "src/foo.js" and "src/a/b/foo.js"), a lone "**" (not followed by "/")
+// matches any suffix including "/", a single "*" matches within one path
+// segment only, everything else is literal. This is deliberately not a full
+// glob library — the config's own examples ("app/models/subscription*",
+// "config/routes.rb") only need this subset, and no glob dependency is
+// installed in this repo.
+//
+// Git can report backslash-separated paths on Windows; both the pattern
+// (written with "/") and the candidate path are separator-normalized before
+// matching so a tier pattern still resolves regardless of platform.
+//
+// Compiled patterns are cached by (normalized) pattern string — a large PR
+// with many changed files re-tests the same handful of configured patterns
+// per file, so recompiling the regex per file would be wasted work.
 // ---------------------------------------------------------------------------
 
 function escapeGlobLiteral(ch) {
   return /[.*+?^${}()|[\]\\]/.test(ch) ? `\\${ch}` : ch;
 }
 
+function normalizePathSeparators(value) {
+  return value.replace(/\\/g, "/");
+}
+
+const globPatternCache = new Map();
+
 function globToRegExp(pattern) {
+  const normalizedPattern = normalizePathSeparators(pattern);
+  const cached = globPatternCache.get(normalizedPattern);
+  if (cached) return cached;
   let re = "";
-  for (let i = 0; i < pattern.length; i += 1) {
-    const ch = pattern[i];
-    if (ch === "*") {
-      if (pattern[i + 1] === "*") {
-        re += ".*";
-        i += 1;
+  for (let i = 0; i < normalizedPattern.length; i += 1) {
+    const ch = normalizedPattern[i];
+    if (ch === "*" && normalizedPattern[i + 1] === "*") {
+      if (normalizedPattern[i + 2] === "/") {
+        re += "(?:.*/)?"; // "**/" — zero or more whole path segments
+        i += 2; // consume the second "*" and the "/"
       } else {
-        re += "[^/]*";
+        re += ".*"; // lone "**" — any suffix, including "/"
+        i += 1; // consume the second "*"
       }
+    } else if (ch === "*") {
+      re += "[^/]*"; // single "*" — within one path segment only
     } else {
       re += escapeGlobLiteral(ch);
     }
   }
-  return new RegExp(`^${re}$`);
+  const compiled = new RegExp(`^${re}$`);
+  globPatternCache.set(normalizedPattern, compiled);
+  return compiled;
 }
 
 export function matchesGlob(filePath, pattern) {
   if (typeof filePath !== "string" || typeof pattern !== "string" || pattern.length === 0) return false;
-  return globToRegExp(pattern).test(filePath);
+  return globToRegExp(pattern).test(normalizePathSeparators(filePath));
 }
 
 function matchesAnyPattern(filePath, patterns) {
@@ -226,8 +251,6 @@ export function computeSizeBudget({
   const diffAnalysis = analyzeDiff({ nameStatusOutput, diffOutput });
   const files = parseNumstatZ(numstatOutput);
 
-  let wholeLoc = 0;
-  let t1SliceLoc = 0;
   const tierLoc = { default: 0, t1: 0, t3: 0 };
   // Denominator for the unclassified-ratio fail-closed check: source-like
   // changed lines only (code + test + unknown). docs/config/ci are
@@ -262,11 +285,21 @@ export function computeSizeBudget({
     }
     const tier = resolveFileTier(file.path, tiers);
     tierLoc[tier] += logic;
-    wholeLoc += logic;
-    if (tier === "t1") t1SliceLoc += logic;
   }
-  wholeLoc = Math.round(wholeLoc);
-  t1SliceLoc = Math.round(t1SliceLoc);
+  // Round each tier's unrounded subtotal once, then derive wholeLogicLoc as
+  // the SUM of the rounded tiers rather than independently rounding the
+  // unrounded total — otherwise fractional per-tier subtotals (testDiscount
+  // applied per test file) can round down to 0 in each tier while their sum
+  // rounds up to 1, leaving the reported breakdown unable to reconcile with
+  // wholeLogicLoc. Summing the already-rounded tiers keeps the breakdown
+  // additive by construction.
+  const tierLogicLoc = {
+    default: Math.round(tierLoc.default),
+    t1: Math.round(tierLoc.t1),
+    t3: Math.round(tierLoc.t3),
+  };
+  const wholeLoc = tierLogicLoc.default + tierLogicLoc.t1 + tierLogicLoc.t3;
+  const t1SliceLoc = tierLogicLoc.t1;
   const unclassifiedRatio = sourceChangedLines > 0 ? unclassifiedChangedLines / sourceChangedLines : 0;
   const substantiallyUnclassified = unclassifiedRatio > UNCLASSIFIED_BLOCK_RATIO || tierPatternDroppedToZero;
 
@@ -343,7 +376,7 @@ export function computeSizeBudget({
     outcome,
     wholeLogicLoc: wholeLoc,
     t1SliceLoc,
-    tierLogicLoc: { default: Math.round(tierLoc.default), t1: Math.round(tierLoc.t1), t3: Math.round(tierLoc.t3) },
+    tierLogicLoc,
     thresholds: {
       testDiscount,
       absoluteHardLoc,

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -229,7 +229,13 @@ export function computeSizeBudget({
   let wholeLoc = 0;
   let t1SliceLoc = 0;
   const tierLoc = { default: 0, t1: 0, t3: 0 };
-  let totalChangedLines = 0;
+  // Denominator for the unclassified-ratio fail-closed check: source-like
+  // changed lines only (code + test + unknown). docs/config/ci are
+  // legitimately-zero-LOC categories the classifier already excludes from
+  // logicLoc; counting them here would let padding a non-JS-source PR with
+  // docs/config dilute the unclassified fraction below the block threshold
+  // while wholeLogicLoc stays silently at (or near) 0.
+  let sourceChangedLines = 0;
   let unclassifiedChangedLines = 0;
   // A configured t1/t3 pattern is an explicit operator signal that a path is
   // risk-slice/relaxed-tier; a matching file that classifies outside
@@ -241,12 +247,16 @@ export function computeSizeBudget({
   for (const file of files) {
     const category = classifyFile(file.path);
     const changedLines = file.added + file.deleted;
-    totalChangedLines += changedLines;
+    if (category === "unknown") {
+      sourceChangedLines += changedLines;
+      unclassifiedChangedLines += changedLines;
+    } else if (category === "code" || category === "test") {
+      sourceChangedLines += changedLines;
+    }
     let logic = 0;
     if (category === "code") logic = changedLines;
     else if (category === "test") logic = testDiscount * changedLines;
     else {
-      if (category === "unknown") unclassifiedChangedLines += changedLines;
       if (changedLines > 0 && matchesAnyPattern(file.path, tierPatterns)) tierPatternDroppedToZero = true;
       continue; // docs/config/ci/unknown excluded — covers generated/lockfile content
     }
@@ -257,7 +267,7 @@ export function computeSizeBudget({
   }
   wholeLoc = Math.round(wholeLoc);
   t1SliceLoc = Math.round(t1SliceLoc);
-  const unclassifiedRatio = totalChangedLines > 0 ? unclassifiedChangedLines / totalChangedLines : 0;
+  const unclassifiedRatio = sourceChangedLines > 0 ? unclassifiedChangedLines / sourceChangedLines : 0;
   const substantiallyUnclassified = unclassifiedRatio > UNCLASSIFIED_BLOCK_RATIO || tierPatternDroppedToZero;
 
   const reasons = [];
@@ -277,7 +287,7 @@ export function computeSizeBudget({
     reasons.push(
       tierPatternDroppedToZero
         ? "a configured t1/t3 pattern matched a file that classifies outside code/test (its logic LOC would silently drop to 0); size budget cannot be computed safely — no waiver possible"
-        : `substantial unclassified/non-JS source (${Math.round(unclassifiedRatio * 100)}% of changed lines); size budget cannot be computed safely — no waiver possible`,
+        : `substantial unclassified/non-JS source (${Math.round(unclassifiedRatio * 100)}% of source-like changed lines); size budget cannot be computed safely — no waiver possible`,
     );
   }
   if (wholeLoc > absoluteHardLoc) {

--- a/scripts/loop/sanctioned-commands.mjs
+++ b/scripts/loop/sanctioned-commands.mjs
@@ -34,6 +34,7 @@ export const SANCTIONED_COMMANDS = Object.freeze({
     "review-threads": "scripts/github/list-review-threads.mjs",
     "gate-coordination": "scripts/loop/detect-pr-gate-coordination-state.mjs",
     "agent-stall": "scripts/loop/detect-agent-stall.mjs",
+    "size-budget": "scripts/loop/check-size-budget.mjs",
   }),
 
   // Metadata edits.

--- a/test/loop/check-size-budget.test.mjs
+++ b/test/loop/check-size-budget.test.mjs
@@ -62,6 +62,21 @@ test("matchesGlob: '**' matches across path segments", () => {
   assert.equal(matchesGlob("app/frontends/index.js", "app/frontends/**"), true);
 });
 
+test("matchesGlob: 'src/**/foo.js' globstar matches zero-or-more segments (including zero)", () => {
+  assert.equal(matchesGlob("src/foo.js", "src/**/foo.js"), true);
+  assert.equal(matchesGlob("src/a/b/foo.js", "src/**/foo.js"), true);
+});
+
+test("matchesGlob: single '*' stays within one segment even with a trailing extension", () => {
+  assert.equal(matchesGlob("app/models/x.rb", "app/models/*.rb"), true);
+  assert.equal(matchesGlob("app/models/sub/x.rb", "app/models/*.rb"), false);
+});
+
+test("matchesGlob: a backslash-separated candidate path matches a '/'-written pattern", () => {
+  assert.equal(matchesGlob("src\\billing\\charge.mjs", "src/billing/*"), true);
+  assert.equal(matchesGlob("src\\a\\b\\foo.js", "src/**/foo.js"), true);
+});
+
 test("resolveFileTier: t1 pattern wins over t3, unmatched falls to default", () => {
   const tiers = {
     t1: { patterns: ["src/billing/*"] },
@@ -332,6 +347,33 @@ test("t3 tier: a file matching a configured t3 pattern resolves its LOC under ti
   assert.equal(result.outcome, "escalate");
   assert.equal(result.tierLogicLoc.t3, 900);
   assert.equal(result.tierLogicLoc.default, 0);
+});
+
+test("tierLogicLoc reconciles with wholeLogicLoc across tiers under a fractional testDiscount", () => {
+  // Two test-only files, each contributing testDiscount(0.25) * 2 lines = 0.5
+  // logic LOC — one in the default tier, one in t1 (src/billing/*). Rounding
+  // each tier's 0.5 subtotal independently (Math.round -> 1 each) and summing
+  // the rounded tiers gives wholeLogicLoc = 2, which is what this asserts.
+  // Rounding the RAW total (0.5 + 0.5 = 1.0) instead would have produced
+  // wholeLogicLoc = 1, unable to reconcile with a tier breakdown of 1 + 1.
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.test.mjs\nM\tsrc/billing/charge.test.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([
+      [2, 0, "src/foo.test.mjs"],
+      [2, 0, "src/billing/charge.test.mjs"],
+    ]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.tierLogicLoc.default, 1);
+  assert.equal(result.tierLogicLoc.t1, 1);
+  assert.equal(result.tierLogicLoc.t3, 0);
+  assert.equal(result.wholeLogicLoc, 2);
+  assert.equal(
+    result.wholeLogicLoc,
+    result.tierLogicLoc.default + result.tierLogicLoc.t1 + result.tierLogicLoc.t3,
+  );
+  assert.equal(result.t1SliceLoc, result.tierLogicLoc.t1);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/loop/check-size-budget.test.mjs
+++ b/test/loop/check-size-budget.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computeSizeBudget,
+  matchesGlob,
+  parseNumstatZ,
+  resolveFileTier,
+} from "../../scripts/loop/check-size-budget.mjs";
+
+// ---------------------------------------------------------------------------
+// Fixtures — small, realistic diff/name-status/numstat inputs. A MIXED diff
+// (code + test files present) needs real hunk content so the shared
+// classifier (analyzeDiff) doesn't fall back to "ambiguous"; a single-
+// category diff needs none (T0-only inference already resolves it).
+// ---------------------------------------------------------------------------
+
+const MIXED_DIFF = `diff --git a/src/foo.mjs b/src/foo.mjs
+index aaa..bbb 100644
+--- a/src/foo.mjs
++++ b/src/foo.mjs
+@@ -1,2 +1,5 @@
+ function foo() {
++  doWork();
++  doMoreWork();
++  doEvenMoreWork();
+   return 1;
+ }
+diff --git a/test/foo.test.mjs b/test/foo.test.mjs
+index ccc..ddd 100644
+--- a/test/foo.test.mjs
++++ b/test/foo.test.mjs
+@@ -1,1 +1,3 @@
+ test("foo", () => {
++  assert.equal(foo(), 1);
++  assert.ok(true);
+ });
+`;
+const MIXED_NAME_STATUS = "M\tsrc/foo.mjs\nM\ttest/foo.test.mjs\n";
+
+function numstatZ(entries) {
+  return entries.map(([added, deleted, path]) => `${added}\t${deleted}\t${path}`).join("\0") + "\0";
+}
+
+// ---------------------------------------------------------------------------
+// matchesGlob / resolveFileTier
+// ---------------------------------------------------------------------------
+
+test("matchesGlob: literal path matches exactly, nothing else", () => {
+  assert.equal(matchesGlob("config/routes.rb", "config/routes.rb"), true);
+  assert.equal(matchesGlob("config/routes2.rb", "config/routes.rb"), false);
+});
+
+test("matchesGlob: single '*' matches within one path segment only", () => {
+  assert.equal(matchesGlob("app/models/subscription_plan.rb", "app/models/subscription*"), true);
+  assert.equal(matchesGlob("app/models/nested/subscription_plan.rb", "app/models/subscription*"), false);
+});
+
+test("matchesGlob: '**' matches across path segments", () => {
+  assert.equal(matchesGlob("app/frontends/web/index.js", "app/frontends/**"), true);
+  assert.equal(matchesGlob("app/frontends/index.js", "app/frontends/**"), true);
+});
+
+test("resolveFileTier: t1 pattern wins over t3, unmatched falls to default", () => {
+  const tiers = {
+    t1: { patterns: ["src/billing/*"] },
+    t3: { patterns: ["src/scaffold/*"] },
+  };
+  assert.equal(resolveFileTier("src/billing/charge.mjs", tiers), "t1");
+  assert.equal(resolveFileTier("src/scaffold/widget.mjs", tiers), "t3");
+  assert.equal(resolveFileTier("src/other/thing.mjs", tiers), "default");
+});
+
+test("resolveFileTier: no tiers configured -> every file is default", () => {
+  assert.equal(resolveFileTier("src/billing/charge.mjs", {}), "default");
+  assert.equal(resolveFileTier("src/billing/charge.mjs", undefined), "default");
+});
+
+// ---------------------------------------------------------------------------
+// parseNumstatZ
+// ---------------------------------------------------------------------------
+
+test("parseNumstatZ: plain files", () => {
+  const out = parseNumstatZ(numstatZ([[12, 3, "src/foo.mjs"], [10, 0, "test/foo.test.mjs"]]));
+  assert.deepEqual(out, [
+    { path: "src/foo.mjs", added: 12, deleted: 3 },
+    { path: "test/foo.test.mjs", added: 10, deleted: 0 },
+  ]);
+});
+
+test("parseNumstatZ: rename record resolves to the NEW path", () => {
+  const out = parseNumstatZ("0\t0\t\0old.txt\0new.txt\0");
+  assert.deepEqual(out, [{ path: "new.txt", added: 0, deleted: 0 }]);
+});
+
+test("parseNumstatZ: binary file ('-' counts) contributes zero LOC", () => {
+  const out = parseNumstatZ("-\t-\tbin.dat\0");
+  assert.deepEqual(out, [{ path: "bin.dat", added: 0, deleted: 0 }]);
+});
+
+test("parseNumstatZ: empty input -> no files", () => {
+  assert.deepEqual(parseNumstatZ(""), []);
+});
+
+// ---------------------------------------------------------------------------
+// computeSizeBudget — outcomes
+// ---------------------------------------------------------------------------
+
+const SIZE_CONFIG = {
+  testDiscount: 0.25,
+  absoluteHardLoc: 2000,
+  tiers: {
+    default: { softLoc: 400, waiverLoc: 1500 },
+    t1: { patterns: ["src/billing/*"], sliceHardLoc: 400 },
+  },
+};
+
+test("pass: small mixed change stays under softLoc", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[3, 0, "src/foo.mjs"], [2, 0, "test/foo.test.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "pass");
+  assert.equal(result.ok, true);
+  // 3 code + 0.25*2 test = 3.5 -> rounds to 4
+  assert.equal(result.wholeLogicLoc, 4);
+  assert.deepEqual(result.reasons, []);
+});
+
+test("escalate: whole-PR logic LOC over softLoc but within waiverLoc", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[500, 0, "src/foo.mjs"], [40, 0, "test/foo.test.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "escalate");
+  assert.equal(result.ok, false);
+  assert.ok(result.reasons.some((r) => r.includes("default.softLoc")));
+});
+
+test("block, no waiver possible: whole-PR logic LOC over absoluteHardLoc even when waived", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[2500, 0, "src/foo.mjs"], [0, 0, "test/foo.test.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+    approvedBy: "Jane Reviewer",
+  });
+  assert.equal(result.outcome, "block");
+  assert.ok(result.reasons.some((r) => r.includes("absoluteHardLoc") && r.includes("no waiver possible")));
+});
+
+test("block, no waiver possible: config errors present, regardless of waiver", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[3, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    configErrors: [{ path: "gates.size.tiers", message: "invalid" }],
+    waived: true,
+    approvedBy: "Jane Reviewer",
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.configErrorCount, 1);
+  assert.ok(result.reasons.some((r) => r.includes("config errors present")));
+});
+
+test("block, no waiver possible: unclassifiable (ambiguous) diff", () => {
+  // A mixed diff with NO hunk content to classify from (e.g. the best-effort
+  // full-diff capture degraded to empty) is unclassifiable per the shared
+  // classifier — mirrors write-gate-context.mjs's documented degrade path.
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: "",
+    numstatOutput: numstatZ([[3, 0, "src/foo.mjs"], [2, 0, "test/foo.test.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+    approvedBy: "Jane Reviewer",
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.ambiguous, true);
+  assert.ok(result.reasons.some((r) => r.includes("unclassifiable")));
+});
+
+test("block: T1 slice over sliceHardLoc, not waived", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[500, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.t1SliceLoc, 500);
+  assert.ok(result.reasons.some((r) => r.includes("t1.sliceHardLoc") && r.includes("not waived")));
+});
+
+test("T1 waiver WITHOUT a named approver stays blocked", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[500, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+    // approvedBy omitted
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.waiver.t1Valid, false);
+  assert.ok(result.reasons.some((r) => r.includes("requires --approved-by naming a human approver")));
+});
+
+test("T1 waiver WITH a named approver is valid and clears the slice-hard-loc block", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[500, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+    approvedBy: "Jane Reviewer",
+  });
+  // 500 whole-PR logic LOC also exceeds default.softLoc (400), so the waiver
+  // clears the BLOCK but the whole-PR total still escalates on its own.
+  assert.equal(result.outcome, "escalate");
+  assert.equal(result.waiver.t1Valid, true);
+  assert.equal(result.waiver.approvedBy, "Jane Reviewer");
+  assert.ok(result.reasons.some((r) => r.includes("waived by Jane Reviewer")));
+  assert.ok(!result.reasons.some((r) => r.includes("t1.sliceHardLoc") && r.includes("not waived")));
+});
+
+test("default-tier waiver: over waiverLoc blocks when not waived", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[1600, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "block");
+  assert.ok(result.reasons.some((r) => r.includes("default.waiverLoc") && r.includes("not waived")));
+});
+
+test("default-tier waiver: granting it clears the block but the escalation still stands", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: MIXED_NAME_STATUS,
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[1600, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+  });
+  // A waived default-tier over-budget PR still escalates the review contract
+  // (author annotations, human review, no Copilot-clean) — the waiver only
+  // lifts the BLOCK, never the raised bar.
+  assert.equal(result.outcome, "escalate");
+  assert.equal(result.waiver.defaultValid, true);
+  assert.ok(result.reasons.some((r) => r.includes("default.waiverLoc") && r.includes("waived")));
+});
+
+test("t3 tier: relaxed default (softLoc: null) never escalates on LOC alone", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/scaffold/widget.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[900, 0, "src/scaffold/widget.mjs"]]),
+    sizeConfig: {
+      ...SIZE_CONFIG,
+      tiers: { ...SIZE_CONFIG.tiers, default: { softLoc: null, waiverLoc: null } },
+    },
+  });
+  assert.equal(result.outcome, "pass");
+  assert.equal(result.wholeLogicLoc, 900);
+});

--- a/test/loop/check-size-budget.test.mjs
+++ b/test/loop/check-size-budget.test.mjs
@@ -244,6 +244,32 @@ test("T1 waiver WITH a named approver is valid and clears the slice-hard-loc blo
   assert.ok(!result.reasons.some((r) => r.includes("t1.sliceHardLoc") && r.includes("not waived")));
 });
 
+test("a T1 slice over sliceHardLoc alongside an unwaivable block (absoluteHardLoc) blocks with a valid waiver request present, both the T1 and default-tier reason arms name the unwaivable-block collision", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    // 2500 whole-PR logic LOC: over t1.sliceHardLoc (400), over
+    // absoluteHardLoc (2000, unwaivable), and over default.waiverLoc (1500).
+    numstatOutput: numstatZ([[2500, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+    approvedBy: "Jane Reviewer",
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.waiver.t1Valid, false);
+  assert.equal(result.waiver.defaultValid, false);
+  assert.ok(
+    result.reasons.some(
+      (r) => r.includes("t1.sliceHardLoc") && r.includes("no waiver possible alongside an unwaivable block"),
+    ),
+  );
+  assert.ok(
+    result.reasons.some(
+      (r) => r.includes("default.waiverLoc") && r.includes("no waiver possible alongside an unwaivable block"),
+    ),
+  );
+});
+
 test("default-tier waiver: over waiverLoc blocks when not waived", () => {
   const result = computeSizeBudget({
     nameStatusOutput: MIXED_NAME_STATUS,
@@ -390,6 +416,29 @@ test("boundary: t1.sliceHardLoc — AT threshold does not block, ABOVE does", ()
   assert.ok(aboveThreshold.reasons.some((r) => r.includes("t1.sliceHardLoc") && r.includes("not waived")));
 });
 
+test("boundary: UNCLASSIFIED_BLOCK_RATIO (source-like denominator) — AT threshold does not block on it, ABOVE does", () => {
+  // AT: 500 unknown + 500 code -> sourceChangedLines 1000, ratio 500/1000 = 0.5
+  // exactly (strict `>`, so this must not trigger the unclassified block).
+  const atThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tapp/models/thing.rb\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[500, 0, "src/foo.mjs"], [500, 0, "app/models/thing.rb"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.ok(!atThreshold.reasons.some((r) => r.includes("unclassified")));
+
+  // ABOVE: 500 code + 501 unknown -> sourceChangedLines 1001, ratio 501/1001
+  // > 0.5 -> blocks.
+  const aboveThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tapp/models/thing.rb\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[500, 0, "src/foo.mjs"], [501, 0, "app/models/thing.rb"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(aboveThreshold.outcome, "block");
+  assert.ok(aboveThreshold.reasons.some((r) => r.includes("unclassified") && r.includes("no waiver possible")));
+});
+
 // ---------------------------------------------------------------------------
 // computeSizeBudget — generated/lockfile/docs/config exclusion
 // ---------------------------------------------------------------------------
@@ -431,6 +480,30 @@ test("a mostly-JS diff with a little unknown source still computes normally (no 
   });
   assert.equal(result.outcome, "pass");
   assert.equal(result.wholeLogicLoc, 300);
+});
+
+test("a substantially-unclassified diff still blocks when padded with docs+config (docs/config must not dilute the unclassified ratio)", () => {
+  // Same shape as the pure-Ruby-only case above, but padded with docs/config
+  // lines that contribute 0 logicLoc and are NOT source-like: the ratio
+  // denominator is source-like changed lines (code + test + unknown) only,
+  // so this padding must not dilute unclassifiedRatio below the block
+  // threshold. Before the fix, the denominator was ALL changed lines
+  // (300 rb + 300 docs + 100 config = 700, ratio 300/700 = 0.43 -> pass);
+  // after the fix, the denominator is source-like lines only (300 rb,
+  // docs/config excluded), so ratio is 300/300 = 1.0 -> still blocks.
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tapp/models/subscription.rb\nM\tdocs/design.md\nM\tconfig/settings.yml\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([
+      [300, 0, "app/models/subscription.rb"],
+      [300, 0, "docs/design.md"],
+      [100, 0, "config/settings.yml"],
+    ]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.wholeLogicLoc, 0);
+  assert.ok(result.reasons.some((r) => r.includes("unclassified") && r.includes("no waiver possible")));
 });
 
 test("a configured t1 pattern matching a file that classifies unknown (0 LOC) blocks even when unclassified lines are a small share of the diff", () => {

--- a/test/loop/check-size-budget.test.mjs
+++ b/test/loop/check-size-budget.test.mjs
@@ -506,6 +506,23 @@ test("a substantially-unclassified diff still blocks when padded with docs+confi
   assert.ok(result.reasons.some((r) => r.includes("unclassified") && r.includes("no waiver possible")));
 });
 
+test("a docs-only diff (zero source-like changed lines) does not spuriously block as unclassified source", () => {
+  // The unclassifiedRatio guard reads `sourceChangedLines > 0 ? ... : 0`, so a
+  // diff with no code/test/unknown lines must take the zero-source false
+  // branch: ratio 0, no unclassified block, wholeLogicLoc 0, pass. A `: 0`
+  // regressing to `: 1` would spuriously block every docs-only PR — this pins
+  // the fail-open direction of the guard.
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tdocs/design.md\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[300, 0, "docs/design.md"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "pass");
+  assert.equal(result.wholeLogicLoc, 0);
+  assert.ok(!result.reasons.some((r) => r.includes("unclassified")));
+});
+
 test("a configured t1 pattern matching a file that classifies unknown (0 LOC) blocks even when unclassified lines are a small share of the diff", () => {
   const result = computeSizeBudget({
     nameStatusOutput: "M\tsrc/foo.mjs\nM\tsrc/billing/charge.rb\n",

--- a/test/loop/check-size-budget.test.mjs
+++ b/test/loop/check-size-budget.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   computeSizeBudget,
   matchesGlob,
+  parseCheckSizeBudgetCliArgs,
   parseNumstatZ,
   resolveFileTier,
 } from "../../scripts/loop/check-size-budget.mjs";
@@ -69,6 +70,14 @@ test("resolveFileTier: t1 pattern wins over t3, unmatched falls to default", () 
   assert.equal(resolveFileTier("src/billing/charge.mjs", tiers), "t1");
   assert.equal(resolveFileTier("src/scaffold/widget.mjs", tiers), "t3");
   assert.equal(resolveFileTier("src/other/thing.mjs", tiers), "default");
+});
+
+test("resolveFileTier: a file matching BOTH t1 and t3 patterns resolves to t1", () => {
+  const tiers = {
+    t1: { patterns: ["src/billing/*"] },
+    t3: { patterns: ["src/billing/*"] },
+  };
+  assert.equal(resolveFileTier("src/billing/charge.mjs", tiers), "t1");
 });
 
 test("resolveFileTier: no tiers configured -> every file is default", () => {
@@ -152,6 +161,11 @@ test("block, no waiver possible: whole-PR logic LOC over absoluteHardLoc even wh
   });
   assert.equal(result.outcome, "block");
   assert.ok(result.reasons.some((r) => r.includes("absoluteHardLoc") && r.includes("no waiver possible")));
+  // Output-contract: waiver.*Valid must not read true under an unwaivable
+  // ceiling, even though --waived/--approved-by were both given and wholeLoc
+  // (2500) also exceeds default.waiverLoc (1500).
+  assert.equal(result.waiver.defaultValid, false);
+  assert.equal(result.waiver.t1Valid, false);
 });
 
 test("block, no waiver possible: config errors present, regardless of waiver", () => {
@@ -257,7 +271,10 @@ test("default-tier waiver: granting it clears the block but the escalation still
   assert.ok(result.reasons.some((r) => r.includes("default.waiverLoc") && r.includes("waived")));
 });
 
-test("t3 tier: relaxed default (softLoc: null) never escalates on LOC alone", () => {
+test("default tier: relaxed default (softLoc: null) never escalates on LOC alone", () => {
+  // Named for what it actually drives: SIZE_CONFIG has no t3 patterns, so
+  // src/scaffold/widget.mjs resolves to the DEFAULT tier here, not t3 (see
+  // the genuine t3-resolution test below for that case).
   const result = computeSizeBudget({
     nameStatusOutput: "M\tsrc/scaffold/widget.mjs\n",
     diffOutput: "",
@@ -269,4 +286,194 @@ test("t3 tier: relaxed default (softLoc: null) never escalates on LOC alone", ()
   });
   assert.equal(result.outcome, "pass");
   assert.equal(result.wholeLogicLoc, 900);
+  assert.equal(result.tierLogicLoc.default, 900);
+});
+
+test("t3 tier: a file matching a configured t3 pattern resolves its LOC under tierLogicLoc.t3, not default", () => {
+  // wholeLoc (900) is still measured against the DEFAULT tier's softLoc
+  // (400) regardless of which tier the file resolved to — t3 does not give
+  // it a relaxed whole-PR ceiling in Phase 1 (see the config-honesty note on
+  // SizeTierConfig); resolveFileTier still routes its LOC into tierLogicLoc.t3.
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/scaffold/widget.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[900, 0, "src/scaffold/widget.mjs"]]),
+    sizeConfig: {
+      ...SIZE_CONFIG,
+      tiers: { ...SIZE_CONFIG.tiers, t3: { patterns: ["src/scaffold/*"] } },
+    },
+  });
+  assert.equal(result.outcome, "escalate");
+  assert.equal(result.tierLogicLoc.t3, 900);
+  assert.equal(result.tierLogicLoc.default, 0);
+});
+
+// ---------------------------------------------------------------------------
+// computeSizeBudget — boundary values (strict `>`, not `>=`)
+// ---------------------------------------------------------------------------
+
+test("boundary: absoluteHardLoc — AT threshold does not block on it, ABOVE does", () => {
+  const atThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[2000, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true, // clears the default.waiverLoc block this whole-PR total also crosses
+  });
+  assert.ok(!atThreshold.reasons.some((r) => r.includes("absoluteHardLoc")));
+
+  const aboveThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[2001, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+    waived: true,
+  });
+  assert.equal(aboveThreshold.outcome, "block");
+  assert.ok(aboveThreshold.reasons.some((r) => r.includes("absoluteHardLoc") && r.includes("no waiver possible")));
+});
+
+test("boundary: default.waiverLoc — AT threshold does not block, ABOVE does", () => {
+  const atThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[1500, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.ok(!atThreshold.reasons.some((r) => r.includes("default.waiverLoc")));
+
+  const aboveThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[1501, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(aboveThreshold.outcome, "block");
+  assert.ok(aboveThreshold.reasons.some((r) => r.includes("default.waiverLoc") && r.includes("not waived")));
+});
+
+test("boundary: default.softLoc — AT threshold does not escalate, ABOVE does", () => {
+  const atThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[400, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(atThreshold.outcome, "pass");
+
+  const aboveThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[401, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(aboveThreshold.outcome, "escalate");
+  assert.ok(aboveThreshold.reasons.some((r) => r.includes("default.softLoc")));
+});
+
+test("boundary: t1.sliceHardLoc — AT threshold does not block, ABOVE does", () => {
+  const atThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[400, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(atThreshold.outcome, "pass");
+
+  const aboveThreshold = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/billing/charge.mjs\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[401, 0, "src/billing/charge.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(aboveThreshold.outcome, "block");
+  assert.ok(aboveThreshold.reasons.some((r) => r.includes("t1.sliceHardLoc") && r.includes("not waived")));
+});
+
+// ---------------------------------------------------------------------------
+// computeSizeBudget — generated/lockfile/docs/config exclusion
+// ---------------------------------------------------------------------------
+
+test("a lockfile with a large numstat count contributes 0 logic LOC alongside a small code change", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tpackage-lock.json\nM\tsrc/foo.mjs\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[5000, 0, "package-lock.json"], [3, 0, "src/foo.mjs"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "pass");
+  assert.equal(result.wholeLogicLoc, 3);
+  assert.equal(result.tierLogicLoc.default, 3);
+});
+
+// ---------------------------------------------------------------------------
+// computeSizeBudget — fail-closed on substantially unclassified source
+// ---------------------------------------------------------------------------
+
+test("a pure-Ruby-style diff (all files classify unknown) blocks — size budget cannot be computed safely", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tapp/models/subscription.rb\n",
+    diffOutput: "",
+    numstatOutput: numstatZ([[500, 0, "app/models/subscription.rb"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "block");
+  assert.equal(result.wholeLogicLoc, 0);
+  assert.ok(result.reasons.some((r) => r.includes("unclassified") && r.includes("no waiver possible")));
+});
+
+test("a mostly-JS diff with a little unknown source still computes normally (no block)", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tweird/thing.xyz\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[300, 0, "src/foo.mjs"], [10, 0, "weird/thing.xyz"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "pass");
+  assert.equal(result.wholeLogicLoc, 300);
+});
+
+test("a configured t1 pattern matching a file that classifies unknown (0 LOC) blocks even when unclassified lines are a small share of the diff", () => {
+  const result = computeSizeBudget({
+    nameStatusOutput: "M\tsrc/foo.mjs\nM\tsrc/billing/charge.rb\n",
+    diffOutput: MIXED_DIFF,
+    numstatOutput: numstatZ([[500, 0, "src/foo.mjs"], [10, 0, "src/billing/charge.rb"]]),
+    sizeConfig: SIZE_CONFIG,
+  });
+  assert.equal(result.outcome, "block");
+  assert.ok(result.reasons.some((r) => r.includes("t1/t3 pattern") && r.includes("no waiver possible")));
+});
+
+// ---------------------------------------------------------------------------
+// parseCheckSizeBudgetCliArgs
+// ---------------------------------------------------------------------------
+
+test("parseCheckSizeBudgetCliArgs: missing --base throws", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs([]), /--base/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a positional argument throws", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs(["--base", "main", "extra"]), /Unknown argument/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a '-'-leading --base throws", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs(["--base", "-evil"]), /plausible git ref/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a '..'-containing --base throws", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs(["--base", "main..evil"]), /plausible git ref/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a '-'-leading --head throws (same denylist as --base)", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs(["--base", "main", "--head", "-evil"]), /plausible git ref/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a '..'-containing --head throws (same denylist as --base)", () => {
+  assert.throws(() => parseCheckSizeBudgetCliArgs(["--base", "main", "--head", "feature..evil"]), /plausible git ref/);
+});
+
+test("parseCheckSizeBudgetCliArgs: a plain valid --base (and --head) is accepted", () => {
+  const options = parseCheckSizeBudgetCliArgs(["--base", "main", "--head", "feature/x"]);
+  assert.equal(options.base, "main");
+  assert.equal(options.head, "feature/x");
 });


### PR DESCRIPTION
## Objective

Phase 1 of the fail-closed PR size-budget feature (tracked by the four-phase epic issue 1480): the pure-computation core. Consumer evidence and DORA 2025 both point at review of large batches as the mechanism behind the AI-era stability penalty; dev-loops has draft-first PRs and diff classification but no blocking size concept. This slice lands the computation the later phases enforce on — a `gates.size` config block and a `scripts/loop/check-size-budget.mjs` that classifies a diff, computes logic LOC (whole-PR and per-tier), resolves review tiers from configured path patterns, and emits `pass` | `escalate` | `block`. It computes and reports only; no enforcement is wired, so no existing flow changes behavior. This PR is the spec-of-record for its own slice; the epic issue stays open until the later phases land.

## In scope

- `gates.size` in `FileConfigSchema` (`packages/core/src/config/config.mjs`: `SizeTierConfig`/`SizeTiersConfig`/`SizeConfig`, mirroring the existing `GateConfig`/`FanoutConfig` style) plus shipped defaults in `extension-defaults.yaml` (`testDiscount: 0.25`, `absoluteHardLoc: 2000`, default tier `softLoc: 400`/`waiverLoc: 1500`, empty `t1`/`t3`). Active by default.
- Regenerated JSON schema (`schemas/dev-loop-config.schema.json`).
- New `scripts/loop/check-size-budget.mjs` — pure computation: consumes the existing `diff-analyzer.mjs` classifier for `logicLoc = code + testDiscount x test` (generated/lockfile/docs/config excluded by the classifier's own signal), resolves tier from glob patterns, computes the T1-slice LOC separately from whole-PR LOC, emits `pass`/`escalate`/`block`. Exit 0/1/2, JSON via `jq-output.mjs`, registered as `dev-loops gate size-budget` in `cli/index.mjs` + `scripts/loop/sanctioned-commands.mjs`.
- Fixture-backed tests (`test/loop/check-size-budget.test.mjs`, `packages/core/test/config.test.mjs`).

## Explicit non-goals

- Any enforcement, verdict-contract, pre-approval, or refiner change — those are phases 2-4 of the epic and are deliberately absent here.
- Forcing or automating PR splits; a new gate name, new lifecycle states, or any `GATE_NAMES` change.
- Shipping consumer-specific tier patterns; `t1`/`t3` defaults ship empty.
- Extending the shared classifier's source-language coverage (see Open questions).

## Acceptance criteria

- [x] `check-size-budget.mjs` computes `logicLoc = code + testDiscount x test` (generated/lockfile excluded), resolves the tier from configured path patterns, computes T1-slice LOC separately, and emits `pass`/`escalate`/`block`; exit 0/1/2, JSON via `jq-output.mjs`, registered in `cli/index.mjs` + `sanctioned-commands.mjs`.
- [x] Blocks with no waiver on: whole-PR logic LOC over `absoluteHardLoc`, an unclassifiable/ambiguous diff, and non-empty config `errors[]` from `loadDevLoopConfig`.
- [x] A T1 slice over `sliceHardLoc` blocks unless waived, and a T1 waiver requires a named human approver (computed as a waiver-validity input; the granting CLI surface is phase 2).
- [x] `gates.size` exists in `FileConfigSchema` with a regenerated JSON schema; shipped defaults as specified; active by default.
- [x] `GATE_NAMES` and the 13-state PR lifecycle are unchanged.

## Definition of done

- [x] Fixture-backed tests cover tier resolution, slice-LOC computation, each outcome (`pass`/`escalate`/`block`), both waiver paths (default-tier and T1 with approver), and the config-`errors[]` block.
- [x] JSON schema regenerated and committed with the config change.
- [x] `npm run verify` green; `node scripts/claude/generate-claude-assets.mjs` leaves the tree clean.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| AC1: computation + CLI registration | DoD 1 (fixture-backed outcome tests) + DoD 3 (verify green) | no enforcement wiring (phase 2) |
| AC2: no-waiver block conditions (absoluteHardLoc / unclassifiable / config errors) | DoD 1 (block-path tests incl. config-errors) | no PR-split forcing |
| AC3: T1-slice block unless waived, T1 waiver names an approver | DoD 1 (T1 waiver with/without approver tests) | no consumer-specific tier patterns shipped |
| AC4: gates.size schema + regenerated JSON schema + shipped defaults, active by default | DoD 2 (schema regenerated + committed) | no GATE_NAMES / lifecycle change |
| AC5: GATE_NAMES + 13-state lifecycle unchanged | DoD 3 (verify green; diff touches neither) | no new gate name or states |

## Open questions / risks

- Source-language coverage (soft dependency): `logicLoc` keys off the shared `diff-analyzer.mjs` classifier, which currently treats only JS/TS as `code`. Non-JS source (Ruby, Python, etc.) classifies `unknown`. This slice adds a fail-closed stopgap so a diff whose changed lines are substantially unclassified resolves to `block` (ambiguous) rather than silently passing at 0 LOC; full per-language LOC counting is a classifier change tracked separately. Until that lands, non-JS logic LOC is conservatively treated as unclassifiable, never undercounted-to-pass.
- Later phases: enforcement wiring in `readyForReview()` plus the waiver-granting CLI (phase 2), verdict/evidence contract fields and the pre-approval human-approval requirement (phase 3), and the refiner phase-doc size estimate (phase 4) are not in this PR; the epic issue tracks them.

## Validation

```sh
npm run schema:check
node --test test/loop/check-size-budget.test.mjs
node --test packages/core/test/config.test.mjs
npm run verify
```

Part of the four-phase size-budget epic (issue 1480); this PR is phase 1 and does not itself complete the epic.
