### PR TITLE
chore(repo): package.json script/dep cleanup + CI workflow hygiene

### DIFF
--- a/.github/workflows/gate-evidence.yml
+++ b/.github/workflows/gate-evidence.yml
@@ -1,102 +1,10 @@
 name: Gate evidence
 
-# Server-side enforcement of the draft_gate / pre_approval_gate contract
-# (skills/docs/merge-preconditions.md, MERGE-PRECOND-REQUIRED items 3-4). Runs on
-# GitHub's own token so that — once an operator makes this a required check in
-# branch protection on the default branch — an API-driven ready/merge transition
-# (gh CLI, MCP/REST, web UI) cannot bypass the gates the client-side tooling
-# already enforces. Until then it runs and reports but does not block merge.
-#
-# Skipped entirely while the PR is a draft (draft_gate is not required yet, and a
-# draft PR cannot be merged regardless). A skipped run posts no `gate-evidence`
-# status at all, leaving the required check pending rather than passing — fine,
-# since a draft PR is never mergeable anyway. The first non-draft run (at
-# latest, ready_for_review) always posts a real status once merge is possible.
-#
-# Evaluation provenance: the checkout below is pinned to the DEFAULT BRANCH,
-# so the detector code that computes the verdict is always the trusted base
-# tree — never the PR head. This matters because the review/comment-class
-# triggers run in the base-repo context with `statuses: write` (fork
-# pull_request runs get a read-only token, but the comment-class runs do
-# not): a head-tree checkout would let a fork PR swap the detector (or a
-# package lifecycle script under npm ci) and forge a green required check on
-# itself with no maintainer involvement. The resolved PR head SHA is used
-# ONLY as the status TARGET, never as the code source. (For issue_comment
-# events GitHub additionally reads the workflow DEFINITION itself from the
-# default branch, so changes to this trigger arm only after merge.)
-#
-# Trigger staleness (the thread/comment axis) was a real gap: the verdict
-# depends on PR comment history + thread resolution, and pull_request events
-# don't re-fire when a review is submitted or a review comment opens a new
-# thread. Closed by also re-firing on pull_request_review (submitted) and
-# pull_request_review_comment (created) — the two events through which a NEW
-# unresolved thread appears, which is the stale-green direction that matters
-# here.
-#
-# The stale-PENDING direction (#1702) is closed two ways. First, the check is
-# now PRE-MERGE-ONLY: `synchronize` is NOT a trigger, so development pushes do
-# not start/leave a gate-evidence run and the check materializes only at a
-# pre-merge/verdict point (opened / reopened / ready_for_review / a posted-or-edited
-# verdict review / a verdict-shaped issue comment). Second, a run NEVER posts a
-# `pending` status: it always posts a definitive success/failure for the
-# current head. Because the workflow only fires at a merge-decision moment, the
-# previous "in-progress -> pending" case (evidence not yet established for the
-# current head) is now a fail-closed `failure` rather than a dangling pending —
-# the next verdict-post re-fires the check and flips it to `success`. Gate
-# verdicts are posted as a PR REVIEW
-# (upsert-checkpoint-verdict.mjs, the round's single visible surface), so a
-# NEW verdict re-fires via pull_request_review [submitted], and a same-head
-# in-place correction (PUT pulls/{pr}/reviews/{id}) re-fires via
-# pull_request_review [edited]. The issue_comment trigger below covers only
-# the LEGACY/fallback issue-comment verdicts (old PRs; the zero-dep fallback
-# poster), guarded to PR comments that START with the gate-comment marker
-# ("### Gate review:") AND come from a trusted author
-# (OWNER/MEMBER/COLLABORATOR — the verdict posters run under operator auth),
-# so ordinary discussion comments and untrusted marker-shaped comments never
-# start a run. issue_comment events carry no pull_request payload object, so
-# the Resolve-PR-facts step below fetches number/draft/head SHA once and
-# every later step reads those outputs.
-#
-# `gh run rerun` is NOT a recovery path for a stale status: it replays the
-# original event payload (an older head / pre-verdict comment set), so the
-# fresh evaluation still misses the current state. Post (or correct in place)
-# the gate verdict review instead — that re-fires this workflow with fresh
-# context.
-#
-# (GitHub Actions has no `pull_request_review_thread` workflow trigger —
-# thread resolve/unresolve is a webhook but not an `on:` event — so it is not
-# used; the review events above cover a newly-appearing unresolved thread. Narrow
-# residual: a bare "Unresolve conversation" UI action on an already-resolved
-# thread with no accompanying review/comment fires only that non-triggerable
-# event and is not re-caught until the next review or comment — bounded by the
-# maintainer-gated merge.) All the added
-# events are triggered by base-repo actions and run in the base-repo context,
-# so they get this workflow's declared permissions (including `statuses:
-# write`) even when the PR head is a fork; the two review events carry the
-# `pull_request` payload object directly, while issue_comment does not — hence
-# the Resolve-PR-facts step.
-#
-# Head-SHA mismatch on the non-pull_request event types: unlike `pull_request`
-# (whose implicit job check-run GitHub auto-associates with the PR's head
-# commit), `github.sha` for review/comment events is not the PR head (base
-# branch for review events, default branch for issue_comment). An implicit
-# check-run from those triggers would land on the wrong commit and never
-# refresh the required check on the head — the exact staleness this workflow
-# exists to close. So the job posts an EXPLICIT commit status to the RESOLVED
-# PR head SHA (steps.pr.outputs.head_sha — always the right commit, on every
-# trigger type) instead of relying on the job's own auto-attached check-run. To avoid two different reporters (the
-# job's own check-run + this explicit status) both claiming the required
-# `gate-evidence` context — which GitHub's docs warn is ambiguous — the job
-# itself is named something else; the explicit status below is the ONLY
-# thing that ever reports context `gate-evidence`.
-# Pre-merge-only trigger set (#1702): `synchronize` is deliberately absent so
-# development pushes never start a blocking gate-evidence run. The remaining
-# events are all pre-merge/verdict points: PR opened/reopened, ready_for_review
-# (the draft->non-draft merge-review transition), a posted or edited verdict
-# review, a new unresolved-thread review comment, and a verdict-shaped issue
-# comment. A clean verdict on the current head is guaranteed to re-fire via
-# pull_request_review [submitted]/[edited], so a satisfied PR flips straight to
-# `success` at the pre-merge point instead of dangling on a stale pending.
+# Behavioral contract (triggers, staleness, fail-closed provenance) is pinned by
+# test/github/gate-evidence-workflow.test.mjs.
+# Rationale and design records:
+#   docs/decisions/0034-server-side-gate-evidence-required-check.md
+#   docs/decisions/0043-gate-evidence-verdict-comment-refire.md
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -19,7 +19,7 @@ jobs:
   compile-wiki:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Check out repository
