### PR TITLE
feat(gate): enforce size budget at the draft-exit + waiver CLI (phase 2 of #1480)

### DIFF
--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -8,6 +8,7 @@ import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
 import { syncBoardStatus as realSyncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
 import { evaluatePrSizeBudget as realEvaluatePrSizeBudget } from "../loop/check-size-budget.mjs";
+import { sanitizeInline } from "./post-gate-findings.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number> [--waive-size-budget --reason <text> [--approved-by <human>]]
@@ -106,8 +107,8 @@ function renderSizeBudgetWaiverCommentBody({ headSha, sizeBudget, reason, approv
     "",
     `- **head SHA:** ${headSha}`,
     `- **tier:** ${tier}`,
-    `- **justification:** ${reason}`,
-    `- **approved by:** ${approvedBy ?? "n/a (default-tier waiver)"}`,
+    `- **justification:** ${sanitizeInline(reason)}`,
+    `- **approved by:** ${approvedBy == null ? "n/a (default-tier waiver)" : sanitizeInline(approvedBy)}`,
     `- **whole-PR logic LOC:** ${sizeBudget.wholeLogicLoc}`,
     "",
     "_Minimal standalone record — phase 3 folds tier/outcome/waiver into the checkpoint-verdict contract._",

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -7,32 +7,57 @@ import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
 import { syncBoardStatus as realSyncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
+import { evaluatePrSizeBudget as realEvaluatePrSizeBudget } from "../loop/check-size-budget.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
-const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number>\nWrapper around gh pr ready that enforces gate-evidence validation.\n\n${JQ_OUTPUT_USAGE}`;
+const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number> [--waive-size-budget --reason <text> [--approved-by <human>]]
+Wrapper around gh pr ready that enforces gate-evidence validation and the
+fail-closed PR size budget (gates.size): a block outcome (whole-PR logic LOC
+over absoluteHardLoc, a T1 slice over sliceHardLoc, an unclassifiable diff, or
+non-empty config errors[]) prevents the draft exit unless waived; an escalate
+outcome does not block but is recorded on the result for a later phase to act on.
+
+--waive-size-budget requires --reason <text> naming the justification; a
+T1-slice waiver additionally requires --approved-by <human> naming a human
+approver (an unwaivable block — absoluteHardLoc, config errors, ambiguous, or
+substantially-unclassified — is never waivable, no matter these flags).
+
+${JQ_OUTPUT_USAGE}`;
 const parseError = buildParseError(USAGE);
-const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state, mergeStateStatus, title, closingIssuesReferences(first:10){ nodes{ number } } } } }`;
+const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, baseRefName, state, mergeStateStatus, title, closingIssuesReferences(first:10){ nodes{ number } } } } }`;
 
 export function parseReadyForReviewCliArgs(argv) {
   const { tokens } = parseArgs({
     args: [...argv],
-    options: { help: { type: "boolean", short: "h" }, repo: { type: "string" }, pr: { type: "string" }, ...JQ_OUTPUT_PARSE_OPTIONS },
+    options: {
+      help: { type: "boolean", short: "h" },
+      repo: { type: "string" },
+      pr: { type: "string" },
+      "waive-size-budget": { type: "boolean" },
+      reason: { type: "string" },
+      "approved-by": { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
     allowPositionals: true,
     strict: false,
     tokens: true,
   });
-  const opts = { help: false, repo: undefined, pr: undefined };
+  const opts = { help: false, repo: undefined, pr: undefined, waiveSizeBudget: false, reason: null, approvedBy: null };
   for (const token of tokens) {
     if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
     if (token.kind !== "option") continue;
     if (token.name === "help") { opts.help = true; return opts; }
     if (token.name === "repo") { opts.repo = requireTokenValue(token, parseError).trim(); continue; }
     if (token.name === "pr") { opts.pr = parsePrNumber(requireTokenValue(token, parseError), parseError); continue; }
+    if (token.name === "waive-size-budget") { opts.waiveSizeBudget = true; continue; }
+    if (token.name === "reason") { opts.reason = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "approved-by") { opts.approvedBy = requireTokenValue(token, parseError).trim(); continue; }
     if (matchJqOutputToken(token, opts, (t) => requireTokenValue(t, parseError))) continue;
     throw parseError(`Unknown argument: ${token.rawName}`);
   }
   if (!opts.repo || opts.pr === undefined) throw parseError("ready-for-review requires --repo and --pr");
   parseRepoSlug(opts.repo);
+  if (opts.waiveSizeBudget && !opts.reason) throw parseError("--waive-size-budget requires --reason <text>");
   return opts;
 }
 
@@ -50,7 +75,7 @@ async function fetchPrState({ repo, pr }, { env, ghCommand }) {
   const closingIssues = (d.closingIssuesReferences?.nodes ?? [])
     .map((n) => n?.number)
     .filter((n) => Number.isInteger(n) && n > 0);
-  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null, title: typeof d.title === "string" ? d.title : null, closingIssues };
+  return { id: d.id, isDraft: d.isDraft === true, headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null, baseRefName: typeof d.baseRefName === "string" ? d.baseRefName.trim() : null, state: typeof d.state === "string" ? d.state.trim() : null, mergeStateStatus: typeof d.mergeStateStatus === "string" ? d.mergeStateStatus.trim() : null, title: typeof d.title === "string" ? d.title : null, closingIssues };
 }
 
 async function fetchCiStatus({ repo, pr }, { env, ghCommand }) {
@@ -66,7 +91,34 @@ async function fetchCiStatus({ repo, pr }, { env, ghCommand }) {
   return { status: blocking.length === 0 ? "success" : "blocked", blockingSummary: blocking.length > 0 ? `Blocking: ${blocking.map(c=>c.bucket).join(", ")}` : null };
 }
 
-export async function readyForReview(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), syncBoardStatus = realSyncBoardStatus } = {}) {
+// Minimal, standalone record of a granted size-budget waiver on the PR — NOT
+// the checkpoint-verdict surface (upsert-checkpoint-verdict.mjs): that
+// contract has no tier/outcome/waiver fields yet (phase 3 formalizes them).
+// Posting here only when the waiver actually mattered (t1Valid/defaultValid)
+// keeps a `--waive-size-budget` pass-through on an under-budget PR silent.
+function renderSizeBudgetWaiverCommentBody({ headSha, sizeBudget, reason, approvedBy }) {
+  const tier = sizeBudget.waiver.t1Valid ? "t1" : "default";
+  const lines = [
+    "## Size-budget waiver granted",
+    "",
+    `- **head SHA:** ${headSha}`,
+    `- **tier:** ${tier}`,
+    `- **justification:** ${reason}`,
+    `- **approved by:** ${approvedBy ?? "n/a (default-tier waiver)"}`,
+    `- **whole-PR logic LOC:** ${sizeBudget.wholeLogicLoc}`,
+    "",
+    "_Minimal standalone record — phase 3 folds tier/outcome/waiver into the checkpoint-verdict contract._",
+  ];
+  return lines.join("\n");
+}
+
+async function postSizeBudgetWaiverComment({ repo, pr, headSha, sizeBudget, reason, approvedBy }, { env, ghCommand }) {
+  const body = renderSizeBudgetWaiverCommentBody({ headSha, sizeBudget, reason, approvedBy });
+  const result = await runChild(ghCommand, ["pr", "comment", String(pr), "--repo", repo, "--body", body], env);
+  if (result.code !== 0) throw new Error(`Failed to post size-budget waiver record: ${result.stderr.trim() || `exit code ${result.code}`}`);
+}
+
+export async function readyForReview(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), syncBoardStatus = realSyncBoardStatus, evaluatePrSizeBudget = realEvaluatePrSizeBudget } = {}) {
   const { config } = await loadDevLoopConfig({ repoRoot });
   const draftGateConfig = resolveGateConfig(config, "draft");
   const requireCi = draftGateConfig?.requireCi !== false;
@@ -87,6 +139,27 @@ export async function readyForReview(options, { env = process.env, ghCommand = "
   // mark ready while any gate-authored thread still dangles (the #1584 bug).
   if (gate.unresolvedGateThreadCount === -1) throw new Error(`PR #${options.pr} could not read review-thread state from GitHub; re-run when API connectivity is restored`);
   if (gate.unresolvedGateThreadCount !== 0) throw new Error(`PR #${options.pr} has ${gate.unresolvedGateThreadCount} unresolved gate-authored review thread(s); run the disposition pass (close-gate-findings) + fixer triage to resolve (fix-close or defer-close) every gate-authored thread before marking ready for review`);
+  // Fail-closed PR size budget (gates.size): the sole enforcement point plus
+  // pre-pr-ready-gate.mjs's mirror of the same check on the raw `gh pr ready`
+  // path. A waiver is only ever accepted here (never on the raw path) — see
+  // --waive-size-budget above.
+  if (!prState.baseRefName) throw new Error(`Could not resolve PR #${options.pr} base branch`);
+  const sizeBudget = await evaluatePrSizeBudget({
+    base: `origin/${prState.baseRefName}`,
+    head: headSha,
+    repoRoot,
+    waived: options.waiveSizeBudget === true,
+    approvedBy: options.approvedBy ?? null,
+  });
+  if (sizeBudget.outcome === "block") {
+    throw new Error(`PR #${options.pr} blocked by size budget: ${sizeBudget.reasons.join("; ")}`);
+  }
+  if (sizeBudget.waiver.t1Valid || sizeBudget.waiver.defaultValid) {
+    await postSizeBudgetWaiverComment(
+      { repo: options.repo, pr: options.pr, headSha, sizeBudget, reason: options.reason, approvedBy: options.approvedBy },
+      { env, ghCommand },
+    );
+  }
   const readyResult = await runChild(ghCommand, ["pr", "ready", String(options.pr), "--repo", options.repo], env);
   if (readyResult.code !== 0) throw new Error(`gh pr ready failed`);
   // #1069: couple the In-Progress board move to the ready transition. Best-effort
@@ -102,7 +175,7 @@ export async function readyForReview(options, { env = process.env, ghCommand = "
   } catch (err) {
     boardSync = [{ ok: true, skipped: true, reason: err?.message ?? "board sync failed" }];
   }
-  return { ok: true, action: "marked_ready", repo: options.repo, pr: options.pr, headSha, draftGateSatisfied: gate.effectiveHeadClean && gate.unresolvedGateThreadCount === 0, unresolvedGateThreadCount: gate.unresolvedGateThreadCount, boardSync };
+  return { ok: true, action: "marked_ready", repo: options.repo, pr: options.pr, headSha, draftGateSatisfied: gate.effectiveHeadClean && gate.unresolvedGateThreadCount === 0, unresolvedGateThreadCount: gate.unresolvedGateThreadCount, sizeBudget, boardSync };
 }
 
 export async function main(argv = process.argv.slice(2), runtime = {}) {

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -12,9 +12,12 @@ import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToke
 
 const USAGE = `Usage: ready-for-review.mjs --repo <owner/name> --pr <number> [--waive-size-budget --reason <text> [--approved-by <human>]]
 Wrapper around gh pr ready that enforces gate-evidence validation and the
-fail-closed PR size budget (gates.size): a block outcome (whole-PR logic LOC
-over absoluteHardLoc, a T1 slice over sliceHardLoc, an unclassifiable diff, or
-non-empty config errors[]) prevents the draft exit unless waived; an escalate
+fail-closed PR size budget (gates.size): a block outcome prevents the draft
+exit unless waived. Waiver-eligible block triggers — whole-PR logic LOC over
+default.waiverLoc, or a T1 slice over t1.sliceHardLoc — accept
+--waive-size-budget; whole-PR logic LOC over absoluteHardLoc, non-empty config
+errors[], an ambiguous diff, or a substantially-unclassified diff are
+unwaivable block triggers, never bypassed by --waive-size-budget. An escalate
 outcome does not block but is recorded on the result for a later phase to act on.
 
 --waive-size-budget requires --reason <text> naming the justification; a

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -54,7 +54,7 @@ export function parseReadyForReviewCliArgs(argv) {
     if (token.name === "pr") { opts.pr = parsePrNumber(requireTokenValue(token, parseError), parseError); continue; }
     if (token.name === "waive-size-budget") { opts.waiveSizeBudget = true; continue; }
     if (token.name === "reason") { opts.reason = requireTokenValue(token, parseError).trim(); continue; }
-    if (token.name === "approved-by") { opts.approvedBy = requireTokenValue(token, parseError).trim(); continue; }
+    if (token.name === "approved-by") { const v = requireTokenValue(token, parseError).trim(); opts.approvedBy = v === "" ? null : v; continue; }
     if (matchJqOutputToken(token, opts, (t) => requireTokenValue(t, parseError))) continue;
     throw parseError(`Unknown argument: ${token.rawName}`);
   }

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -407,7 +407,7 @@ export function computeSizeBudget({
  * scripts/github/write-gate-context.mjs) so the byte-for-byte diff/LOC counts
  * a run produces don't depend on the operator's local git config.
  */
-function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), maxBuffer = 64 * 1024 * 1024 }) {
+export function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), maxBuffer = 64 * 1024 * 1024 }) {
   const range = `${base}...${head}`;
   const isolation = [
     "-c", "color.ui=false",
@@ -426,6 +426,14 @@ function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), 
     encoding: "utf8",
     maxBuffer,
     env: gitEnvWithoutDirOverrides(),
+    // Explicit stdio so a git WARNING on stderr (e.g. a deprecated ambient
+    // GIT_CONFIG_* override) never leaks onto the calling CLI's own stderr —
+    // execFileSync's stderr is only captured into the thrown error's
+    // `.message` on a non-zero exit when piped like this; without an
+    // explicit stdio, Node lets a clean-exit child's stderr write straight
+    // through to the parent, corrupting a caller's machine-parseable JSON
+    // (e.g. pre-pr-ready-gate.mjs's error-path emits the result to stderr).
+    stdio: ["ignore", "pipe", "pipe"],
   });
   try {
     return {
@@ -436,6 +444,27 @@ function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), 
   } catch (err) {
     throw new Error(`git diff against --base ${JSON.stringify(base)} failed: ${err?.message ?? err}`);
   }
+}
+
+/**
+ * The ONE shared code path readyForReview() and pre-pr-ready-gate.mjs both
+ * call to enforce the size budget (phase 2) — loads `gates.size` config,
+ * captures the base...head diff, and runs computeSizeBudget. `base` must
+ * already be a locally-resolvable ref (e.g. "origin/main"); like the CLI
+ * above, this never runs `git fetch` itself — the caller's checkout/worktree
+ * flow is responsible for the base ref being present locally.
+ */
+export async function evaluatePrSizeBudget({
+  base,
+  head = "HEAD",
+  repoRoot = process.cwd(),
+  waived = false,
+  approvedBy = null,
+} = {}) {
+  const { config, errors: configErrors } = await loadDevLoopConfig({ repoRoot });
+  const sizeConfig = config?.gates?.size ?? {};
+  const { nameStatusOutput, diffOutput, numstatOutput } = captureSizeBudgetDiff({ base, head, repoRoot });
+  return computeSizeBudget({ nameStatusOutput, diffOutput, numstatOutput, sizeConfig, configErrors, waived, approvedBy });
 }
 
 function assertPlausibleRef(ref, label, onError) {

--- a/scripts/loop/check-size-budget.mjs
+++ b/scripts/loop/check-size-budget.mjs
@@ -407,7 +407,7 @@ export function computeSizeBudget({
  * scripts/github/write-gate-context.mjs) so the byte-for-byte diff/LOC counts
  * a run produces don't depend on the operator's local git config.
  */
-export function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), maxBuffer = 64 * 1024 * 1024 }) {
+function captureSizeBudgetDiff({ base, head = "HEAD", repoRoot = process.cwd(), maxBuffer = 64 * 1024 * 1024 }) {
   const range = `${base}...${head}`;
   const isolation = [
     "-c", "color.ui=false",

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -9,19 +9,23 @@ import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.m
 import { fetchDraftGateEvidence } from "../github/_gate-finding-surface.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { parseArgs } from "node:util";
+import { evaluatePrSizeBudget as realEvaluatePrSizeBudget } from "./check-size-budget.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
 const USAGE = `Usage:
   pre-pr-ready-gate.mjs --repo <owner/name> --pr <number>
 
-Gate guard for gh pr ready (draft → ready-for-review transition).
-Blocks unless a visible clean draft_gate checkpoint verdict exists for the
-PR's current head SHA, on either surface it can live on: the round's PR
-review, or a legacy verdict issue comment.
+Gate guard for gh pr ready (draft → ready-for-review transition). Blocks
+unless a visible clean draft_gate checkpoint verdict exists for the PR's
+current head SHA (on either surface it can live on: the round's PR review, or
+a legacy verdict issue comment) AND the fail-closed PR size budget
+(gates.size) does not return a block outcome. This is the guard the raw
+\`gh pr ready\` hook path runs — no --waive-size-budget surface here; a size
+waiver can only be granted through ready-for-review.mjs.
 
 Exit codes:
-  0  Draft gate evidence exists — ready transition is allowed
-  1  Draft gate evidence missing or insufficient — transition blocked
+  0  Draft gate evidence exists and the size budget does not block — ready transition is allowed
+  1  Draft gate evidence missing/insufficient, or the size budget blocks — transition blocked
 
 Output (stdout, JSON on success):
   {
@@ -30,7 +34,8 @@ Output (stdout, JSON on success):
     "pr": 17,
     "currentHeadSha": "abc1234",
     "draftGateSatisfied": true,
-    "draftGate": { "visible": true, "headSha": "abc1234", "verdict": "clean", ... }
+    "draftGate": { "visible": true, "headSha": "abc1234", "verdict": "clean", ... },
+    "sizeBudget": { "outcome": "pass"|"escalate", ... }
   }
 
 Error output (stderr, JSON):
@@ -38,7 +43,7 @@ Error output (stderr, JSON):
 ${JQ_OUTPUT_USAGE}`.trim();
 
 const parseError = buildParseError(USAGE);
-const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, state } } }`;
+const PR_VIEW_QUERY = `query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { id, isDraft, headRefOid, baseRefName, state } } }`;
 
 export function parsePrePrReadyGateCliArgs(argv) {
   const options = { help: false, repo: undefined, pr: undefined };
@@ -97,11 +102,12 @@ async function fetchPrState({ repo, pr }, { env, ghCommand }) {
     id: d.id,
     isDraft: d.isDraft === true,
     headRefOid: typeof d.headRefOid === "string" ? d.headRefOid.trim() : null,
+    baseRefName: typeof d.baseRefName === "string" ? d.baseRefName.trim() : null,
     state: typeof d.state === "string" ? d.state.trim() : null,
   };
 }
 
-export async function prePrReadyGate(options, { env = process.env, ghCommand = "gh" } = {}) {
+export async function prePrReadyGate(options, { env = process.env, ghCommand = "gh", repoRoot = process.cwd(), evaluatePrSizeBudget = realEvaluatePrSizeBudget } = {}) {
   const prState = await fetchPrState({ repo: options.repo, pr: options.pr }, { env, ghCommand });
   const headSha = prState.headRefOid;
   if (!headSha) throw new Error(`Could not resolve PR head SHA`);
@@ -151,6 +157,32 @@ export async function prePrReadyGate(options, { env = process.env, ghCommand = "
     };
   }
 
+  // Fail-closed PR size budget (gates.size): the same computation
+  // readyForReview() runs, via the shared evaluatePrSizeBudget code path in
+  // check-size-budget.mjs — but with no waiver surface. A raw `gh pr ready`
+  // intercepted by this guard can never be waived; only ready-for-review.mjs's
+  // --waive-size-budget can grant one.
+  if (!prState.baseRefName) throw new Error(`Could not resolve PR #${options.pr} base branch`);
+  const sizeBudget = await evaluatePrSizeBudget({
+    base: `origin/${prState.baseRefName}`,
+    head: headSha,
+    repoRoot,
+  });
+  if (sizeBudget.outcome === "block") {
+    return {
+      ok: false,
+      error: `PR #${options.pr} blocked by size budget: ${sizeBudget.reasons.join("; ")}`,
+      repo: options.repo,
+      pr: options.pr,
+      currentHeadSha: headSha,
+      draftGateSatisfied: true,
+      unresolvedGateThreadCount: gate.unresolvedGateThreadCount,
+      draftGate: gate.draftGate,
+      draftGateMarker: gate.draftGateMarker,
+      sizeBudget,
+    };
+  }
+
   return {
     ok: true,
     repo: options.repo,
@@ -160,6 +192,7 @@ export async function prePrReadyGate(options, { env = process.env, ghCommand = "
     unresolvedGateThreadCount: gate.unresolvedGateThreadCount,
     draftGate: gate.draftGate,
     draftGateMarker: gate.draftGateMarker,
+    sizeBudget,
   };
 }
 

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { RUN_ID_MARKERS } from "@dev-loops/core/loop/run-context";
@@ -147,6 +147,78 @@ export const DEFAULT_TEST_PR_BODY = [
   "- none",
   "",
 ].join("\n");
+
+// ---------------------------------------------------------------------------
+// Real-git fixture for the size-budget check (readyForReview / pre-pr-ready-
+// gate wire computeSizeBudget over an ACTUAL local `git diff`, not a gh-stub
+// response — see scripts/loop/check-size-budget.mjs's evaluatePrSizeBudget).
+// Builds a tiny two-commit repo at `workDir`: a base commit, then a
+// `refs/remotes/origin/<baseBranch>` ref pinned to it (the state a real
+// `git fetch origin <base>` would leave, without touching the network), then
+// one small head commit on top. Returns the real head SHA so the gh-stub PR
+// payload's headRefOid can match what git actually computed — required
+// because check-size-budget.mjs's diff-capture calls real `git`, not the gh
+// stub.
+// ---------------------------------------------------------------------------
+
+const GIT_FIXTURE_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+function runGitFixture(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: GIT_FIXTURE_ENV });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed (${result.status}): ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * @param {string} workDir — an existing empty directory (e.g. a mkdtemp result)
+ * @param {{
+ *   baseBranch?: string,
+ *   devloopsYaml?: string|null — written into the BASE commit (not the diff)
+ *     so a gates.size override never itself counts toward logic LOC,
+ *   headFiles?: Array<{ path: string, content: string }> — files the head
+ *     commit adds; defaults to one small code file (an under-budget diff),
+ * }} [opts]
+ * @returns {{ headSha: string, baseBranch: string }}
+ */
+export async function initSizeBudgetFixtureRepo(workDir, {
+  baseBranch = "main",
+  devloopsYaml = null,
+  headFiles = [{ path: "src/example.mjs", content: "export function example() {\n  return 1;\n}\n" }],
+} = {}) {
+  runGitFixture(workDir, ["init", "-q", "-b", baseBranch]);
+  runGitFixture(workDir, ["config", "commit.gpgsign", "false"]);
+  await writeFile(path.join(workDir, "README.md"), "base fixture\n", "utf8");
+  if (devloopsYaml) await writeFile(path.join(workDir, ".devloops"), devloopsYaml, "utf8");
+  runGitFixture(workDir, ["add", "."]);
+  runGitFixture(workDir, ["commit", "-q", "-m", "base"]);
+  const baseSha = runGitFixture(workDir, ["rev-parse", "HEAD"]);
+  runGitFixture(workDir, ["update-ref", `refs/remotes/origin/${baseBranch}`, baseSha]);
+
+  for (const file of headFiles) {
+    await mkdir(path.dirname(path.join(workDir, file.path)), { recursive: true });
+    await writeFile(path.join(workDir, file.path), file.content, "utf8");
+  }
+  runGitFixture(workDir, ["add", "."]);
+  runGitFixture(workDir, ["commit", "-q", "-m", "head"]);
+  const headSha = runGitFixture(workDir, ["rev-parse", "HEAD"]);
+  return { headSha, baseBranch };
+}
+
+/** A code-file body whose line count is >= `count` changed (added) lines — for
+ * size-budget fixtures that need to cross a specific LOC threshold. */
+export function repeatedLinesContent(count, { prefix = "const x", } = {}) {
+  const lines = [];
+  for (let i = 0; i < count; i += 1) lines.push(`${prefix}${i} = ${i};`);
+  return `${lines.join("\n")}\n`;
+}
 
 export function runNode(scriptPath, args = [], options = {}) {
   return new Promise((resolve, reject) => {

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -219,7 +219,7 @@ export async function initSizeBudgetFixtureRepo(workDir, {
 
 /** A code-file body whose line count is >= `count` changed (added) lines — for
  * size-budget fixtures that need to cross a specific LOC threshold. */
-export function repeatedLinesContent(count, { prefix = "const x", } = {}) {
+export function repeatedLinesContent(count, { prefix = "const x" } = {}) {
   const lines = [];
   for (let i = 0; i < count; i += 1) lines.push(`${prefix}${i} = ${i};`);
   return `${lines.join("\n")}\n`;

--- a/test/_helpers.mjs
+++ b/test/_helpers.mjs
@@ -167,6 +167,11 @@ const GIT_FIXTURE_ENV = {
   GIT_AUTHOR_EMAIL: "test@example.com",
   GIT_COMMITTER_NAME: "Test",
   GIT_COMMITTER_EMAIL: "test@example.com",
+  // Mirror the isolation captureSizeBudgetDiff's gitEnvWithoutDirOverrides
+  // applies in production: an ambient GIT_DIR/GIT_WORK_TREE would redirect
+  // this fixture's init/add/commit calls into a different repo entirely.
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
 };
 
 function runGitFixture(cwd, args) {

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -4,7 +4,14 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { initSizeBudgetFixtureRepo, repeatedLinesContent, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+
+// A stub evaluatePrSizeBudget that always passes — for tests exercising
+// OTHER readyForReview() logic (board sync, etc.) via direct function calls,
+// so they don't need a real git fixture just to clear the size-budget check.
+function passingSizeBudget() {
+  return { ok: true, outcome: "pass", wholeLogicLoc: 0, t1SliceLoc: 0, reasons: [], waiver: { requested: false, approvedBy: null, t1Valid: false, defaultValid: false } };
+}
 
 import { parseReadyForReviewCliArgs, readyForReview } from "../../scripts/github/ready-for-review.mjs";
 
@@ -247,6 +254,7 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-success-"));
 
   try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -255,7 +263,8 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
               pullRequest: {
                 id: "PR_abc123",
                 isDraft: true,
-                headRefOid: "abc123def456",
+                headRefOid: headSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
               },
@@ -271,14 +280,14 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
       {
         stdout: JSON.stringify([
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 101,
             html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
             created_at: "2026-06-05T00:00:00Z",
             updated_at: "2026-06-05T00:00:00Z",
           },
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 102,
             html_url: "https://github.com/owner/repo/pull/17#issuecomment-102",
             created_at: "2026-06-05T00:00:00Z",
@@ -292,7 +301,7 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
 
     const result = await runNode(
       ["--repo", "owner/repo", "--pr", "17"],
-      { env },
+      { env, cwd: tempDir },
     );
 
     assert.equal(result.code, 0, `Expected exit code 0, got ${result.code}. Stderr: ${result.stderr}`);
@@ -300,6 +309,7 @@ test("succeeds when draft gate evidence exists and CI is green", async () => {
     assert.equal(output.ok, true, `Script returned ok=false: ${result.stderr}`);
     assert.equal(output.action, "marked_ready");
     assert.equal(output.pr, 17);
+    assert.equal(output.sizeBudget.outcome, "pass");
 
     // Verify gh pr ready was called
     const calls = await readGhCalls(ghLogPath);
@@ -314,6 +324,7 @@ test("succeeds when the clean draft verdict lives only in the review stream (sin
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-review-surface-"));
 
   try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -322,7 +333,8 @@ test("succeeds when the clean draft verdict lives only in the review stream (sin
               pullRequest: {
                 id: "PR_abc123",
                 isDraft: true,
-                headRefOid: "abc123def456",
+                headRefOid: headSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
               },
@@ -339,7 +351,7 @@ test("succeeds when the clean draft verdict lives only in the review stream (sin
       {
         stdout: JSON.stringify([
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 4001,
             state: "COMMENTED",
             submitted_at: "2026-06-05T00:00:00Z",
@@ -353,7 +365,7 @@ test("succeeds when the clean draft verdict lives only in the review stream (sin
 
     const result = await runNode(
       ["--repo", "owner/repo", "--pr", "17"],
-      { env },
+      { env, cwd: tempDir },
     );
 
     assert.equal(result.code, 0, `Expected exit code 0, got ${result.code}. Stderr: ${result.stderr}`);
@@ -372,6 +384,7 @@ test("still marks ready off an issue-comment verdict when the reviews fetch fail
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-reviews-fetch-fail-"));
 
   try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -380,7 +393,8 @@ test("still marks ready off an issue-comment verdict when the reviews fetch fail
               pullRequest: {
                 id: "PR_abc123",
                 isDraft: true,
-                headRefOid: "abc123def456",
+                headRefOid: headSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
               },
@@ -396,7 +410,7 @@ test("still marks ready off an issue-comment verdict when the reviews fetch fail
       {
         stdout: JSON.stringify([
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 101,
             html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
             created_at: "2026-06-05T00:00:00Z",
@@ -411,7 +425,7 @@ test("still marks ready off an issue-comment verdict when the reviews fetch fail
 
     const result = await runNode(
       ["--repo", "owner/repo", "--pr", "17"],
-      { env },
+      { env, cwd: tempDir },
     );
 
     assert.equal(result.code, 0, `Expected exit code 0, got ${result.code}. Stderr: ${result.stderr}`);
@@ -466,6 +480,7 @@ test("proceeds when PR title is clean", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-clean-title-"));
 
   try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -474,7 +489,8 @@ test("proceeds when PR title is clean", async () => {
               pullRequest: {
                 id: "PR_abc123",
                 isDraft: true,
-                headRefOid: "abc123def456",
+                headRefOid: headSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
                 title: "Add user authentication flow",
@@ -491,7 +507,7 @@ test("proceeds when PR title is clean", async () => {
       {
         stdout: JSON.stringify([
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 101,
             html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
             created_at: "2026-06-05T00:00:00Z",
@@ -503,7 +519,7 @@ test("proceeds when PR title is clean", async () => {
       { stdout: "" }, // gh pr ready
     ]);
 
-    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
 
     assert.equal(result.code, 0, `Expected exit code 0, got ${result.code}. Stderr: ${result.stderr}`);
     const output = JSON.parse(result.stdout);
@@ -568,6 +584,9 @@ test("built-in In-Progress board sync runs after gh pr ready and is NON-FATAL (#
     // No .devloops in tempDir → board not configured → syncBoardStatus is a
     // clean fail-open skip. Running with cwd: tempDir keeps the board sync from
     // shelling out to gh, but proves the tail runs and marking ready still wins.
+    // The real size-budget fixture repo lives at the same cwd (also used as
+    // the size-budget diff's local checkout).
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -576,7 +595,8 @@ test("built-in In-Progress board sync runs after gh pr ready and is NON-FATAL (#
               pullRequest: {
                 id: "PR_abc123",
                 isDraft: true,
-                headRefOid: "abc123def456",
+                headRefOid: headSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
                 closingIssuesReferences: { nodes: [{ number: 55 }] },
@@ -589,7 +609,7 @@ test("built-in In-Progress board sync runs after gh pr ready and is NON-FATAL (#
       {
         stdout: JSON.stringify([
           {
-            body: "Gate review: draft_gate\nReviewed head SHA: abc123def456\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review",
+            body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
             id: 101,
             html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
             created_at: "2026-06-05T00:00:00Z",
@@ -638,6 +658,7 @@ function preReadyGhStub(tempDir, { closingIssueNodes = [] } = {}) {
               id: "PR_abc123",
               isDraft: true,
               headRefOid: "abc123def456",
+              baseRefName: "main",
               state: "OPEN",
               mergeStateStatus: "CLEAN",
               title: "Add feature",
@@ -675,7 +696,7 @@ test("board tail targets the closing issue (not the PR) when closingIssues prese
     };
     const result = await readyForReview(
       { repo: "owner/repo", pr: 17 },
-      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync, evaluatePrSizeBudget: passingSizeBudget },
     );
     assert.equal(result.ok, true);
     assert.equal(result.action, "marked_ready");
@@ -698,7 +719,7 @@ test("board tail falls back to the PR number when closingIssues is empty (#1069)
     };
     const result = await readyForReview(
       { repo: "owner/repo", pr: 17 },
-      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync, evaluatePrSizeBudget: passingSizeBudget },
     );
     assert.equal(result.action, "marked_ready");
     assert.equal(syncCalls.length, 1);
@@ -715,7 +736,7 @@ test("board tail is NON-FATAL: a throwing syncBoardStatus never fails marking re
     const fakeSync = async () => { throw new Error("board exploded"); };
     const result = await readyForReview(
       { repo: "owner/repo", pr: 17 },
-      { env, repoRoot: tempDir, syncBoardStatus: fakeSync },
+      { env, repoRoot: tempDir, syncBoardStatus: fakeSync, evaluatePrSizeBudget: passingSizeBudget },
     );
     assert.equal(result.ok, true);
     assert.equal(result.action, "marked_ready");
@@ -792,8 +813,8 @@ test("succeeds when gate comment has abbreviated SHA matching full PR head SHA",
 
   try {
     // GitHub reports full 40-char SHA; gate comment may record abbreviated 7+ char SHA
-    const fullHeadSha = "abc123def456789012345678901234567890abcd";
-    const abbrevHeadSha = "abc123d";
+    const { headSha: fullHeadSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir);
+    const abbrevHeadSha = fullHeadSha.slice(0, 7);
     const { env, ghLogPath } = await writeGhStub(tempDir, [
       {
         stdout: JSON.stringify({
@@ -803,6 +824,7 @@ test("succeeds when gate comment has abbreviated SHA matching full PR head SHA",
                 id: "PR_abc123",
                 isDraft: true,
                 headRefOid: fullHeadSha,
+                baseRefName: baseBranch,
                 state: "OPEN",
                 mergeStateStatus: "CLEAN",
               },
@@ -832,7 +854,7 @@ test("succeeds when gate comment has abbreviated SHA matching full PR head SHA",
 
     const result = await runNode(
       ["--repo", "owner/repo", "--pr", "17"],
-      { env },
+      { env, cwd: tempDir },
     );
 
     assert.equal(result.code, 0);
@@ -913,4 +935,240 @@ test("#1585: ready-for-review fails closed (-1) when review-thread state is unre
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed PR size budget (gates.size) — phase 2 wiring: real git diff +
+// config, one gh stub sequence shared by every scenario below (PR view, CI,
+// draft_gate evidence, gate-close), so only the size-budget outcome differs
+// per test. gh pr ready and gh pr comment are appended per-test depending on
+// whether the size check is expected to let the draft exit proceed.
+// ---------------------------------------------------------------------------
+
+function sizeBudgetGhStubEntries({ headSha, baseBranch, extraEntries = [] }) {
+  return [
+    {
+      stdout: JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              id: "PR_abc123",
+              isDraft: true,
+              headRefOid: headSha,
+              baseRefName: baseBranch,
+              state: "OPEN",
+              mergeStateStatus: "CLEAN",
+            },
+          },
+        },
+      }),
+    },
+    { stdout: JSON.stringify([{ name: "test", state: "success", bucket: "pass" }]) },
+    {
+      stdout: JSON.stringify([
+        {
+          body: `Gate review: draft_gate\nReviewed head SHA: ${headSha}\nVerdict: clean\nFindings summary: no issues found\nNext action: mark ready for review`,
+          id: 101,
+          html_url: "https://github.com/owner/repo/pull/17#issuecomment-101",
+          created_at: "2026-06-05T00:00:00Z",
+          updated_at: "2026-06-05T00:00:00Z",
+        },
+      ]),
+    },
+    ...gateCloseStubs(),
+    ...extraEntries,
+  ];
+}
+
+test("size budget: escalate outcome allows ready and records the escalation signal on the result", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-escalate-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        softLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({
+      headSha,
+      baseBranch,
+      extraEntries: [{ stdout: "" }], // gh pr ready
+    }));
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.sizeBudget.outcome, "escalate");
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"), "gh pr ready should still be called on escalate");
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "comment"), "no waiver record should be posted when no waiver was requested");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: a waiver-eligible block (default.waiverLoc) with no waiver requested prevents the draft exit", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-block-nowaiver-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        waiverLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch }));
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /blocked by size budget/i);
+    assert.match(result.stderr, /waiverLoc/);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"), "gh pr ready must not be called on a block");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: a valid default-tier waiver allows the same over-waiverLoc PR through and posts a minimal waiver record", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-waived-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        waiverLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({
+      headSha,
+      baseBranch,
+      extraEntries: [{ stdout: "" }, { stdout: "" }], // gh pr comment (waiver record) + gh pr ready
+    }));
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", "reviewed together as one atomic rename"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.notEqual(output.sizeBudget.outcome, "block");
+    assert.equal(output.sizeBudget.waiver.defaultValid, true);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"));
+    const commentCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "comment");
+    assert.ok(commentCall, "a waiver record comment should have been posted");
+    const body = commentCall[commentCall.indexOf("--body") + 1];
+    assert.match(body, /Size-budget waiver granted/);
+    assert.match(body, /reviewed together as one atomic rename/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: an unwaivable block (absoluteHardLoc) is never bypassed by --waive-size-budget", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-unwaivable-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    absoluteHardLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch }));
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", "please let this through", "--approved-by", "someone"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /blocked by size budget/i);
+    assert.match(result.stderr, /absoluteHardLoc/);
+    assert.match(result.stderr, /no waiver possible/i);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && (c[1] === "ready" || c[1] === "comment")));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: a T1-slice waiver without --approved-by is refused", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-t1-noapprover-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: 'version: 1\ngates:\n  size:\n    tiers:\n      t1:\n        patterns:\n          - "src/money/**"\n        sliceHardLoc: 2\n',
+      headFiles: [{ path: "src/money/pay.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch }));
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", "money-slice rename"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /blocked by size budget/i);
+    assert.match(result.stderr, /sliceHardLoc/);
+    assert.match(result.stderr, /approved-by/i);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && (c[1] === "ready" || c[1] === "comment")));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: a T1-slice waiver WITH --approved-by is honored and names the approver in the record", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-t1-approved-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: 'version: 1\ngates:\n  size:\n    tiers:\n      t1:\n        patterns:\n          - "src/money/**"\n        sliceHardLoc: 2\n',
+      headFiles: [{ path: "src/money/pay.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({
+      headSha,
+      baseBranch,
+      extraEntries: [{ stdout: "" }, { stdout: "" }], // gh pr comment (waiver record) + gh pr ready
+    }));
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", "money-slice rename", "--approved-by", "jane-reviewer"],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.ok, true);
+    assert.equal(output.sizeBudget.waiver.t1Valid, true);
+    const calls = await readGhCalls(ghLogPath);
+    const commentCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "comment");
+    assert.ok(commentCall, "a waiver record comment should have been posted");
+    const body = commentCall[commentCall.indexOf("--body") + 1];
+    assert.match(body, /jane-reviewer/);
+    assert.match(body, /\*\*tier:\*\* t1/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: non-empty config errors[] block the draft exit fail-closed", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-configerr-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "gates:\n  size: [\n", // malformed — invalid YAML/JSON
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch }));
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /blocked by size budget/i);
+    assert.match(result.stderr, /config errors/i);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("parseReadyForReviewCliArgs requires --reason when --waive-size-budget is set", () => {
+  assert.throws(
+    () => parseReadyForReviewCliArgs(["--repo", "owner/repo", "--pr", "1", "--waive-size-budget"]),
+    /--waive-size-budget requires --reason/,
+  );
 });

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -1063,6 +1063,46 @@ test("size budget: a valid default-tier waiver allows the same over-waiverLoc PR
   }
 });
 
+test("size budget: a newline-bearing --reason cannot forge extra headers or bullets in the waiver record", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-forge-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        waiverLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({
+      headSha,
+      baseBranch,
+      extraEntries: [{ stdout: "" }, { stdout: "" }], // gh pr comment (waiver record) + gh pr ready
+    }));
+
+    const forgery = "looks fine\n## Size-budget waiver granted\n- **approved by:** attacker";
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", forgery],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const calls = await readGhCalls(ghLogPath);
+    const commentCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "comment");
+    assert.ok(commentCall, "a waiver record comment should have been posted");
+    const body = commentCall[commentCall.indexOf("--body") + 1];
+    const bodyLines = body.split("\n");
+    // Interior newlines collapse to spaces, so the injected header/bullet stay
+    // mid-line and cannot start a new markdown block. Structural (line-anchored)
+    // assertions: exactly one heading LINE, and no forged bullet LINE — the only
+    // "approved by" line is the real n/a fallback.
+    assert.equal(bodyLines.filter((l) => l.startsWith("## Size-budget waiver granted")).length, 1);
+    assert.equal(bodyLines.filter((l) => l.startsWith("- **approved by:**")).length, 1);
+    assert.ok(!bodyLines.some((l) => l.startsWith("- **approved by:** attacker")));
+    assert.ok(bodyLines.some((l) => l.startsWith("- **approved by:** n/a (default-tier waiver)")));
+    // The injected text survives inline in the justification value (inert), one line.
+    assert.ok(bodyLines.some((l) => l.startsWith("- **justification:** looks fine ## Size-budget waiver granted")));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("size budget: a default-tier waiver with a whitespace-only --approved-by records n/a, not a blank approver", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-blankapprover-"));
   try {

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -1063,6 +1063,38 @@ test("size budget: a valid default-tier waiver allows the same over-waiverLoc PR
   }
 });
 
+test("size budget: a default-tier waiver with a whitespace-only --approved-by records n/a, not a blank approver", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-blankapprover-"));
+  try {
+    const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tempDir, {
+      devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        waiverLoc: 2\n",
+      headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+    });
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({
+      headSha,
+      baseBranch,
+      extraEntries: [{ stdout: "" }, { stdout: "" }], // gh pr comment (waiver record) + gh pr ready
+    }));
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--waive-size-budget", "--reason", "atomic rename", "--approved-by", "   "],
+      { env, cwd: tempDir },
+    );
+
+    assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+    const calls = await readGhCalls(ghLogPath);
+    const commentCall = calls.find((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "comment");
+    assert.ok(commentCall, "a waiver record comment should have been posted");
+    const body = commentCall[commentCall.indexOf("--body") + 1];
+    // Whitespace-only --approved-by normalizes to null, so the record shows the
+    // default-tier fallback rather than a blank "approved by:" line.
+    assert.match(body, /approved by:\*\* n\/a \(default-tier waiver\)/);
+    assert.doesNotMatch(body, /approved by:\*\*\s*$/m);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("size budget: an unwaivable block (absoluteHardLoc) is never bypassed by --waive-size-budget", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-unwaivable-"));
   try {

--- a/test/github/ready-for-review.test.mjs
+++ b/test/github/ready-for-review.test.mjs
@@ -1166,6 +1166,40 @@ test("size budget: non-empty config errors[] block the draft exit fail-closed", 
   }
 });
 
+test("size budget: fails closed when the PR has no resolvable baseRefName (guard throws before the diff)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-nobaseref-"));
+  try {
+    const headSha = "abc123def456";
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch: undefined }));
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env });
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /Could not resolve PR #17 base branch/i);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"), "gh pr ready must not be called when baseRefName cannot be resolved");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("size budget: fails closed when origin/<base> is not locally resolvable (git diff failure)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-ready-size-badbase-"));
+  try {
+    const { headSha } = await initSizeBudgetFixtureRepo(tempDir);
+    const { env, ghLogPath } = await writeGhStub(tempDir, sizeBudgetGhStubEntries({ headSha, baseBranch: "totally-unresolvable-base" }));
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /git diff against --base/i);
+    const calls = await readGhCalls(ghLogPath);
+    assert.ok(!calls.some((c) => Array.isArray(c) && c[0] === "pr" && c[1] === "ready"), "gh pr ready must not be called when the base ref cannot be resolved");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("parseReadyForReviewCliArgs requires --reason when --waive-size-budget is set", () => {
   assert.throws(
     () => parseReadyForReviewCliArgs(["--repo", "owner/repo", "--pr", "1", "--waive-size-budget"]),

--- a/test/loop/pre-pr-ready-gate.test.mjs
+++ b/test/loop/pre-pr-ready-gate.test.mjs
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
+import { initSizeBudgetFixtureRepo, repeatedLinesContent, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 
 import { parsePrePrReadyGateCliArgs } from "../../scripts/loop/pre-pr-ready-gate.mjs";
 
@@ -142,9 +142,10 @@ test("gate passes: draft PR with clean draft_gate comment for current head", asy
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
   t.after(() => rm(tmpDir, { recursive: true, force: true }));
 
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir);
   const { env } = await writeGhStub(tmpDir, [
-    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
-    { stdout: JSON.stringify([makeDraftGateComment(HEAD_SHA_SHORT)]) },
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
     ...gateCloseStubs(),
   ]);
 
@@ -154,19 +155,21 @@ test("gate passes: draft PR with clean draft_gate comment for current head", asy
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.ok, true);
   assert.equal(parsed.draftGateSatisfied, true);
+  assert.equal(parsed.sizeBudget.outcome, "pass");
 });
 
 test("gate passes: clean draft verdict lives only in the review stream (single-surface round)", async (t) => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
   t.after(() => rm(tmpDir, { recursive: true, force: true }));
 
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir);
   const { env } = await writeGhStub(tmpDir, [
-    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
     { stdout: "[]" }, // issue comments: no verdict on the legacy surface
     {
       stdout: JSON.stringify([
         {
-          ...makeDraftGateComment(HEAD_SHA_SHORT),
+          ...makeDraftGateComment(headSha.slice(0, 7)),
           state: "COMMENTED",
           submitted_at: "2026-06-07T00:00:00Z",
           html_url: "https://github.com/owner/repo/pull/42#pullrequestreview-100",
@@ -188,9 +191,10 @@ test("gate passes off a legacy issue-comment verdict when the reviews fetch fail
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-test-"));
   t.after(() => rm(tmpDir, { recursive: true, force: true }));
 
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir);
   const { env } = await writeGhStub(tmpDir, [
-    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
-    { stdout: JSON.stringify([makeDraftGateComment(HEAD_SHA_SHORT)]) },
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
     { stdout: "", code: 1, stderr: "HTTP 500" }, // reviews fetch fails
     ...gateThreadLoginStubs(),
   ], { repeatLastOnOverflow: false });
@@ -244,8 +248,9 @@ test("gate passes: non-draft PR with visible clean draft_gate (relaxed, any head
 
   // Even though the draft_gate comment has a different head SHA,
   // the PR is no longer draft so any visible clean draft_gate is sufficient
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir);
   const { env } = await writeGhStub(tmpDir, [
-    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: false })) },
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: false, headRefOid: headSha, baseRefName: baseBranch })) },
     { stdout: JSON.stringify([makeDraftGateComment("9999999")]) },
     ...gateCloseStubs(),
   ]);
@@ -370,9 +375,10 @@ test("#1585 (d) ordering: the fixer sees nice-to-haves BEFORE the disposition pa
   // The fixer triaged the nice-to-have (fixed or deferred) and the disposition
   // pass closed the thread — 0 unresolved gate-authored threads remain. The
   // gate-close assertion passes and the PR can go ready.
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir);
   const { env } = await writeGhStub(tmpDir, [
-    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) },
-    { stdout: JSON.stringify([makeDraftGateComment(HEAD_SHA_SHORT)]) },
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
     { stdout: "[]" }, // listPrReviews (fail-open)
     { assertArgs: ["api", "user"], stdout: `${JSON.stringify({ login: "pi-local-run" })}\n` },
     {
@@ -389,4 +395,100 @@ test("#1585 (d) ordering: the fixer sees nice-to-haves BEFORE the disposition pa
   assert.equal(parsed.ok, true);
   assert.equal(parsed.draftGateSatisfied, true);
   assert.equal(parsed.unresolvedGateThreadCount, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed PR size budget (gates.size) — the same computation
+// readyForReview() runs, mirrored on the raw `gh pr ready` hook path. No
+// waiver surface here: only ready-for-review.mjs's --waive-size-budget can
+// grant one, so these scenarios never need to exercise a waiver.
+// ---------------------------------------------------------------------------
+
+test("size budget: escalate outcome still passes the gate (no waiver surface needed) and records the signal", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-escalate-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir, {
+    devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        softLoc: 2\n",
+    headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+  });
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 0, `Expected exit 0, got ${result.code}. Stderr: ${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.sizeBudget.outcome, "escalate");
+});
+
+test("size budget: a block outcome (default.waiverLoc, no waiver possible on this path) refuses the raw gh pr ready path", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-block-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir, {
+    devloopsYaml: "version: 1\ngates:\n  size:\n    tiers:\n      default:\n        waiverLoc: 2\n",
+    headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+  });
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.match(stderrParsed.error, /blocked by size budget/i);
+  assert.match(stderrParsed.error, /waiverLoc/);
+});
+
+test("size budget: an unwaivable block (absoluteHardLoc) refuses the raw gh pr ready path", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-unwaivable-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir, {
+    devloopsYaml: "version: 1\ngates:\n  size:\n    absoluteHardLoc: 2\n",
+    headFiles: [{ path: "src/big.mjs", content: repeatedLinesContent(10) }],
+  });
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.match(stderrParsed.error, /absoluteHardLoc/);
+  assert.match(stderrParsed.error, /no waiver possible/i);
+});
+
+test("size budget: non-empty config errors[] block the raw gh pr ready path fail-closed", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-configerr-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { headSha, baseBranch } = await initSizeBudgetFixtureRepo(tmpDir, {
+    devloopsYaml: "gates:\n  size: [\n", // malformed — invalid YAML/JSON
+  });
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: baseBranch })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.match(stderrParsed.error, /config errors/i);
 });

--- a/test/loop/pre-pr-ready-gate.test.mjs
+++ b/test/loop/pre-pr-ready-gate.test.mjs
@@ -472,6 +472,43 @@ test("size budget: an unwaivable block (absoluteHardLoc) refuses the raw gh pr r
   assert.match(stderrParsed.error, /no waiver possible/i);
 });
 
+test("size budget: fails closed when the PR has no resolvable baseRefName (guard throws before the diff)", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-nobaseref-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true })) }, // baseRefName omitted
+    { stdout: JSON.stringify([makeDraftGateComment(HEAD_SHA_SHORT)]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.match(stderrParsed.error, /Could not resolve PR #42 base branch/i);
+});
+
+test("size budget: fails closed when origin/<base> is not locally resolvable (git diff failure)", async (t) => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-badbase-"));
+  t.after(() => rm(tmpDir, { recursive: true, force: true }));
+
+  const { headSha } = await initSizeBudgetFixtureRepo(tmpDir);
+  const { env } = await writeGhStub(tmpDir, [
+    { stdout: JSON.stringify(buildPrStateResponse({ isDraft: true, headRefOid: headSha, baseRefName: "totally-unresolvable-base" })) },
+    { stdout: JSON.stringify([makeDraftGateComment(headSha.slice(0, 7))]) },
+    ...gateCloseStubs(),
+  ]);
+
+  const result = await runNode(["--repo", "owner/repo", "--pr", "42"], { cwd: tmpDir, env });
+
+  assert.equal(result.code, 1);
+  const stderrParsed = JSON.parse(result.stderr);
+  assert.equal(stderrParsed.ok, false);
+  assert.match(stderrParsed.error, /git diff against --base/i);
+});
+
 test("size budget: non-empty config errors[] block the raw gh pr ready path fail-closed", async (t) => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "pre-pr-size-configerr-"));
   t.after(() => rm(tmpDir, { recursive: true, force: true }));


### PR DESCRIPTION
## Objective

Phase 2 of the fail-closed PR size-budget epic (issue 1480): enforcement at the draft-exit. Phase 1 shipped the pure computation (`check-size-budget.mjs` + `gates.size` config) but nothing consumed it. This slice wires that computation into the single sanctioned draft-exit (`readyForReview()`) and the raw-hook guard (`pre-pr-ready-gate.mjs`) so an over-budget change can no longer leave draft unreviewed, and adds the auditable waiver-granting CLI. This PR is the spec-of-record for its own slice; the epic stays open for phases 3-4.

Escalation-not-rejection holds: a `block` outcome stops the draft exit, an `escalate` outcome is recorded (not blocked) for phase 3 to raise the review contract, and `pass` proceeds. Waivers are deliberate and auditable; unwaivable blocks (absolute ceiling, config errors, ambiguous/substantially-unclassified diffs) can never be waived.

## In scope

- `readyForReview()` (`scripts/github/ready-for-review.mjs`): after the existing CI / draft-gate-evidence / unresolved-thread checks and before `gh pr ready`, run the size check over `origin/<baseRef>...<headSha>`. `block` (unwaived or unwaivable) throws and prevents the draft exit; `escalate` attaches a `sizeBudget` result to the return value (recorded, not blocking); `pass` proceeds. `baseRefName` added to the PR-view query.
- Waiver-granting CLI: `--waive-size-budget --reason "<text>"` (reason required with the flag) and `--approved-by <human>` (required for a T1-slice waiver). Waiver inputs feed the phase-1 `computeSizeBudget` `waived`/`approvedBy` parameters (no waiver logic duplicated); an unwaivable block is never cleared by a waiver. A consumed waiver posts a minimal standalone record (head SHA, tier, justification, approver, whole-PR LOC).
- `pre-pr-ready-gate.mjs`: mirrors the same check via the shared path, with no waiver inputs (waivers are grantable only through `ready-for-review.mjs`).
- Shared code path (`scripts/loop/check-size-budget.mjs`): new exported `evaluatePrSizeBudget()` over an internal `captureSizeBudgetDiff()` — the one place both callers route through. Also pinned `execFileSync` git `stdio` so a clean-exit git stderr warning can't corrupt the JSON payload (a latent bug this wiring surfaced).
- Tests: real-git fixture-repo helper in `test/_helpers.mjs`; block/escalate/pass/waiver scenarios across `ready-for-review.test.mjs` and `pre-pr-ready-gate.test.mjs`.

## Explicit non-goals

- Verdict/evidence contract tier/outcome/waiver FIELDS and the `final_local_preapproval_gate` human-approval requirement — phase 3. This slice only records/surfaces the escalation and posts a minimal waiver note; it does not formalize the verdict schema.
- The refiner phase-doc size estimate — phase 4.
- Any `gates.size` schema/default change (phase 1 shipped it); no `GATE_NAMES` or lifecycle change.
- Forcing or automating PR splits; extending the classifier's source-language coverage (tracked on the epic).

## Acceptance criteria

- [x] `readyForReview()` runs the size check before `gh pr ready`; a `block` outcome prevents the draft exit (throws with the reasons).
- [x] An `escalate` outcome does not block ready; the `sizeBudget` result is recorded on the return value for phase 3 to consume.
- [x] Config `errors[]` from `loadDevLoopConfig` block the draft exit (fail-closed), and an unwaivable block (absoluteHardLoc / ambiguous / substantially-unclassified) is never cleared by a waiver.
- [x] Waivers are granted only via `ready-for-review.mjs --waive-size-budget --reason "..."` (T1: additionally `--approved-by <human>`); a T1 waiver without an approver is refused; a consumed waiver is recorded with justification + head SHA.
- [x] `pre-pr-ready-gate.mjs` applies the identical check through one shared code path (no duplicated size logic), with no waiver surface of its own.
- [x] `GATE_NAMES` and the 13-state PR lifecycle are unchanged.

## Definition of done

- [x] Fixture-backed tests cover block-prevents-ready (unwaivable and waiver-eligible), valid default-tier waiver, T1 waiver with/without approver, unwaivable-not-bypassed, config-errors block, escalate-allows-ready, and pass — mirrored on the pre-pr-ready-gate path.
- [x] `npm run verify` green; `npm run assets:check` clean; `npm run schema:check` up to date.
- [x] One shared `evaluatePrSizeBudget()` path; no size logic reimplemented in the callers.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| AC1: block prevents draft exit | DoD 1 (block-prevents-ready tests) | no PR-split forcing |
| AC2: escalate recorded, not blocked | DoD 1 (escalate-allows-ready test) | verdict-contract escalation enforcement is phase 3 |
| AC3: config-errors block + unwaivable never waived | DoD 1 (config-errors + unwaivable-not-bypassed tests) | no schema/default change |
| AC4: waiver CLI, T1 needs approver, recorded | DoD 1 (waiver scenario tests) | verdict-schema waiver fields are phase 3 |
| AC5: pre-pr-ready-gate via one shared path | DoD 3 (shared evaluatePrSizeBudget) | no waiver surface on that path |
| AC6: GATE_NAMES + lifecycle unchanged | DoD 2 (verify green; diff touches neither) | no new gate name or states |

## Open questions / risks

- This slice activates enforcement: once merged, an over-budget draft-exit is blocked repo-wide. The shipped default budget (softLoc 400 / waiverLoc 1500 / absoluteHardLoc 2000, empty t1/t3) escalates but does not block typical changes; only a whole-PR logic-LOC over 1500 (waiver-eligible) or 2000 (hard) blocks. This is the issue's active-by-default intent.
- Escalate currently only records; the review-contract raise (author annotations, human review, Copilot-clean insufficient) lands in phase 3 with the verdict/evidence fields.
- Non-JS source-language LOC coverage remains the fail-closed stopgap from phase 1 (substantially-unclassified → block); real per-language counting is tracked on the epic as a prerequisite for non-JS consumers.

## Validation

```sh
node --test test/github/ready-for-review.test.mjs test/loop/pre-pr-ready-gate.test.mjs
npm run verify
npm run assets:check
```

Part of the four-phase size-budget epic (issue 1480); this PR is phase 2 and does not itself complete the epic.