@@ -67,33 +67,8 @@ jobs:
           name: compiled-wiki
           path: .llmwiki/wiki
 
-  publish-wiki:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_wiki == 'true')
-    needs: compile-wiki
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download compiled wiki
-        uses: actions/download-artifact@v4
-        with:
-          name: compiled-wiki
-          path: .llmwiki/wiki
-
       - name: Publish wiki
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_wiki == 'true')
         env:
           LLMWIKI_PUBLISH_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git
         run: |

--- a/docs/repo-wiki-manual-first.md
+++ b/docs/repo-wiki-manual-first.md
@@ -41,7 +41,7 @@ Pinned source ref used by the helper:
 
 Helper entrypoint:
 
-- `scripts/repo-wiki-local.mjs`
+- `scripts/repo-wiki.mjs --source local`
 
 ## Local prerequisites
 
@@ -66,7 +66,7 @@ Generated artifacts under `.llmwiki/run/`, `.llmwiki/wiki/`, and `.llmwiki/searc
 Prepare the pinned local-helper fallback (only needed for the fallback path):
 
 ```bash
-npm run repo-wiki:prepare
+node scripts/repo-wiki.mjs --source local prepare
 ```
 
 Run a full local bootstrap export from a clean checkout (scan + plan + compile, no LLM key required for the deterministic compile step):
@@ -80,37 +80,36 @@ The lint step is intentionally **not** wired into the bootstrap script: `npm run
 flags a pre-existing `OPENAI_API_KEY` mention in `README.md` as secret-like content, and that
 issue is outside this slice. Run lint separately if you want to inspect wiki page health.
 Lint remains available as an explicit opt-in step via `npm run repo-wiki:lint`.
-Lint of ingested markdown docs is also available separately via `npm run repo-wiki:lint-docs`.
+Lint of ingested markdown docs is also available separately via `node scripts/repo-wiki.mjs lint-docs --repo .`.
 
 ```bash
-npm run repo-wiki:scan
-npm run repo-wiki:plan
-npm run repo-wiki:lint-docs
-npm run repo-wiki:compile
+node scripts/repo-wiki.mjs scan --repo .
+node scripts/repo-wiki.mjs plan --repo .
+node scripts/repo-wiki.mjs lint-docs --repo .
+node scripts/repo-wiki.mjs compile --repo .
 npm run repo-wiki:lint
 ```
 
-To run the same stages against the offline fallback source checkout instead of the published npm package, prefix the stage script with `repo-wiki:local-`:
+To run the same stages against the offline fallback source checkout instead of the published npm package, add `--source local` to each stage:
 
 ```bash
-npm run repo-wiki:local-bootstrap
-npm run repo-wiki:local-scan
-npm run repo-wiki:local-plan
-npm run repo-wiki:local-lint-docs
-npm run repo-wiki:local-compile
-npm run repo-wiki:local-lint
+node scripts/repo-wiki.mjs --source local scan --repo .
+node scripts/repo-wiki.mjs --source local plan --repo .
+node scripts/repo-wiki.mjs --source local lint-docs --repo .
+node scripts/repo-wiki.mjs --source local compile --repo .
+node scripts/repo-wiki.mjs --source local lint --repo .
 ```
 
 Inspect the documentation lint output separately:
 
 ```bash
-npm run repo-wiki:lint-docs
+node scripts/repo-wiki.mjs lint-docs --repo .
 ```
 
 Search the generated local wiki output:
 
 ```bash
-npm run repo-wiki:search -- "dev-loop"
+node scripts/repo-wiki.mjs search --repo . "dev-loop"
 ```
 
 Inspect the generated wiki pages directly:
@@ -122,7 +121,7 @@ find .llmwiki/wiki -maxdepth 1 -type f | sort
 If you want to regenerate `.llmwiki/config.json` and `.llmwiki/schema.md` from the helper instead of using the checked-in versions:
 
 ```bash
-npm run repo-wiki:init
+node scripts/repo-wiki.mjs init --repo .
 ```
 
 ## What each path does
@@ -138,7 +137,7 @@ npm run repo-wiki:init
 
 ### Fallback (local helper) path
 
-`scripts/repo-wiki-local.mjs`:
+`scripts/repo-wiki.mjs --source local`:
 
 1. clones `mfittko/repo-wiki` under `.tmp/repo-wiki/<ref>/source/`
 2. checks out the pinned commit `d7e772e3d702a75896a6f4eec574a4e4e5bfa6dd`
@@ -150,9 +149,9 @@ npm run repo-wiki:init
 The following commands were run from a clean checkout of this repository (see the lint caveat above; lint is intentionally excluded from this verification list because of a pre-existing repo-wiki finding):
 
 ```bash
-npm run repo-wiki:scan
-npm run repo-wiki:plan
-npm run repo-wiki:compile
+node scripts/repo-wiki.mjs scan --repo .
+node scripts/repo-wiki.mjs plan --repo .
+node scripts/repo-wiki.mjs compile --repo .
 npm run repo-wiki:lint
 find .llmwiki/wiki -maxdepth 1 -type f | sort
 ```
@@ -171,8 +170,8 @@ A GitHub Actions workflow at `.github/workflows/wiki.yml` compiles the repositor
 
 ### Triggers
 
-- `push` to `main` — runs the `compile-wiki` job and, because it is on `main`, the `publish-wiki` job.
-- `workflow_dispatch` — optionally opt in to `publish_wiki` after `compile-wiki` succeeds. The compile job always runs `npm run repo-wiki:bootstrap` (scan + plan + compile).
+- `push` to `main` — runs the single `compile-wiki` job, which compiles and, because it is on `main`, also publishes.
+- `workflow_dispatch` — the `compile-wiki` job always runs `npm run repo-wiki:bootstrap` (scan + plan + compile); the publish step runs only when you opt in to `publish_wiki`.
 
 ### Required operator setup
 
@@ -197,12 +196,11 @@ A GitHub Actions workflow at `.github/workflows/wiki.yml` compiles the repositor
    - `LLMWIKI_LLM_SYSTEM_PROMPT`
    - `LLMWIKI_LLM_SYSTEM_PROMPT_FILE`
 4. **Repo Wiki feature**:
-   - Confirm Wikis are enabled: Settings → General → Features → Wikis. If disabled, the `publish-wiki` job fails with a clear run summary message.
+   - Confirm Wikis are enabled: Settings → General → Features → Wikis. If disabled, the publish step of the `compile-wiki` job fails with a clear run summary message.
 
-### Workflow jobs
+### Workflow job
 
-- `compile-wiki` — checks out the repo, installs Node.js 24 dependencies, runs `npm run repo-wiki:bootstrap` (chained scan + plan + compile) and `npm run repo-wiki:lint`, then uploads `.llmwiki/wiki` as the `compiled-wiki` artifact.
-- `publish-wiki` — downloads the artifact and pushes it to `${{ github.repository }}.wiki.git` using `secrets.GITHUB_TOKEN` via `npm run repo-wiki -- publish --target github-wiki`.
+- `compile-wiki` — checks out the repo, installs Node.js 24 dependencies, runs `npm run repo-wiki:bootstrap` (chained scan + plan + compile) and `npm run repo-wiki:lint`, and uploads `.llmwiki/wiki` as the `compiled-wiki` artifact. On pushes to `main` (or a `workflow_dispatch` opt-in) the same job's publish step pushes the compiled pages to `${{ github.repository }}.wiki.git` using `secrets.GITHUB_TOKEN` via `npm run repo-wiki -- publish --target github-wiki`.
 
 ### Local commands still work
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@dev-loops/core": "^1.0.0-rc.1",
+        "@dev-loops/core": "^1.0.0-rc.6",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "verify": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack test:dev-loop test:workflows",
-    "test": "run-p --aggregate-output --continue-on-error test:assets test:extension test:scripts test:core test:docs test:pack",
+    "test": "npm run verify",
     "test:assets": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/dev-loop-init-phase-smoke.test.mjs test/core-runtime-boundary.test.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:doc-guard": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/contracts/*.test.mjs test/workflow-handoff-contract.test.mjs",
     "test:extension": "node --import tsx --test --test-reporter ./test/failure-summary-reporter.mjs test/extension-checks.test.mjs test/extension-post-merge-update.test.mjs test/extension-command-contract.test.mjs test/extension-package-contract.test.mjs test/extension-pi-adapter.test.mjs test/dev-loops-core.test.mjs test/dev-loops-cli.test.mjs test/cli-deps-less-checkout-preflight.test.mjs test/extension-pi-agent-tools.test.mjs",
@@ -34,30 +34,18 @@
     "test:playwright:how-decided-deck": "PW_UI_SLICE=how-decided-deck playwright test --project=how-decided-deck",
     "test:playwright:intro-deck": "PW_UI_SLICE=intro-deck playwright test --project=intro-deck",
     "test:playwright:intro-article": "PW_UI_SLICE=intro-article playwright test --project=intro-article",
-    "test:playwright:ui-review-drive": "PW_UI_SLICE=ui-review-drive playwright test --project=ui-review-drive",
     "test:playwright:deep-dive-article": "PW_UI_SLICE=deep-dive-article playwright test --project=deep-dive-article",
     "test:playwright:how-decided-article": "PW_UI_SLICE=how-decided-article playwright test --project=how-decided-article",
     "smoke:headless": "node scripts/claude/headless-info-smoke.mjs",
     "test:docs": "node scripts/docs/validate-links.mjs && node scripts/docs/validate-rule-ownership.mjs && node scripts/docs/validate-decision-records.mjs",
     "test:workflows": "node scripts/github/lint-workflows.mjs",
     "test:pack": "node --test --test-reporter ./test/failure-summary-reporter.mjs test/packaged-install-smoke.test.mjs",
-    "schema:generate": "node scripts/generate-config-schema.mjs",
     "schema:check": "node scripts/generate-config-schema.mjs --check",
     "assets:check": "node scripts/claude/generate-claude-assets.mjs --check",
     "articles:render": "node scripts/pages/render-article.mjs",
-    "articles:check": "node scripts/pages/render-article.mjs --check",
     "repo-wiki": "node scripts/repo-wiki.mjs",
     "repo-wiki:bootstrap": "node scripts/repo-wiki.mjs scan --repo . && node scripts/repo-wiki.mjs plan --repo . && node scripts/repo-wiki.mjs compile --repo .",
-    "repo-wiki:scan": "node scripts/repo-wiki.mjs scan --repo .",
-    "repo-wiki:plan": "node scripts/repo-wiki.mjs plan --repo .",
-    "repo-wiki:lint-docs": "node scripts/repo-wiki.mjs lint-docs --repo .",
-    "repo-wiki:compile": "node scripts/repo-wiki.mjs compile --repo .",
-    "repo-wiki:lint": "node scripts/repo-wiki.mjs lint --repo .",
-    "repo-wiki:search": "node scripts/repo-wiki.mjs search --repo .",
-    "repo-wiki:init": "node scripts/repo-wiki.mjs init --repo .",
-    "repo-wiki:prepare": "node scripts/repo-wiki.mjs --source local prepare",
-    "repo-wiki:local": "node scripts/repo-wiki.mjs --source local",
-    "repo-wiki:local-prepare": "node scripts/repo-wiki.mjs --source local prepare"
+    "repo-wiki:lint": "node scripts/repo-wiki.mjs lint --repo ."
   },
   "bin": {
     "dev-loops": "./cli/index.mjs"
@@ -94,7 +82,7 @@
     ]
   },
   "dependencies": {
-    "@dev-loops/core": "^1.0.0-rc.1",
+    "@dev-loops/core": "^1.0.0-rc.6",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/test/contracts/jq-output-base-guarantee-contract.test.mjs
+++ b/test/contracts/jq-output-base-guarantee-contract.test.mjs
@@ -97,11 +97,11 @@ const EXCLUDED = new Map([
   ],
   [
     "generate-config-schema.mjs",
-    "Derived-artifact generator (npm run schema:generate/schema:check): JSON.stringify writes schemas/dev-loop-config.schema.json to disk; stdout is a one-line human status, never a JSON tool-result to filter with --jq — same class as claude/generate-claude-assets.mjs.",
+    "Derived-artifact generator (npm run schema:check): JSON.stringify writes schemas/dev-loop-config.schema.json to disk; stdout is a one-line human status, never a JSON tool-result to filter with --jq — same class as claude/generate-claude-assets.mjs.",
   ],
   [
     "pages/render-article.mjs",
-    "Derived-artifact generator (npm run articles:render/articles:check): emits HTML files; JSON.stringify appears only inside thrown error messages, and stdout is a one-line human status — nothing for a caller to filter with --jq.",
+    "Derived-artifact generator (npm run articles:render): emits HTML files; JSON.stringify appears only inside thrown error messages, and stdout is a one-line human status — nothing for a caller to filter with --jq.",
   ],
 ]);
 

--- a/test/contracts/jq-output-base-guarantee-contract.test.mjs
+++ b/test/contracts/jq-output-base-guarantee-contract.test.mjs
@@ -97,7 +97,7 @@ const EXCLUDED = new Map([
   ],
   [
     "generate-config-schema.mjs",
-    "Derived-artifact generator (npm run schema:check): JSON.stringify writes schemas/dev-loop-config.schema.json to disk; stdout is a one-line human status, never a JSON tool-result to filter with --jq — same class as claude/generate-claude-assets.mjs.",
+    "Derived-artifact checker (npm run schema:check): runs the generator with --check, which reads schemas/dev-loop-config.schema.json and compares it to the rendered content, exiting non-zero when stale; stdout is a one-line human status, never a JSON tool-result to filter with --jq — same class as claude/generate-claude-assets.mjs.",
   ],
   [
     "pages/render-article.mjs",


### PR DESCRIPTION
## Objective

Two verified repo-hygiene children of the simplification epic (#1689), batched as one net-negative change because both edit `docs/repo-wiki-manual-first.md` (distinct lines) and are otherwise low-risk file-tree-disjoint cleanups. No functionality is lost.

## In scope

**#1692 — root package.json + repo-wiki doc hygiene**:
- Delete 9 unused `repo-wiki:*` npm scripts (scan, plan, lint-docs, compile, search, init, prepare, local, local-prepare); keep `repo-wiki`, `repo-wiki:bootstrap`, `repo-wiki:lint` (their `wiki.yml` consumers stay).
- Delete `articles:check`, `schema:generate`, `test:playwright:ui-review-drive` (zero live consumers); keep `schema:check`, `articles:render`, `assets:check`, and every other `test:playwright:*`.
- Alias `"test"` to `"npm run verify"` (the prior value was a stale partial copy of verify).
- Bump `@dev-loops/core` to `^1.0.0-rc.6` (published; prior pin `^1.0.0-rc.1`) and sync `package-lock.json`.
- Fix `docs/repo-wiki-manual-first.md`: remove `scripts/repo-wiki-local.mjs` dangling refs (fallback prose points to `scripts/repo-wiki.mjs --source local`), remove the phantom `repo-wiki:local-*` block, rewrite deleted-wrapper invocations to `node scripts/repo-wiki.mjs <stage> --repo .`.
- Update the two `jq-output-base-guarantee-contract.test.mjs` waiver rationale strings so they no longer name the deleted `schema:generate` / `articles:check` (prose only; path-keyed waiver map unchanged).

**#1693 — CI workflow hygiene**:
- `gate-evidence.yml`: replace the ~97-line header comment block with a <=6-line pointer comment naming `test/github/gate-evidence-workflow.test.mjs` and ADRs 0034 + 0043 (file paths only). Everything from `on:` onward, including step-local comments and all job ids, is unchanged.
- `wiki.yml`: merge `compile-wiki` and `publish-wiki` into one job. Keep the `upload-artifact` step with `if: always()`; move the old job-level publish condition verbatim to a step-level `if:` on the publish step; drop the download-artifact step and the redundant second checkout / setup-node / npm ci. The merged job declares `permissions: contents: write`.
- `docs/repo-wiki-manual-first.md`: rewrite the job descriptions to the single-job shape; doc job names match the merged `wiki.yml` job id.

## Explicit non-goals

- No doc merges or orphaned-doc deletions (that is #1694 / #1691).
- No shared gh-helper or script dedup (#1695-#1699).
- No removal of legacy `.pi` settings fallback or `queue.board` alias (#1701, deferred to v1 cut).
- No changes to `playwright.config.mjs` / the `ui-review-drive` project, to `ci.yml`/`pages.yml`/`release.yml`/`npm-publish.yml`, or to any gate-evidence job id/trigger/step.
- No bump of the root package `version` field (release process owns it).

## Acceptance criteria

- [x] The 9 unused `repo-wiki:*` scripts and `articles:check` / `schema:generate` / `test:playwright:ui-review-drive` are gone; the kept scripts remain.
- [x] `"test"` is exactly `"npm run verify"`; `npm test` runs the full verify suite set.
- [x] `@dev-loops/core` is `^1.0.0-rc.6`; `package-lock.json` synced; `npm ci` clean.
- [x] `docs/repo-wiki-manual-first.md` has zero `repo-wiki-local.mjs` refs and no phantom `repo-wiki:local-*` block; deleted-wrapper invocations rewritten; surviving `repo-wiki:bootstrap`/`repo-wiki:lint` stay as `npm run`.
- [x] `jq-output-base-guarantee-contract.test.mjs` waiver strings no longer name the deleted scripts.
- [x] `gate-evidence.yml` header replaced by a <=6-line file-paths-only pointer comment; everything from `on:` onward unchanged; no job renamed.
- [x] `wiki.yml` is one job with the publish condition as a step-level `if:`, `upload-artifact` with `if: always()` retained, no download-artifact / duplicate checkout-setup-npm, `permissions: contents: write`.
- [x] `docs/repo-wiki-manual-first.md` job descriptions match the single-job shape.

## Definition of done

- [x] `orphan-test-coverage`, `verify-suite-matrix-drift`, and `gate-evidence-workflow` tests pass.
- [x] `npm run test:docs`, `npm run test:workflows`, and `npm run verify` pass.
- [x] `npm ci` clean after the lockfile sync (no package.json/lock drift).
- [x] Post-merge: the wiki workflow run on the merge commit on main is green.

## AC / DoD / Non-goals matrix

| Acceptance criterion | Verified by DoD item(s) | Non-goal boundary |
|---|---|---|
| package.json scripts pruned + `test` aliased | orphan-test-coverage, verify-suite-matrix-drift, npm test == verify | no playwright project / version-field change |
| `@dev-loops/core` rc.6 + lockfile synced | `npm ci` clean | no other dependency bumps |
| repo-wiki doc dangling refs fixed | test:docs | no doc merges (#1694) |
| waiver rationale strings updated | npm run verify | waiver keys/logic unchanged |
| gate-evidence.yml header pointer only | gate-evidence-workflow test, test:workflows | no trigger/permission/job-id change |
| wiki.yml merged to one job | test:workflows, post-merge wiki run green | no other workflow files touched |
| repo-wiki doc single-job shape | npm run verify | no gh-helper work (#1695) |

## Open questions / risks

- **wiki.yml token-scope widening.** The merged wiki job runs the compile phase (`npm ci` + LLM bootstrap) under `permissions: contents: write` instead of `read`. The token is repo-scoped and the only push target is the wiki remote. Accepted per the issue verifier.

## Validation

```sh
npm run verify
npm run test:docs
npm run test:workflows
npm ci
```

Closes #1692
Closes #1693
