### PR TITLE
feat(gate): defer disposition creates a tracked follow-up issue, never ledger-only

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1686,11 +1686,16 @@ round) and states the window/disposition reason (see `dispositionMessage` in
 when one named shared root cause genuinely closed them all.
 
 <!-- rule: GATE-EXEC-DEFERRAL-RECORD -->
-`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly THREE places, never a
-standalone summary comment as a fourth: the finding's own posted surface — the resolving reply on
+`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in up to THREE places, never a
+standalone summary comment as an extra: the finding's own posted surface — the resolving reply on
 its thread for a locatable finding, or its body-filed entry on the round's review for a
 non-locatable one — the durable findings-log ledger under `tmp/gate-findings/...`, and (#1807,
 below) the PR's ONE tracked GitHub follow-up issue, the durable record that survives a `tmp/` wipe.
+The third place — the tracked issue — is created for every deferral that flows through the
+disposition pass or the judge defer path (a locatable thread stamped `disposition=deferred`). The
+body-filed non-locatable case is the one disclosed exception (#1807 known limitation): it is
+stamped and body-filed durably (the first two places) but does not itself create the tracked
+issue, because that render-time call site has no GitHub I/O.
 The posted surface and the ledger both carry the finding marker's optional `disposition=deferred`
 field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1280,6 +1280,16 @@ to the fixer pass (`GATE-EXEC-JUDGE-AUTHORITY-SPLIT`). If `judge-pass` fails clo
 head, malformed verdict, out-of-range index, undisposed finding), the conductor re-runs the judge at the
 current head rather than degrading to severity-only disposition for a wired gate.
 
+`judge-pass` is also where a judge `defer` creates its tracked follow-up issue (#1807,
+`GATE-EXEC-DEFERRAL-RECORD`): every `defer`-disposed finding gets a stable `fingerprint`, and the
+PR's ONE follow-up issue is created (first defer on the PR) or appended to (a later defer on the
+same PR) via the sanctioned `scripts/github/create-issue.mjs` / `comment-issue.mjs` wrappers —
+never a raw `gh` call. Each `defer` finding's ledger entry carries the resulting
+`followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft, only its
+`fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the same round
+reads back its own prior `--ledger-out` to recover the PR's already-linked issue number and already
+-linked fingerprints, so a retry links the existing issue rather than creating a duplicate.
+
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->
 `GATE-EXEC-JUDGE-AUTHORITY-SPLIT`: The judge owns **relevance** (is this finding for this
 PR?); the fixer owns **reproduction** (does this finding reproduce / is it a real defect?).
@@ -1672,7 +1682,7 @@ when one named shared root cause genuinely closed them all.
 third summary comment: the finding's own posted surface — the resolving reply on its thread for a
 locatable finding, or its body-filed entry on the round's review for a non-locatable one — and the
 durable findings-log ledger under `tmp/gate-findings/...`. Both carry the finding marker's optional `disposition=deferred`
-field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred] -->`),
+field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a
 fixing commit. A THREAD marker is stamped `disposition=deferred` only when the disposition pass
 defers it (a medium thread past the gate's configured medium fix window
@@ -1685,6 +1695,25 @@ non-locatable (body-filed) marker is stamped `disposition=deferred` unconditiona
 severity other than `high`, at the round it is first posted — permanently deferred by
 construction, since a body-filed finding has no code location and so can never become a
 resolvable thread through which the standard fix loop could otherwise close it.
+
+A `defer` is never parked ONLY in the thread marker and the ephemeral tmp findings ledger: it
+ALWAYS creates or appends to a tracked GitHub issue — the
+durable, tracker-first record that survives a `tmp/` wipe. Every `defer` for one PR shares ONE
+follow-up issue, batched: the first deferral on a PR creates it (title `Deferred gate findings for
+<repo>#<pr>`, body listing every deferred finding's fingerprint/severity/angle); every later
+deferral on the same PR — a later round's newly out-of-window medium, a fixer-triaged low, a
+judge `defer` — appends a comment to that SAME issue rather than minting a second one. Both the
+thread marker (`issue=<n>`) and the durable ledger entry (`followUpIssueNumber`) record the issue
+number — the re-attachment pointer that lets a reader recover the tracked record even after the
+ephemeral ledger is gone. Idempotency is per-PR, not per-fingerprint: a re-run of the disposition
+pass links the PR's existing follow-up issue (found on an already-stamped thread marker, or, for
+the judge's own bridge, on the prior `--ledger-out` artifact) rather than creating a duplicate. A
+`disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
+contract violation, refused fail-closed exactly like an out-of-window stamp.
+
+A `reject` (the judge's relevance axis only — see Phase 3.5 below) is never a deferral and creates
+no issue: it records a one-line audit entry in the durable ledger (fingerprint, severity, angle,
+`judgeDisposition: "reject"`, rationale) and nothing else.
 
 ## Execution mode and fan-out evidence enforcement
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1283,12 +1283,20 @@ current head rather than degrading to severity-only disposition for a wired gate
 `judge-pass` is also where a judge `defer` creates its tracked follow-up issue (#1807,
 `GATE-EXEC-DEFERRAL-RECORD`): every `defer`-disposed finding gets a stable `fingerprint`, and the
 PR's ONE follow-up issue is created (first defer on the PR) or appended to (a later defer on the
-same PR) via the sanctioned `scripts/github/create-issue.mjs` / `comment-issue.mjs` wrappers —
-never a raw `gh` call. Each `defer` finding's ledger entry carries the resulting
-`followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft, only its
-`fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the same round
-reads back its own prior `--ledger-out` to recover the PR's already-linked issue number and already
--linked fingerprints, so a retry links the existing issue rather than creating a duplicate.
+same PR) via `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`), which calls the
+sanctioned `createIssue` / `commentIssue` functions imported from `@dev-loops/core/github/issue-ops`
+(the same module the `create-issue.mjs` / `comment-issue.mjs` CLI wrappers themselves call) —
+never a raw `gh` call. `close-gate-findings.mjs`'s own severity/round-based defer routes through
+the SAME `ensureFollowUpIssue`, and both callers' local idempotency caches (`judge-pass`'s
+`--ledger-out`, `close-gate-findings`'s thread `issue=` marker) are fast-path optimizations only —
+`ensureFollowUpIssue` resolves against GitHub itself (an open-issue title search) before creating
+whenever the calling pass doesn't already know a number, so the two independent defer paths always
+converge on the SAME one issue per PR (#1809). Each `defer` finding's ledger entry carries the
+resulting `followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft,
+only its `fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the
+same round reads back its own prior `--ledger-out` to recover the PR's already-linked issue number
+and already-linked fingerprints, so a retry links the existing issue rather than creating a
+duplicate.
 
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->
 `GATE-EXEC-JUDGE-AUTHORITY-SPLIT`: The judge owns **relevance** (is this finding for this
@@ -1678,10 +1686,12 @@ round) and states the window/disposition reason (see `dispositionMessage` in
 when one named shared root cause genuinely closed them all.
 
 <!-- rule: GATE-EXEC-DEFERRAL-RECORD -->
-`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly two places, never a
-third summary comment: the finding's own posted surface — the resolving reply on its thread for a
-locatable finding, or its body-filed entry on the round's review for a non-locatable one — and the
-durable findings-log ledger under `tmp/gate-findings/...`. Both carry the finding marker's optional `disposition=deferred`
+`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly THREE places, never a
+standalone summary comment as a fourth: the finding's own posted surface — the resolving reply on
+its thread for a locatable finding, or its body-filed entry on the round's review for a
+non-locatable one — the durable findings-log ledger under `tmp/gate-findings/...`, and (#1807,
+below) the PR's ONE tracked GitHub follow-up issue, the durable record that survives a `tmp/` wipe.
+The posted surface and the ledger both carry the finding marker's optional `disposition=deferred`
 field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a
 fixing commit. A THREAD marker is stamped `disposition=deferred` only when the disposition pass
@@ -1706,8 +1716,14 @@ judge `defer` — appends a comment to that SAME issue rather than minting a sec
 thread marker (`issue=<n>`) and the durable ledger entry (`followUpIssueNumber`) record the issue
 number — the re-attachment pointer that lets a reader recover the tracked record even after the
 ephemeral ledger is gone. Idempotency is per-PR, not per-fingerprint: a re-run of the disposition
-pass links the PR's existing follow-up issue (found on an already-stamped thread marker, or, for
-the judge's own bridge, on the prior `--ledger-out` artifact) rather than creating a duplicate. A
+pass links the PR's existing follow-up issue rather than creating a duplicate. The judge's own
+bridge (`judge-pass.mjs`) and `close-gate-findings.mjs`'s severity/round-based defer are two
+INDEPENDENT passes with disjoint local caches (the judge's prior `--ledger-out` artifact vs. an
+already-stamped thread marker's `issue=` field) — a PR that defers through both paths converges on
+the SAME one issue because `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`)
+resolves against GitHub itself (an open-issue title search) whenever a pass's own local cache
+doesn't already know a number, not because either pass's cache is authoritative on its own (#1809).
+A
 `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1727,7 +1727,7 @@ A
 `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 
-A `reject` (the judge's relevance axis only — see Phase 3.5 below) is never a deferral and creates
+A `reject` (the judge's relevance axis only — see Phase 3.5 above) is never a deferral and creates
 no issue: it records a one-line audit entry in the durable ledger (fingerprint, severity, angle,
 `judgeDisposition: "reject"`, rationale) and nothing else.
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -1723,8 +1723,7 @@ already-stamped thread marker's `issue=` field) — a PR that defers through bot
 the SAME one issue because `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`)
 resolves against GitHub itself (an open-issue title search) whenever a pass's own local cache
 doesn't already know a number, not because either pass's cache is authoritative on its own (#1809).
-A
-`disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
+A `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 
 A `reject` (the judge's relevance axis only — see Phase 3.5 above) is never a deferral and creates

--- a/packages/core/src/github/issue-ops.mjs
+++ b/packages/core/src/github/issue-ops.mjs
@@ -288,6 +288,13 @@ export async function listIssues(options, { env = process.env, ghCommand = "gh",
   for (const label of options.labels ?? []) {
     args.push("--label", label);
   }
+  // `--search` narrows the result set to gh's own full-text search (title,
+  // body, comments) rather than the bare paged listing — needed by a caller
+  // that must find one specific issue by title without trusting that it falls
+  // within the default 30-issue page.
+  if (typeof options.search === "string" && options.search.length > 0) {
+    args.push("--search", options.search);
+  }
   const result = await run(ghCommand, args, env);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -215,24 +215,41 @@ export function collectFingerprints(text, set) {
 // auto-link token), while the create path's `createIssue` runs no such guard
 // at all — so a raw id in a finding's own summary would silently leak via
 // GitHub's auto-link on a first-ever defer, then abort the whole pass on a
-// LATER defer of the same PR, purely because of defer ordering. Entity-encode
-// the hash here, at the one place every deferred entry renders, so neither
-// path ever sees a live `#<digits>` token to begin with — consistent with the
-// repo's entity-encode-not-escape convention (sanitizeInline/sanitizeCodeSpan
-// above); this must never be "add the throwing guard to createIssue too", or
-// ordinary finding text that happens to start a sentence with a hashtag-like
-// number would fail-close the create path as well.
+// LATER defer of the same PR, purely because of defer ordering.
+//
+// #1809 round-2: entity-encoding the hash (`&#35;123`) does NOT fix this.
+// `guardCommentBodyNoIssuePrIds` is decode-aware — it runs a single
+// renderer-like decode of numeric character references before scanning — so
+// `&#35;123` decodes straight back to `#123` and the guard refuses it exactly
+// like the raw form. The only guard-safe rendering is one that never leaves a
+// `#` immediately adjacent to digits in EITHER the raw or the decoded text, so
+// this strips the leading `#` from a bare id token instead of encoding it
+// (`#123` -> `123`): no decode path can ever reassemble a leading `#` from
+// bare digits, so this is unconditionally guard-safe rather than merely
+// guard-safe-until-decoded. This also makes GitHub's own auto-linker a
+// non-issue (auto-link syntax requires the leading `#`), so the create path
+// (still unguarded) is safe too — both paths render through this one function,
+// so they stay symmetric by construction rather than by each independently
+// avoiding the guard.
+//
+// Runs on the RAW summary/angle text, BEFORE sanitizeInline/sanitizeCodeSpan:
+// those sanitizers emit their own numeric character references (e.g. `&#91;`
+// for `[`), and this regex does not distinguish an entity's digits from a bare
+// id's — neutralizing post-sanitize would re-match and corrupt an
+// already-emitted entity (`&#91;` -> `&&#35;91;`).
 const BARE_ISSUE_PR_ID_RE = /#(\d{1,9})/g;
 function neutralizeBareIssuePrIds(value) {
-  return String(value).replace(BARE_ISSUE_PR_ID_RE, "&#35;$1");
+  return String(value).replace(BARE_ISSUE_PR_ID_RE, "$1");
 }
 
 function formatDeferredFindingEntry({ fingerprint, severity, angle, summary, refUrl }) {
   const detail = typeof summary === "string" && summary.trim().length > 0
-    ? sanitizeInline(summary.trim())
-    : (typeof refUrl === "string" && refUrl.trim().length > 0 ? refUrl.trim() : "(no summary recorded)");
-  const line = `- \`${sanitizeCodeSpan(fingerprint)}\` **${sanitizeInline(normalizeSeverity(severity))}** (\`${sanitizeCodeSpan(angle)}\`): ${detail}`;
-  return neutralizeBareIssuePrIds(line);
+    ? sanitizeInline(neutralizeBareIssuePrIds(summary.trim()))
+    : (typeof refUrl === "string" && refUrl.trim().length > 0
+      ? neutralizeBareIssuePrIds(refUrl.trim())
+      : "(no summary recorded)");
+  const safeAngle = sanitizeCodeSpan(neutralizeBareIssuePrIds(angle));
+  return `- \`${sanitizeCodeSpan(fingerprint)}\` **${sanitizeInline(normalizeSeverity(severity))}** (\`${safeAngle}\`): ${detail}`;
 }
 
 export function buildFollowUpIssueTitle({ repo, pr }) {
@@ -322,8 +339,17 @@ export async function ensureFollowUpIssue(
     );
     return { issueNumber: resolvedIssueNumber, created: false };
   }
+  // #1809 round-2: `commentIssue` (append path, above) runs
+  // `guardCommentBodyNoIssuePrIds` internally; `createIssue` does not. Guard
+  // the create body explicitly here too — belt-and-braces symmetry with the
+  // append path, on top of (never instead of) formatDeferredFindingEntry's own
+  // guard-safe rendering — so a future rendering regression fails closed on
+  // BOTH paths identically rather than only on whichever path happens to defer
+  // second.
+  const createBody = buildFollowUpIssueBody({ repo, pr, entries });
+  guardCommentBodyNoIssuePrIds(createBody, { ref: "follow-up issue body" });
   const result = await createIssue(
-    { repo, title: buildFollowUpIssueTitle({ repo, pr }), body: buildFollowUpIssueBody({ repo, pr, entries }) },
+    { repo, title: buildFollowUpIssueTitle({ repo, pr }), body: createBody },
     { env, ghCommand, run },
   );
   return { issueNumber: result.issueNumber, created: true };

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -13,7 +13,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { matchGateReviewCommentHeader } from "@dev-loops/core/github/copilot-helpers";
-import { createIssue as coreCreateIssue, commentIssue as coreCommentIssue } from "@dev-loops/core/github/issue-ops";
+import { createIssue as coreCreateIssue, commentIssue as coreCommentIssue, listIssues as coreListIssues } from "@dev-loops/core/github/issue-ops";
 import { VALID_SEVERITIES, hasLocatableShape, normalizeSeverity } from "@dev-loops/core/loop/gate-fanin";
 import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import {
@@ -208,11 +208,31 @@ export function collectFingerprints(text, set) {
 // thread marker's own `issue=` field), is reused: new entries are appended as
 // a comment instead of minting a second issue.
 
+// A finding's summary (and, transitively, angle) is untrusted free text from a
+// scoped-review agent. `ensureFollowUpIssue`'s append path renders this same
+// entry into a body that `commentIssue` guards with
+// `guardCommentBodyNoIssuePrIds` (fail-closed: throws on a bare `#<digits>`
+// auto-link token), while the create path's `createIssue` runs no such guard
+// at all — so a raw id in a finding's own summary would silently leak via
+// GitHub's auto-link on a first-ever defer, then abort the whole pass on a
+// LATER defer of the same PR, purely because of defer ordering. Entity-encode
+// the hash here, at the one place every deferred entry renders, so neither
+// path ever sees a live `#<digits>` token to begin with — consistent with the
+// repo's entity-encode-not-escape convention (sanitizeInline/sanitizeCodeSpan
+// above); this must never be "add the throwing guard to createIssue too", or
+// ordinary finding text that happens to start a sentence with a hashtag-like
+// number would fail-close the create path as well.
+const BARE_ISSUE_PR_ID_RE = /#(\d{1,9})/g;
+function neutralizeBareIssuePrIds(value) {
+  return String(value).replace(BARE_ISSUE_PR_ID_RE, "&#35;$1");
+}
+
 function formatDeferredFindingEntry({ fingerprint, severity, angle, summary, refUrl }) {
   const detail = typeof summary === "string" && summary.trim().length > 0
     ? sanitizeInline(summary.trim())
     : (typeof refUrl === "string" && refUrl.trim().length > 0 ? refUrl.trim() : "(no summary recorded)");
-  return `- \`${sanitizeCodeSpan(fingerprint)}\` **${sanitizeInline(normalizeSeverity(severity))}** (\`${sanitizeCodeSpan(angle)}\`): ${detail}`;
+  const line = `- \`${sanitizeCodeSpan(fingerprint)}\` **${sanitizeInline(normalizeSeverity(severity))}** (\`${sanitizeCodeSpan(angle)}\`): ${detail}`;
+  return neutralizeBareIssuePrIds(line);
 }
 
 export function buildFollowUpIssueTitle({ repo, pr }) {
@@ -237,26 +257,70 @@ export function buildFollowUpIssueAppendComment({ entries }) {
 }
 
 /**
+ * Resolve the PR's ONE tracked follow-up issue by asking GitHub itself,
+ * rather than a caller's own local idempotency channel. #1807/cross-path fix:
+ * `judge-pass.mjs` (relevance defer) and `close-gate-findings.mjs`
+ * (severity/round defer) each cache the link in a DISJOINT local store — the
+ * judge's own `--ledger-out` artifact vs. a thread marker's `issue=` field —
+ * so a PR that fires both paths could mint two issues if each trusted only
+ * its own cache. GitHub is the one channel both paths share: search open
+ * issues for the deterministic per-PR title (`buildFollowUpIssueTitle`) and
+ * require an EXACT title match (gh's `--search` is full-text/fuzzy, so a
+ * substring or reordered-word hit must not be treated as this PR's issue).
+ * Returns the lowest matching issue number, or `null` when none exists yet.
+ */
+export async function findFollowUpIssueOnGitHub(
+  { repo, pr },
+  { env = process.env, ghCommand = "gh", run = defaultRunChild, listIssues = coreListIssues } = {},
+) {
+  const title = buildFollowUpIssueTitle({ repo, pr });
+  const { issues } = await listIssues(
+    { repo, state: "open", search: `"${title}" in:title`, limit: 10 },
+    { env, ghCommand, run },
+  );
+  const matches = issues.filter((issue) => issue.title === title).map((issue) => issue.number);
+  return matches.length > 0 ? Math.min(...matches) : null;
+}
+
+/**
  * Create (or, when `existingIssueNumber` is already known, append a comment
  * to) the ONE tracked follow-up issue for a batch of `defer`-disposed
  * findings on one PR. Returns `{ issueNumber, created }`. The `createIssue` /
- * `commentIssue` dependencies default to the sanctioned core wrappers
- * (`@dev-loops/core/github/issue-ops`) — never a raw `gh` call — and are
- * injectable so a caller/test can stub them without hitting the real API.
+ * `commentIssue` / `listIssues` dependencies default to the sanctioned core
+ * wrappers (`@dev-loops/core/github/issue-ops`) — never a raw `gh` call — and
+ * are injectable so a caller/test can stub them without hitting the real API.
+ *
+ * When the caller does not already know an `existingIssueNumber` (its own
+ * local cache is empty or stale), this resolves against GitHub itself
+ * (`findFollowUpIssueOnGitHub`) BEFORE creating — the caller-supplied value
+ * is trusted as a fast-path optimization (skips the search round-trip), but
+ * an absent one is never treated as proof no issue exists yet.
+ *
+ * ponytail: a crash between `createIssue` returning and the caller writing
+ * its own local link (the ledger/marker) no longer orphans a duplicate on
+ * retry — the retry's search-before-create finds the just-created issue on
+ * GitHub and appends instead. The one residual window is GitHub search's own
+ * indexing lag: a retry landing in the brief gap before the new issue is
+ * searchable could still create a second one. Narrowing that further (e.g. a
+ * direct `gh issue view` fallback keyed on a caller-recorded issue number)
+ * is not worth it until it is observed in practice.
  */
 export async function ensureFollowUpIssue(
   { repo, pr, entries, existingIssueNumber },
-  { env = process.env, ghCommand = "gh", run = defaultRunChild, createIssue = coreCreateIssue, commentIssue = coreCommentIssue } = {},
+  { env = process.env, ghCommand = "gh", run = defaultRunChild, createIssue = coreCreateIssue, commentIssue = coreCommentIssue, listIssues = coreListIssues } = {},
 ) {
   if (!Array.isArray(entries) || entries.length === 0) {
     throw new Error("ensureFollowUpIssue: entries must be a non-empty array");
   }
-  if (Number.isInteger(existingIssueNumber) && existingIssueNumber > 0) {
+  const resolvedIssueNumber = Number.isInteger(existingIssueNumber) && existingIssueNumber > 0
+    ? existingIssueNumber
+    : await findFollowUpIssueOnGitHub({ repo, pr }, { env, ghCommand, run, listIssues });
+  if (resolvedIssueNumber !== null) {
     await commentIssue(
-      { repo, issue: existingIssueNumber, body: buildFollowUpIssueAppendComment({ entries }) },
+      { repo, issue: resolvedIssueNumber, body: buildFollowUpIssueAppendComment({ entries }) },
       { env, ghCommand, run },
     );
-    return { issueNumber: existingIssueNumber, created: false };
+    return { issueNumber: resolvedIssueNumber, created: false };
   }
   const result = await createIssue(
     { repo, title: buildFollowUpIssueTitle({ repo, pr }), body: buildFollowUpIssueBody({ repo, pr, entries }) },

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -13,6 +13,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { matchGateReviewCommentHeader } from "@dev-loops/core/github/copilot-helpers";
+import { createIssue as coreCreateIssue, commentIssue as coreCommentIssue } from "@dev-loops/core/github/issue-ops";
 import { VALID_SEVERITIES, hasLocatableShape, normalizeSeverity } from "@dev-loops/core/loop/gate-fanin";
 import { runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import {
@@ -121,12 +122,20 @@ export function isDeferredAtRound(severity, round, mediumFixWindow = MEDIUM_FIX_
 // this module's own reader disagree on the accepted vocabulary.
 const VALID_MARKER_DISPOSITIONS = new Set(["deferred"]);
 
-export function buildFindingMarker({ fp, severity, angle, round, disposition }) {
+// `issue` is the follow-up GitHub issue number a `disposition=deferred`
+// finding is tracked on (#1807, GATE-EXEC-DEFERRAL-RECORD): a deferral must
+// never live only in the thread marker and the ephemeral tmp ledger, so the
+// marker itself carries the re-attachment pointer.
+export function buildFindingMarker({ fp, severity, angle, round, disposition, issue }) {
   if (disposition !== undefined && !VALID_MARKER_DISPOSITIONS.has(disposition)) {
     throw new Error(`buildFindingMarker: disposition must be "deferred" (or omitted), got ${JSON.stringify(disposition)}`);
   }
+  if (issue !== undefined && (!Number.isInteger(issue) || issue <= 0)) {
+    throw new Error(`buildFindingMarker: issue must be a positive integer (or omitted), got ${JSON.stringify(issue)}`);
+  }
   const dispositionField = disposition ? ` disposition=${slugForMarker(disposition)}` : "";
-  return `<!-- dev-loops:finding ${fp} severity=${slugForMarker(severity)} angle=${slugForMarker(angle)} round=${round}${dispositionField} -->`;
+  const issueField = issue !== undefined ? ` issue=${issue}` : "";
+  return `<!-- dev-loops:finding ${fp} severity=${slugForMarker(severity)} angle=${slugForMarker(angle)} round=${round}${dispositionField}${issueField} -->`;
 }
 
 // Anchored to the START of a line (multiline `m`): a marker quoted mid-line
@@ -134,13 +143,20 @@ export function buildFindingMarker({ fp, severity, angle, round, disposition }) 
 // marker as an example) must never be honored as a real marker. Every marker
 // this module renders is always the first character of its own line, so this
 // anchor costs nothing against genuine markers.
-export const FINDING_MARKER_RE = /^<!--\s*dev-loops:finding\s+([0-9a-f]{16})\s+severity=([a-z0-9._-]+)\s+angle=([a-z0-9._-]+)\s+round=(\d+)(?:\s+disposition=(deferred))?\s*-->/m;
+export const FINDING_MARKER_RE = /^<!--\s*dev-loops:finding\s+([0-9a-f]{16})\s+severity=([a-z0-9._-]+)\s+angle=([a-z0-9._-]+)\s+round=(\d+)(?:\s+disposition=(deferred))?(?:\s+issue=(\d+))?\s*-->/m;
 const FINDING_MARKER_FP_ONLY_RE = /^<!--\s*dev-loops:finding\s+([0-9a-f]{16})\b/gm;
 
 export function parseFindingMarker(text) {
   const match = typeof text === "string" ? text.match(FINDING_MARKER_RE) : null;
   if (!match) return null;
-  return { fp: match[1], severity: normalizeSeverity(match[2]), angle: match[3], round: Number(match[4]), disposition: match[5] ?? null };
+  return {
+    fp: match[1],
+    severity: normalizeSeverity(match[2]),
+    angle: match[3],
+    round: Number(match[4]),
+    disposition: match[5] ?? null,
+    issue: match[6] ? Number(match[6]) : null,
+  };
 }
 
 // Round is embedded here (an addition beyond the finding marker's own round=,
@@ -176,6 +192,77 @@ export function collectFingerprints(text, set) {
   for (const match of text.matchAll(FINDING_MARKER_FP_ONLY_RE)) {
     set.add(match[1]);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Follow-up issue for deferred findings (#1807)
+// ---------------------------------------------------------------------------
+//
+// A `defer` disposition — the judge's relevance-based defer (judge-pass.mjs)
+// or the severity/round-based auto-defer (close-gate-findings.mjs's
+// disposition pass) — must never live only in a thread marker and the
+// ephemeral tmp findings ledger; it always creates or appends to ONE tracked
+// GitHub issue per PR (batched: every finding a PR ever defers is one entry
+// on that same issue, never one issue per finding). `existingIssueNumber`,
+// when the caller already knows one (a prior round's ledger, or an existing
+// thread marker's own `issue=` field), is reused: new entries are appended as
+// a comment instead of minting a second issue.
+
+function formatDeferredFindingEntry({ fingerprint, severity, angle, summary, refUrl }) {
+  const detail = typeof summary === "string" && summary.trim().length > 0
+    ? sanitizeInline(summary.trim())
+    : (typeof refUrl === "string" && refUrl.trim().length > 0 ? refUrl.trim() : "(no summary recorded)");
+  return `- \`${sanitizeCodeSpan(fingerprint)}\` **${sanitizeInline(normalizeSeverity(severity))}** (\`${sanitizeCodeSpan(angle)}\`): ${detail}`;
+}
+
+export function buildFollowUpIssueTitle({ repo, pr }) {
+  return `Deferred gate findings for ${repo}#${pr}`;
+}
+
+export function buildFollowUpIssueBody({ repo, pr, entries }) {
+  const lines = [
+    `Gate review findings deferred out of https://github.com/${repo}/pull/${pr}, tracked here instead of only in the gate's thread markers and the ephemeral tmp findings ledger.`,
+    "",
+    ...entries.map(formatDeferredFindingEntry),
+  ];
+  return lines.join("\n");
+}
+
+export function buildFollowUpIssueAppendComment({ entries }) {
+  return [
+    "Additional gate finding(s) deferred to this issue:",
+    "",
+    ...entries.map(formatDeferredFindingEntry),
+  ].join("\n");
+}
+
+/**
+ * Create (or, when `existingIssueNumber` is already known, append a comment
+ * to) the ONE tracked follow-up issue for a batch of `defer`-disposed
+ * findings on one PR. Returns `{ issueNumber, created }`. The `createIssue` /
+ * `commentIssue` dependencies default to the sanctioned core wrappers
+ * (`@dev-loops/core/github/issue-ops`) — never a raw `gh` call — and are
+ * injectable so a caller/test can stub them without hitting the real API.
+ */
+export async function ensureFollowUpIssue(
+  { repo, pr, entries, existingIssueNumber },
+  { env = process.env, ghCommand = "gh", run = defaultRunChild, createIssue = coreCreateIssue, commentIssue = coreCommentIssue } = {},
+) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error("ensureFollowUpIssue: entries must be a non-empty array");
+  }
+  if (Number.isInteger(existingIssueNumber) && existingIssueNumber > 0) {
+    await commentIssue(
+      { repo, issue: existingIssueNumber, body: buildFollowUpIssueAppendComment({ entries }) },
+      { env, ghCommand, run },
+    );
+    return { issueNumber: existingIssueNumber, created: false };
+  }
+  const result = await createIssue(
+    { repo, title: buildFollowUpIssueTitle({ repo, pr }), body: buildFollowUpIssueBody({ repo, pr, entries }) },
+    { env, ghCommand, run },
+  );
+  return { issueNumber: result.issueNumber, created: true };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -237,9 +237,14 @@ export function collectFingerprints(text, set) {
 // for `[`), and this regex does not distinguish an entity's digits from a bare
 // id's — neutralizing post-sanitize would re-match and corrupt an
 // already-emitted entity (`&#91;` -> `&&#35;91;`).
-const BARE_ISSUE_PR_ID_RE = /#(\d{1,9})/g;
+// Strip EVERY number-sign in a consecutive run immediately before a digit, not
+// just the innermost one: `#123` and `##123` alike must leave `123` with no
+// residual number-sign, or the leftover still auto-links AND trips the
+// decode-aware guard. A lookahead consumes only the number-sign(s), keeping the
+// digits.
+const BARE_ISSUE_PR_ID_RE = /#+(?=\d)/g;
 function neutralizeBareIssuePrIds(value) {
-  return String(value).replace(BARE_ISSUE_PR_ID_RE, "$1");
+  return String(value).replace(BARE_ISSUE_PR_ID_RE, "");
 }
 
 function formatDeferredFindingEntry({ fingerprint, severity, angle, summary, refUrl }) {

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -225,12 +225,21 @@ export function collectFingerprints(text, set) {
 // `#` immediately adjacent to digits in EITHER the raw or the decoded text, so
 // this strips the leading `#` from a bare id token instead of encoding it
 // (`#123` -> `123`): no decode path can ever reassemble a leading `#` from
-// bare digits, so this is unconditionally guard-safe rather than merely
-// guard-safe-until-decoded. This also makes GitHub's own auto-linker a
-// non-issue (auto-link syntax requires the leading `#`), so the create path
-// (still unguarded) is safe too — both paths render through this one function,
-// so they stay symmetric by construction rather than by each independently
-// avoiding the guard.
+// bare digits. This also makes GitHub's own auto-linker a non-issue (auto-link
+// syntax requires the leading `#`), so the create path (still unguarded) is
+// safe too — both paths render through this one function, so they stay
+// symmetric by construction rather than by each independently avoiding the
+// guard.
+//
+// ponytail: this strips only a LITERAL `#` before digits — every form a review
+// agent actually authors (prose ids like `#123`). It does NOT mirror the guard's
+// full entity-decode surface, so untrusted text that ALREADY contains an HTML
+// entity encoding of the number-sign adjacent to digits (`&num;123`, `&#x23;123`)
+// still decodes to a bare id under the guard. That input is unreachable from
+// reviewer-authored finding prose, and when it does occur the guard fail-closes
+// (the defer pass aborts — no silent leak), which is the correct backstop.
+// Mirroring the guard's decoder here would duplicate its evolving entity table
+// against input that never arrives; the guard stays the single authority.
 //
 // Runs on the RAW summary/angle text, BEFORE sanitizeInline/sanitizeCodeSpan:
 // those sanitizers emit their own numeric character references (e.g. `&#91;`

--- a/scripts/github/close-gate-findings.mjs
+++ b/scripts/github/close-gate-findings.mjs
@@ -254,8 +254,14 @@ async function stampDeferredDisposition({ repo, commentId, round, mediumFixWindo
 // #1807: the ONE tracked follow-up issue for this PR — reused across gate
 // rounds — is found by scanning every gate-authored thread's OWN marker
 // (resolved threads included: a resolved thread's marker never loses its
-// `issue=` field) for a previously-recorded link. `null` when this PR has
-// never deferred a finding before.
+// `issue=` field) for a previously-recorded link. `null` when this pass's OWN
+// thread markers don't know of one yet — this is a fast-path cache (skips a
+// GitHub round-trip), not the authority: judge-pass.mjs's relevance defer
+// never stamps a thread marker's `issue=` field at all (it runs before any
+// finding is posted as a thread), so a PR whose only prior deferral went
+// through judge-pass always reads `null` here. `ensureFollowUpIssue`
+// (_gate-finding-surface.mjs) closes that gap by resolving against GitHub
+// itself before creating whenever this returns `null`.
 function findExistingFollowUpIssueNumber(threads, login) {
   for (const thread of threads) {
     if (thread.author !== login) continue;

--- a/scripts/github/close-gate-findings.mjs
+++ b/scripts/github/close-gate-findings.mjs
@@ -193,7 +193,19 @@ function selectDispositionTargets(threads, round, login, mediumFixWindow) {
     if (!Number.isInteger(thread.commentId) || thread.commentId <= 0) {
       throw new Error(`Thread ${thread.threadId} carries a gate-authored finding marker selected for deferral but has no resolvable comment id (commentId=${JSON.stringify(thread.commentId)}); refuse to stamp/resolve it.`);
     }
-    targets.push({ threadId: thread.threadId, commentId: thread.commentId, severity: marker.severity, angle: marker.angle, fp: marker.fp });
+    // #1807 idempotency: a target can already carry its own
+    // `disposition=deferred issue=<n>` stamp (e.g. an interrupted retry where
+    // the PATCH landed but the reply+resolve did not) — isDeferredAtRound
+    // still selects it (it must still be resolved), but runDispositionPass
+    // must never re-append it to the follow-up issue a second time.
+    targets.push({
+      threadId: thread.threadId,
+      commentId: thread.commentId,
+      severity: marker.severity,
+      angle: marker.angle,
+      fp: marker.fp,
+      alreadyStamped: marker.disposition === "deferred",
+    });
   }
   return targets;
 }
@@ -287,16 +299,31 @@ async function runDispositionPass({ repo, pr, round, threads, snapshot, login, m
   // this pass defers — reuse an existing one (found on an earlier round's
   // stamped marker) rather than mint a duplicate.
   const existingIssueNumber = findExistingFollowUpIssueNumber(threads, login);
-  const entries = targets.map((target) => ({
-    fingerprint: target.fp,
-    severity: target.severity,
-    angle: target.angle,
-    refUrl: `https://github.com/${repo}/pull/${pr}#discussion_r${target.commentId}`,
-  }));
-  const { issueNumber } = await ensureFollowUpIssue(
-    { repo, pr, entries, existingIssueNumber },
-    { env, ghCommand },
-  );
+  // Idempotency (Copilot review, PR #1809): a target already stamped
+  // `disposition=deferred issue=<n>` on a PRIOR (interrupted) run of this
+  // pass was already recorded on the follow-up issue — appending it again
+  // here would duplicate the "additional finding(s)" comment on every retry.
+  // Only targets NOT yet stamped still need to reach the follow-up issue;
+  // an already-stamped target still needs its reply+resolve below (that is
+  // exactly the retry gap: the stamp landed, the resolve did not), but never
+  // a second append.
+  const unstampedTargets = targets.filter((target) => !target.alreadyStamped);
+  let issueNumber = existingIssueNumber;
+  if (unstampedTargets.length > 0) {
+    const entries = unstampedTargets.map((target) => ({
+      fingerprint: target.fp,
+      severity: target.severity,
+      angle: target.angle,
+      refUrl: `https://github.com/${repo}/pull/${pr}#discussion_r${target.commentId}`,
+    }));
+    ({ issueNumber } = await ensureFollowUpIssue(
+      { repo, pr, entries, existingIssueNumber },
+      { env, ghCommand },
+    ));
+  }
+  // A pure retry (every target already stamped) must always resolve to the
+  // existing issue found on the threads' own markers — the guard in
+  // stampDeferredDisposition below fails closed if this is ever null/mismatched.
   let deferredResolved = 0;
   for (const target of targets) {
     await stampDeferredDisposition({ repo, commentId: target.commentId, round, mediumFixWindow, issueNumber }, { env, ghCommand });

--- a/scripts/github/close-gate-findings.mjs
+++ b/scripts/github/close-gate-findings.mjs
@@ -8,6 +8,7 @@ import {
   FINDING_MARKER_RE,
   MEDIUM_FIX_WINDOW,
   countUnresolvedGateAuthoredThreads,
+  ensureFollowUpIssue,
   fetchThreadsWithFullBodies,
   isDeferredAtRound,
   listPrReviews,
@@ -33,11 +34,13 @@ low is replied-to + resolved at gate close (after the Phase 5 fixer
 triage; #1585). question always stays open too — it is answered, never deferred,
 so an unanswered question blocks gate-close exactly like an open defect; nit is
 replied-to + resolved immediately, with no fixer cycle. A deferred thread's marker is
-stamped \`disposition=deferred\` before it is resolved, so the deferral disposition
-lives on the thread itself and in the durable tmp ledger. A
-contract-violating disposition=deferred stamp on a question or in-window medium
-thread (a subagent bypass of selectDispositionTargets) is detected and rejected
-before the pass runs (#1672).
+stamped \`disposition=deferred issue=<n>\` before it is resolved: a defer ALWAYS creates
+(or, when this PR already has one, appends to) ONE tracked follow-up GitHub issue for
+the round's whole batch of deferrals, so the deferral disposition is never parked only
+in the thread marker and the ephemeral tmp findings ledger. A
+contract-violating disposition=deferred stamp — on a question or in-window medium
+thread (a subagent bypass of selectDispositionTargets), or missing its linked follow-up
+issue number — is detected and rejected before the pass runs (#1672, #1807).
 
 Round number = the MAXIMUM of three worktree-independent-first sources:
   (A) count of DISTINCT reviewed-head SHAs across this gate's own verdict surfaces —
@@ -61,7 +64,8 @@ Optional:
 Output (stdout, JSON):
   { "ok": true, "repo": "...", "pr": 42, "gate": "...", "headSha": "...", "round": N,
     "deferredResolved": <disposition reply+resolve count>,
-    "unresolvedGateThreadCount": <gate-authored threads still unresolved after the defer pass; the gate-close assertion (fetchDraftGateEvidence / ready-for-review) refuses ready-for-review while non-zero (#1585)> }
+    "unresolvedGateThreadCount": <gate-authored threads still unresolved after the defer pass; the gate-close assertion (fetchDraftGateEvidence / ready-for-review) refuses ready-for-review while non-zero (#1585)>,
+    "followUpIssueNumber"?: <the PR's one tracked follow-up issue number; present only when this pass deferred at least one thread (#1807)> }
 
 ${JQ_OUTPUT_USAGE}
 Exit codes:
@@ -77,18 +81,23 @@ function parseError(message) {
 // Disposition pass
 // ---------------------------------------------------------------------------
 
-// #1672: Scan every unresolved gate-authored thread for a contract-violating
-// disposition=deferred stamp — one that selectDispositionTargets would never
-// have produced (question is never deferred; medium is deferred only past the
-// fix window). A subagent that manually stamped disposition=deferred on a
-// question or in-window medium thread (bypassing selectDispositionTargets /
-// stampDeferredDisposition entirely, via a direct gh api PATCH) leaves exactly
-// this signature. The mechanical enforcement (isDeferredAtRound in
-// selectDispositionTargets) is correct, but it only governs what THIS pass
-// stamps — it cannot prevent a manual stamp. This scan detects the bypass
-// BEFORE the disposition pass runs, so a contract-violating stamp surfaces as
-// a gate failure (throw) rather than silently proceeding to reply+resolve or
-// being counted as a clean deferral.
+// #1672/#1807: Scan every unresolved gate-authored thread for a
+// contract-violating disposition=deferred stamp — one that
+// selectDispositionTargets would never have produced (question is never
+// deferred; medium is deferred only past the fix window) OR that carries no
+// linked follow-up issue number (#1807: a defer must never live only in the
+// thread marker and the ephemeral tmp ledger — it always tracks a GitHub
+// issue). A subagent that manually stamped disposition=deferred on a
+// question or in-window medium thread, or that stamped disposition=deferred
+// without creating the follow-up issue first (bypassing
+// selectDispositionTargets / stampDeferredDisposition entirely, via a direct
+// gh api PATCH), leaves exactly this signature. The mechanical enforcement
+// (isDeferredAtRound + ensureFollowUpIssue in the sanctioned pass) is
+// correct, but it only governs what THIS pass stamps — it cannot prevent a
+// manual stamp. This scan detects the bypass BEFORE the disposition pass
+// runs, so a contract-violating stamp surfaces as a gate failure (throw)
+// rather than silently proceeding to reply+resolve or being counted as a
+// clean deferral.
 function detectContractViolatingDeferredStamps(threads, login, round, mediumFixWindow) {
   const violations = [];
   for (const thread of threads) {
@@ -108,13 +117,26 @@ function detectContractViolatingDeferredStamps(threads, login, round, mediumFixW
     if (thread.author !== login) continue;
     const marker = parseFindingMarker(thread.body);
     if (!marker) continue;
-    if (marker.disposition === "deferred" && !isDeferredAtRound(marker.severity, round, mediumFixWindow)) {
-      violations.push({ threadId: thread.threadId, commentId: thread.commentId, severity: marker.severity, round, mediumFixWindow });
+    if (marker.disposition !== "deferred") continue;
+    const outOfWindow = !isDeferredAtRound(marker.severity, round, mediumFixWindow);
+    const missingIssue = !Number.isInteger(marker.issue) || marker.issue <= 0;
+    if (outOfWindow || missingIssue) {
+      violations.push({
+        threadId: thread.threadId,
+        commentId: thread.commentId,
+        severity: marker.severity,
+        round,
+        mediumFixWindow,
+        issue: marker.issue,
+        reason: outOfWindow ? "out-of-window" : "missing-issue-link",
+      });
     }
   }
   if (violations.length > 0) {
-    const details = violations.map((v) => `thread ${v.threadId} (comment ${v.commentId}): severity=${v.severity} at round=${v.round} (mediumFixWindow=${v.mediumFixWindow}) carries disposition=deferred but isDeferredAtRound=false`).join("; ");
-    throw new Error(`GATE-EXEC-THREAD-DISPOSITION violation: ${violations.length} gate-authored thread(s) carry a contract-violating disposition=deferred stamp (${details}). A question must be answered (never deferred) and an in-window medium (round ≤ mediumFixWindow) must stay unresolved to force a fix round. Refuse to proceed with the disposition pass.`);
+    const details = violations
+      .map((v) => `thread ${v.threadId} (comment ${v.commentId}): severity=${v.severity} at round=${v.round} (mediumFixWindow=${v.mediumFixWindow}) carries disposition=deferred, reason=${v.reason}${v.issue ? ` (issue=${v.issue})` : ""}`)
+      .join("; ");
+    throw new Error(`GATE-EXEC-THREAD-DISPOSITION violation: ${violations.length} gate-authored thread(s) carry a contract-violating disposition=deferred stamp (${details}). A question must be answered (never deferred), an in-window medium (round ≤ mediumFixWindow) must stay unresolved to force a fix round, and every disposition=deferred stamp must link a follow-up issue number. Refuse to proceed with the disposition pass.`);
   }
 }
 
@@ -137,9 +159,10 @@ function windowReason(severity, mediumFixWindow) {
 // disposition reason for THIS thread, so no two threads ever receive the same
 // reply body even when a caller batches several deferrals in one pass — unlike
 // a FIX-closing reply (COPILOT-FOLLOWUP-REPLY-RESOLVE-HELPER), nothing here
-// names a "fix" because nothing was fixed.
-function dispositionMessage({ fp, severity, angle, round, mediumFixWindow }) {
-  return `Deferred at gate close (round ${round}, fingerprint ${fp}, severity ${severity}, angle ${angle}): ${windowReason(severity, mediumFixWindow)}; the deferral is recorded on this thread's marker and in the durable findings ledger.`;
+// names a "fix" because nothing was fixed. #1807: the deferral is tracked on a
+// GitHub issue (never only the thread marker and the ephemeral tmp ledger).
+function dispositionMessage({ fp, severity, angle, round, mediumFixWindow, repo, issueNumber }) {
+  return `Deferred at gate close (round ${round}, fingerprint ${fp}, severity ${severity}, angle ${angle}): ${windowReason(severity, mediumFixWindow)}; tracked in follow-up issue https://github.com/${repo}/issues/${issueNumber}.`;
 }
 
 // Every currently-unresolved gate-authored thread, whether newly posted this
@@ -182,7 +205,7 @@ function selectDispositionTargets(threads, round, login, mediumFixWindow) {
 // `/disposition=deferred/` body search): a finding whose own summary or
 // recommendation happens to quote that literal token must never be mistaken
 // for an already-stamped marker.
-async function stampDeferredDisposition({ repo, commentId, round, mediumFixWindow }, { env, ghCommand }) {
+async function stampDeferredDisposition({ repo, commentId, round, mediumFixWindow, issueNumber }, { env, ghCommand }) {
   const payload = await runGhJson(["api", `repos/${repo}/pulls/comments/${commentId}`], { env, ghCommand });
   // Trimmed to match parseReviewThreads' normalizeBody, which is what
   // selectDispositionTargets parsed thread.body through to select this exact
@@ -204,12 +227,42 @@ async function stampDeferredDisposition({ repo, commentId, round, mediumFixWindo
   if (!isDeferredAtRound(marker.severity, round, mediumFixWindow)) {
     throw new Error(`Review comment ${commentId} carries severity=${marker.severity} at round=${round} (mediumFixWindow=${mediumFixWindow}) which must not be deferred (isDeferredAtRound=false); refuse to stamp or resolve a contract-violating disposition=deferred (GATE-EXEC-THREAD-DISPOSITION).`);
   }
-  if (marker.disposition === "deferred") return;
-  const stamped = body.replace(FINDING_MARKER_RE, (m) => m.replace(/\s*-->$/, " disposition=deferred -->"));
+  if (marker.disposition === "deferred") {
+    // Already stamped (an idempotent retry of this pass) — must already link
+    // the SAME follow-up issue this pass resolved for the round's batch
+    // (#1807); a mismatch means the thread was stamped against a different
+    // issue than the one this pass is now tracking, which must fail closed
+    // rather than silently leaving a stale/wrong link on the thread.
+    if (marker.issue !== issueNumber) {
+      throw new Error(`Review comment ${commentId} is already stamped disposition=deferred issue=${marker.issue} but this pass resolved follow-up issue #${issueNumber}; refuse to overwrite the existing link (GATE-EXEC-THREAD-DISPOSITION).`);
+    }
+    return;
+  }
+  // #1807: every disposition=deferred stamp links a follow-up issue number —
+  // never resolve a thread's deferral into the thread marker + ephemeral tmp
+  // ledger alone.
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(`Review comment ${commentId} would be stamped disposition=deferred with no linked follow-up issue number; refuse (GATE-EXEC-THREAD-DISPOSITION).`);
+  }
+  const stamped = body.replace(FINDING_MARKER_RE, (m) => m.replace(/\s*-->$/, ` disposition=deferred issue=${issueNumber} -->`));
   await runGhJson(
     ["api", "-X", "PATCH", `repos/${repo}/pulls/comments/${commentId}`, "-f", `body=${stamped}`],
     { env, ghCommand },
   );
+}
+
+// #1807: the ONE tracked follow-up issue for this PR — reused across gate
+// rounds — is found by scanning every gate-authored thread's OWN marker
+// (resolved threads included: a resolved thread's marker never loses its
+// `issue=` field) for a previously-recorded link. `null` when this PR has
+// never deferred a finding before.
+function findExistingFollowUpIssueNumber(threads, login) {
+  for (const thread of threads) {
+    if (thread.author !== login) continue;
+    const marker = parseFindingMarker(thread.body);
+    if (marker && Number.isInteger(marker.issue) && marker.issue > 0) return marker.issue;
+  }
+  return null;
 }
 
 // `snapshot` is the full-body review-thread snapshot the caller already
@@ -224,17 +277,31 @@ async function runDispositionPass({ repo, pr, round, threads, snapshot, login, m
   if (targets.length === 0) {
     return { deferredResolved: 0 };
   }
+  // #1807: ONE tracked follow-up issue per PR for the whole batch of targets
+  // this pass defers — reuse an existing one (found on an earlier round's
+  // stamped marker) rather than mint a duplicate.
+  const existingIssueNumber = findExistingFollowUpIssueNumber(threads, login);
+  const entries = targets.map((target) => ({
+    fingerprint: target.fp,
+    severity: target.severity,
+    angle: target.angle,
+    refUrl: `https://github.com/${repo}/pull/${pr}#discussion_r${target.commentId}`,
+  }));
+  const { issueNumber } = await ensureFollowUpIssue(
+    { repo, pr, entries, existingIssueNumber },
+    { env, ghCommand },
+  );
   let deferredResolved = 0;
   for (const target of targets) {
-    await stampDeferredDisposition({ repo, commentId: target.commentId, round, mediumFixWindow }, { env, ghCommand });
-    const message = dispositionMessage({ fp: target.fp, severity: target.severity, angle: target.angle, round, mediumFixWindow });
+    await stampDeferredDisposition({ repo, commentId: target.commentId, round, mediumFixWindow, issueNumber }, { env, ghCommand });
+    const message = dispositionMessage({ fp: target.fp, severity: target.severity, angle: target.angle, round, mediumFixWindow, repo, issueNumber });
     await replyAndMaybeResolve(
       { repo, pr, commentId: target.commentId, threadId: target.threadId, body: message, resolve: true, validatedSnapshot: snapshot },
       { env, ghCommand },
     );
     deferredResolved += 1;
   }
-  return { deferredResolved };
+  return { deferredResolved, followUpIssueNumber: issueNumber };
 }
 
 // ---------------------------------------------------------------------------
@@ -328,7 +395,7 @@ export async function closeGateFindings(options, { env = process.env, ghCommand 
   // earlier round must be reconciled against THIS round regardless of whether
   // this round posted anything of its own.
   const { threads, snapshot } = await fetchThreadsWithFullBodies({ repo, pr }, gh);
-  const { deferredResolved } = await runDispositionPass(
+  const { deferredResolved, followUpIssueNumber } = await runDispositionPass(
     { repo, pr, round, threads, snapshot, login, mediumFixWindow },
     gh,
   );
@@ -355,7 +422,13 @@ export async function closeGateFindings(options, { env = process.env, ghCommand 
   // this snapshot invariant.)
   const unresolvedGateThreadCount = countUnresolvedGateAuthoredThreads(threads, login) - deferredResolved;
 
-  return { ok: true, repo, pr, gate, headSha, round, deferredResolved, unresolvedGateThreadCount };
+  const result = { ok: true, repo, pr, gate, headSha, round, deferredResolved, unresolvedGateThreadCount };
+  // #1807: only present when this pass actually deferred something — a round
+  // with nothing to defer creates no follow-up issue and reports none.
+  if (followUpIssueNumber !== undefined) {
+    result.followUpIssueNumber = followUpIssueNumber;
+  }
+  return result;
 }
 
 async function main() {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -159,6 +159,18 @@ function validateFindingsArray(parsed, flagLabel) {
     if (typeof f.judgeCriterion === "string" && f.judgeCriterion.trim().length > 0) {
       entry.judgeCriterion = f.judgeCriterion.trim();
     }
+    // #1807: a judge-pass-enriched finding carries a stable `fingerprint`
+    // (act/defer/reject — the reject audit entry keys on it too) and a
+    // `defer` finding additionally carries `followUpIssueNumber` — the PR's
+    // ONE tracked follow-up GitHub issue. Pass both through unvalidated
+    // beyond shape: they are produced by the sanctioned judge-pass bridge,
+    // never hand-authored.
+    if (typeof f.fingerprint === "string" && f.fingerprint.trim().length > 0) {
+      entry.fingerprint = f.fingerprint.trim();
+    }
+    if (Number.isInteger(f.followUpIssueNumber) && f.followUpIssueNumber > 0) {
+      entry.followUpIssueNumber = f.followUpIssueNumber;
+    }
     if (f.followUpDraft !== undefined && f.followUpDraft !== null) {
       // Mirrors validateJudgeVerdict's followUpDraft shape rule
       // (packages/core/src/loop/gate-fanin.mjs): gate on presence, carving

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -162,11 +162,17 @@ function validateFindingsArray(parsed, flagLabel) {
     // #1807: a judge-pass-enriched finding carries a stable `fingerprint`
     // (act/defer/reject — the reject audit entry keys on it too) and a
     // `defer` finding additionally carries `followUpIssueNumber` — the PR's
-    // ONE tracked follow-up GitHub issue. Pass both through unvalidated
-    // beyond shape: they are produced by the sanctioned judge-pass bridge,
-    // never hand-authored.
+    // ONE tracked follow-up GitHub issue. Both come from the sanctioned
+    // judge-pass bridge; absent/empty is tolerated (skipped), but a present
+    // fingerprint is shape-validated against the marker's own `[0-9a-f]{16}`
+    // contract so a malformed / hand-edited ledger fails closed here rather
+    // than silently producing a marker the finding-marker regex never matches.
     if (typeof f.fingerprint === "string" && f.fingerprint.trim().length > 0) {
-      entry.fingerprint = f.fingerprint.trim();
+      const fp = f.fingerprint.trim();
+      if (!/^[0-9a-f]{16}$/.test(fp)) {
+        throw parseError(`${flagLabel}[${i}].fingerprint must be a 16-char lowercase hex string`);
+      }
+      entry.fingerprint = fp;
     }
     if (Number.isInteger(f.followUpIssueNumber) && f.followUpIssueNumber > 0) {
       entry.followUpIssueNumber = f.followUpIssueNumber;

--- a/scripts/loop/judge-pass.mjs
+++ b/scripts/loop/judge-pass.mjs
@@ -7,6 +7,7 @@ import {
   applyJudgeDispositions,
   validateJudgeVerdict,
 } from "@dev-loops/core/loop/gate-fanin";
+import { ensureFollowUpIssue, fingerprintFinding } from "../github/_gate-finding-surface.mjs";
 import { resolveFindingsInput } from "../github/_findings-input.mjs";
 import {
   JQ_OUTPUT_PARSE_OPTIONS,
@@ -45,6 +46,12 @@ Inputs:
   --ledger-out <path>          Write the enriched { overallVerdict, findings, scopeDrift }
                                to this path as JSON, so the durable disposition ledger
                                carries what the judge consciously marked act/defer/reject.
+                               Every disposed finding also carries a \`fingerprint\`; a
+                               \`defer\` finding additionally carries \`followUpIssueNumber\`
+                               — the PR's ONE tracked follow-up GitHub issue (created or
+                               appended to, batched across every defer in the round; never
+                               one issue per finding). A re-run reads this same path back
+                               first, so an already-linked finding is not re-created (#1807).
   --repo-root <path>           Root used to resolve relative --findings-file /
                                --judge-verdict / --out / --ledger-out paths
                                (default: process.cwd()).
@@ -288,7 +295,75 @@ async function readJudgeVerdict(judgePath, parseErr) {
   return parsed;
 }
 
-export async function judgePassCli(options, { repoRoot = process.cwd() } = {}) {
+// Best-effort read of a prior --ledger-out artifact (the same path this run
+// is about to overwrite) to recover the PR's already-linked follow-up issue
+// (#1807 idempotency, batching policy): a re-run of the judge pass over the
+// same round must reuse the PR's ONE tracked follow-up issue rather than
+// mint a duplicate, and must not re-append fingerprints it already recorded
+// there. Tolerates a missing/malformed prior artifact (first-ever run) by
+// returning an empty link set — never fails the pass over a stale/partial
+// read of its own prior output.
+async function readPriorFollowUpLinks(ledgerOutPath) {
+  if (!ledgerOutPath) return { issueNumber: null, linkedFingerprints: new Set() };
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(ledgerOutPath, "utf8"));
+  } catch {
+    return { issueNumber: null, linkedFingerprints: new Set() };
+  }
+  const priorFindings = Array.isArray(parsed?.findings) ? parsed.findings : [];
+  const issueNumber = priorFindings
+    .map((f) => f?.followUpIssueNumber)
+    .find((n) => Number.isInteger(n) && n > 0) ?? null;
+  const linkedFingerprints = new Set(
+    issueNumber === null
+      ? []
+      : priorFindings.filter((f) => f?.followUpIssueNumber === issueNumber).map((f) => f.fingerprint),
+  );
+  return { issueNumber, linkedFingerprints };
+}
+
+/**
+ * Attach a stable per-finding `fingerprint` to every judge-disposed finding
+ * (act/defer/reject — #1807's one-line reject audit entry keys on it too),
+ * then — for every `defer` disposition — create or append to the PR's ONE
+ * tracked follow-up GitHub issue (batched: never one issue per finding).
+ * Mutates `enriched` in place (each element already the judge-pass's own
+ * fresh copy from `applyJudgeDispositions`). A re-run over the same
+ * `ledgerOutPath` links the already-linked findings without creating a
+ * duplicate issue or re-appending fingerprints already recorded on it.
+ */
+async function applyFollowUpIssues(enriched, { repo, pr, ledgerOutPath }, deps) {
+  for (const f of enriched) {
+    f.fingerprint = fingerprintFinding(f);
+  }
+  const deferred = enriched.filter((f) => f.judgeDisposition === "defer");
+  if (deferred.length === 0) return;
+  const { issueNumber: priorIssueNumber, linkedFingerprints } = await readPriorFollowUpLinks(ledgerOutPath);
+  const newlyDeferred = deferred.filter((f) => !linkedFingerprints.has(f.fingerprint));
+  if (priorIssueNumber !== null && newlyDeferred.length === 0) {
+    // Every currently-deferred finding is already linked to the PR's
+    // follow-up issue — a pure retry. No gh call at all.
+    for (const f of deferred) f.followUpIssueNumber = priorIssueNumber;
+    return;
+  }
+  const entries = (newlyDeferred.length > 0 ? newlyDeferred : deferred).map((f) => ({
+    fingerprint: f.fingerprint,
+    severity: f.severity,
+    angle: f.angle,
+    summary: f.summary,
+  }));
+  const { issueNumber } = await ensureFollowUpIssue(
+    { repo, pr, entries, existingIssueNumber: priorIssueNumber },
+    deps,
+  );
+  for (const f of deferred) f.followUpIssueNumber = issueNumber;
+}
+
+export async function judgePassCli(
+  options,
+  { repoRoot = process.cwd(), env = process.env, ghCommand = "gh", run, createIssue, commentIssue } = {},
+) {
   const resolvedRoot = options.repoRoot ? path.resolve(repoRoot, options.repoRoot) : repoRoot;
   const { findings, overallVerdict } = await resolvePayload(options, resolvedRoot);
   const judgeVerdict = await readJudgeVerdict(
@@ -296,6 +371,15 @@ export async function judgePassCli(options, { repoRoot = process.cwd() } = {}) {
     parseError,
   );
   const result = runJudgePass(findings, judgeVerdict, options.headSha);
+
+  // #1807: a `defer` disposition always tracks a GitHub issue — never only the
+  // ephemeral tmp ledger. One issue per PR, batched; idempotent across re-runs
+  // via the prior --ledger-out artifact this run is about to overwrite.
+  await applyFollowUpIssues(
+    result.enriched,
+    { repo: options.repo, pr: Number(options.pr), ledgerOutPath: options.ledgerOut ? path.resolve(resolvedRoot, options.ledgerOut) : null },
+    { env, ghCommand, run, createIssue, commentIssue },
+  );
 
   const written = new Set();
   if (options.ledgerOut) {

--- a/scripts/loop/judge-pass.mjs
+++ b/scripts/loop/judge-pass.mjs
@@ -303,6 +303,14 @@ async function readJudgeVerdict(judgePath, parseErr) {
 // there. Tolerates a missing/malformed prior artifact (first-ever run) by
 // returning an empty link set — never fails the pass over a stale/partial
 // read of its own prior output.
+//
+// This is a FAST-PATH cache only, not the authority: this pass's own
+// --ledger-out is a disjoint store from close-gate-findings.mjs's thread
+// markers, so a `null` here does not mean no follow-up issue exists — it only
+// means this run doesn't know of one locally. `ensureFollowUpIssue`
+// (_gate-finding-surface.mjs) resolves against GitHub itself before creating
+// whenever the number passed in here is `null`, which is what actually closes
+// the cross-path duplicate-issue gap between the two independent defer paths.
 async function readPriorFollowUpLinks(ledgerOutPath) {
   if (!ledgerOutPath) return { issueNumber: null, linkedFingerprints: new Set() };
   let parsed;
@@ -362,7 +370,7 @@ async function applyFollowUpIssues(enriched, { repo, pr, ledgerOutPath }, deps) 
 
 export async function judgePassCli(
   options,
-  { repoRoot = process.cwd(), env = process.env, ghCommand = "gh", run, createIssue, commentIssue } = {},
+  { repoRoot = process.cwd(), env = process.env, ghCommand = "gh", run, createIssue, commentIssue, listIssues } = {},
 ) {
   const resolvedRoot = options.repoRoot ? path.resolve(repoRoot, options.repoRoot) : repoRoot;
   const { findings, overallVerdict } = await resolvePayload(options, resolvedRoot);
@@ -378,7 +386,7 @@ export async function judgePassCli(
   await applyFollowUpIssues(
     result.enriched,
     { repo: options.repo, pr: Number(options.pr), ledgerOutPath: options.ledgerOut ? path.resolve(resolvedRoot, options.ledgerOut) : null },
-    { env, ghCommand, run, createIssue, commentIssue },
+    { env, ghCommand, run, createIssue, commentIssue, listIssues },
   );
 
   const written = new Set();

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1686,11 +1686,16 @@ round) and states the window/disposition reason (see `dispositionMessage` in
 when one named shared root cause genuinely closed them all.
 
 <!-- rule: GATE-EXEC-DEFERRAL-RECORD -->
-`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly THREE places, never a
-standalone summary comment as a fourth: the finding's own posted surface — the resolving reply on
+`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in up to THREE places, never a
+standalone summary comment as an extra: the finding's own posted surface — the resolving reply on
 its thread for a locatable finding, or its body-filed entry on the round's review for a
 non-locatable one — the durable findings-log ledger under `tmp/gate-findings/...`, and (#1807,
 below) the PR's ONE tracked GitHub follow-up issue, the durable record that survives a `tmp/` wipe.
+The third place — the tracked issue — is created for every deferral that flows through the
+disposition pass or the judge defer path (a locatable thread stamped `disposition=deferred`). The
+body-filed non-locatable case is the one disclosed exception (#1807 known limitation): it is
+stamped and body-filed durably (the first two places) but does not itself create the tracked
+issue, because that render-time call site has no GitHub I/O.
 The posted surface and the ledger both carry the finding marker's optional `disposition=deferred`
 field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1280,6 +1280,16 @@ to the fixer pass (`GATE-EXEC-JUDGE-AUTHORITY-SPLIT`). If `judge-pass` fails clo
 head, malformed verdict, out-of-range index, undisposed finding), the conductor re-runs the judge at the
 current head rather than degrading to severity-only disposition for a wired gate.
 
+`judge-pass` is also where a judge `defer` creates its tracked follow-up issue (#1807,
+`GATE-EXEC-DEFERRAL-RECORD`): every `defer`-disposed finding gets a stable `fingerprint`, and the
+PR's ONE follow-up issue is created (first defer on the PR) or appended to (a later defer on the
+same PR) via the sanctioned `scripts/github/create-issue.mjs` / `comment-issue.mjs` wrappers —
+never a raw `gh` call. Each `defer` finding's ledger entry carries the resulting
+`followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft, only its
+`fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the same round
+reads back its own prior `--ledger-out` to recover the PR's already-linked issue number and already
+-linked fingerprints, so a retry links the existing issue rather than creating a duplicate.
+
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->
 `GATE-EXEC-JUDGE-AUTHORITY-SPLIT`: The judge owns **relevance** (is this finding for this
 PR?); the fixer owns **reproduction** (does this finding reproduce / is it a real defect?).
@@ -1672,7 +1682,7 @@ when one named shared root cause genuinely closed them all.
 third summary comment: the finding's own posted surface — the resolving reply on its thread for a
 locatable finding, or its body-filed entry on the round's review for a non-locatable one — and the
 durable findings-log ledger under `tmp/gate-findings/...`. Both carry the finding marker's optional `disposition=deferred`
-field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred] -->`),
+field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a
 fixing commit. A THREAD marker is stamped `disposition=deferred` only when the disposition pass
 defers it (a medium thread past the gate's configured medium fix window
@@ -1685,6 +1695,25 @@ non-locatable (body-filed) marker is stamped `disposition=deferred` unconditiona
 severity other than `high`, at the round it is first posted — permanently deferred by
 construction, since a body-filed finding has no code location and so can never become a
 resolvable thread through which the standard fix loop could otherwise close it.
+
+A `defer` is never parked ONLY in the thread marker and the ephemeral tmp findings ledger: it
+ALWAYS creates or appends to a tracked GitHub issue — the
+durable, tracker-first record that survives a `tmp/` wipe. Every `defer` for one PR shares ONE
+follow-up issue, batched: the first deferral on a PR creates it (title `Deferred gate findings for
+<repo>#<pr>`, body listing every deferred finding's fingerprint/severity/angle); every later
+deferral on the same PR — a later round's newly out-of-window medium, a fixer-triaged low, a
+judge `defer` — appends a comment to that SAME issue rather than minting a second one. Both the
+thread marker (`issue=<n>`) and the durable ledger entry (`followUpIssueNumber`) record the issue
+number — the re-attachment pointer that lets a reader recover the tracked record even after the
+ephemeral ledger is gone. Idempotency is per-PR, not per-fingerprint: a re-run of the disposition
+pass links the PR's existing follow-up issue (found on an already-stamped thread marker, or, for
+the judge's own bridge, on the prior `--ledger-out` artifact) rather than creating a duplicate. A
+`disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
+contract violation, refused fail-closed exactly like an out-of-window stamp.
+
+A `reject` (the judge's relevance axis only — see Phase 3.5 below) is never a deferral and creates
+no issue: it records a one-line audit entry in the durable ledger (fingerprint, severity, angle,
+`judgeDisposition: "reject"`, rationale) and nothing else.
 
 ## Execution mode and fan-out evidence enforcement
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1283,12 +1283,20 @@ current head rather than degrading to severity-only disposition for a wired gate
 `judge-pass` is also where a judge `defer` creates its tracked follow-up issue (#1807,
 `GATE-EXEC-DEFERRAL-RECORD`): every `defer`-disposed finding gets a stable `fingerprint`, and the
 PR's ONE follow-up issue is created (first defer on the PR) or appended to (a later defer on the
-same PR) via the sanctioned `scripts/github/create-issue.mjs` / `comment-issue.mjs` wrappers —
-never a raw `gh` call. Each `defer` finding's ledger entry carries the resulting
-`followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft, only its
-`fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the same round
-reads back its own prior `--ledger-out` to recover the PR's already-linked issue number and already
--linked fingerprints, so a retry links the existing issue rather than creating a duplicate.
+same PR) via `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`), which calls the
+sanctioned `createIssue` / `commentIssue` functions imported from `@dev-loops/core/github/issue-ops`
+(the same module the `create-issue.mjs` / `comment-issue.mjs` CLI wrappers themselves call) —
+never a raw `gh` call. `close-gate-findings.mjs`'s own severity/round-based defer routes through
+the SAME `ensureFollowUpIssue`, and both callers' local idempotency caches (`judge-pass`'s
+`--ledger-out`, `close-gate-findings`'s thread `issue=` marker) are fast-path optimizations only —
+`ensureFollowUpIssue` resolves against GitHub itself (an open-issue title search) before creating
+whenever the calling pass doesn't already know a number, so the two independent defer paths always
+converge on the SAME one issue per PR (#1809). Each `defer` finding's ledger entry carries the
+resulting `followUpIssueNumber`; a `reject` carries neither an issue link nor a follow-up draft,
+only its `fingerprint` and rationale (the one-line audit entry). Re-running `judge-pass` for the
+same round reads back its own prior `--ledger-out` to recover the PR's already-linked issue number
+and already-linked fingerprints, so a retry links the existing issue rather than creating a
+duplicate.
 
 <!-- rule: GATE-EXEC-JUDGE-AUTHORITY-SPLIT -->
 `GATE-EXEC-JUDGE-AUTHORITY-SPLIT`: The judge owns **relevance** (is this finding for this
@@ -1678,10 +1686,12 @@ round) and states the window/disposition reason (see `dispositionMessage` in
 when one named shared root cause genuinely closed them all.
 
 <!-- rule: GATE-EXEC-DEFERRAL-RECORD -->
-`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly two places, never a
-third summary comment: the finding's own posted surface — the resolving reply on its thread for a
-locatable finding, or its body-filed entry on the round's review for a non-locatable one — and the
-durable findings-log ledger under `tmp/gate-findings/...`. Both carry the finding marker's optional `disposition=deferred`
+`GATE-EXEC-DEFERRAL-RECORD`: A deferred finding's record lives in exactly THREE places, never a
+standalone summary comment as a fourth: the finding's own posted surface — the resolving reply on
+its thread for a locatable finding, or its body-filed entry on the round's review for a
+non-locatable one — the durable findings-log ledger under `tmp/gate-findings/...`, and (#1807,
+below) the PR's ONE tracked GitHub follow-up issue, the durable record that survives a `tmp/` wipe.
+The posted surface and the ledger both carry the finding marker's optional `disposition=deferred`
 field (`<!-- dev-loops:finding <fp16> severity=<s> angle=<a> round=<n>[ disposition=deferred][ issue=<n>] -->`),
 which is what tells a deferred thread apart from one the fix loop genuinely resolved with a
 fixing commit. A THREAD marker is stamped `disposition=deferred` only when the disposition pass
@@ -1706,8 +1716,14 @@ judge `defer` — appends a comment to that SAME issue rather than minting a sec
 thread marker (`issue=<n>`) and the durable ledger entry (`followUpIssueNumber`) record the issue
 number — the re-attachment pointer that lets a reader recover the tracked record even after the
 ephemeral ledger is gone. Idempotency is per-PR, not per-fingerprint: a re-run of the disposition
-pass links the PR's existing follow-up issue (found on an already-stamped thread marker, or, for
-the judge's own bridge, on the prior `--ledger-out` artifact) rather than creating a duplicate. A
+pass links the PR's existing follow-up issue rather than creating a duplicate. The judge's own
+bridge (`judge-pass.mjs`) and `close-gate-findings.mjs`'s severity/round-based defer are two
+INDEPENDENT passes with disjoint local caches (the judge's prior `--ledger-out` artifact vs. an
+already-stamped thread marker's `issue=` field) — a PR that defers through both paths converges on
+the SAME one issue because `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`)
+resolves against GitHub itself (an open-issue title search) whenever a pass's own local cache
+doesn't already know a number, not because either pass's cache is authoritative on its own (#1809).
+A
 `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1727,7 +1727,7 @@ A
 `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 
-A `reject` (the judge's relevance axis only — see Phase 3.5 below) is never a deferral and creates
+A `reject` (the judge's relevance axis only — see Phase 3.5 above) is never a deferral and creates
 no issue: it records a one-line audit entry in the durable ledger (fingerprint, severity, angle,
 `judgeDisposition: "reject"`, rationale) and nothing else.
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -1723,8 +1723,7 @@ already-stamped thread marker's `issue=` field) — a PR that defers through bot
 the SAME one issue because `ensureFollowUpIssue` (`scripts/github/_gate-finding-surface.mjs`)
 resolves against GitHub itself (an open-issue title search) whenever a pass's own local cache
 doesn't already know a number, not because either pass's cache is authoritative on its own (#1809).
-A
-`disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
+A `disposition=deferred` thread marker with no linked `issue=<n>` is a `GATE-EXEC-THREAD-DISPOSITION`
 contract violation, refused fail-closed exactly like an out-of-window stamp.
 
 A `reject` (the judge's relevance axis only — see Phase 3.5 above) is never a deferral and creates

--- a/test/github/close-gate-findings.test.mjs
+++ b/test/github/close-gate-findings.test.mjs
@@ -181,6 +181,26 @@ function patchReviewCommentEntry(commentId) {
   };
 }
 
+// #1807: before stamping any target, the disposition pass creates (or, when
+// this PR already has one, appends to) the PR's ONE tracked follow-up issue
+// for the round's whole batch. `gh issue create` prints the created issue's
+// bare URL on stdout (not JSON) — matches core createIssue's own parsing.
+function createFollowUpIssueEntry(issueNumber = 9500) {
+  return {
+    assertArgs: ["issue", "create", "--repo", REPO],
+    stdout: `https://github.com/${REPO}/issues/${issueNumber}\n`,
+  };
+}
+
+// The append path (an existing follow-up issue already found on a thread
+// marker): `gh issue comment` prints the new comment's URL on stdout.
+function appendFollowUpIssueEntry(issueNumber) {
+  return {
+    assertArgs: ["issue", "comment", String(issueNumber), "--repo", REPO],
+    stdout: `https://github.com/${REPO}/issues/${issueNumber}#issuecomment-1\n`,
+  };
+}
+
 // closeGateFindings' fixed gh call order: `api user`, reviews, issue comments,
 // then the thread listing + full-body walk that feed the disposition pass.
 function roundEntries({ reviews = [], issueComments = [{ id: 1, body: verdictBody("draft_gate") }], threads = [], fullBodyThreads = threads } = {}) {
@@ -461,6 +481,7 @@ test("an open worth-fixing-now thread is replied-to + resolved FROM ROUND 4", as
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6002, wfnBody("1111111111111111")),
       patchReviewCommentEntry(6002),
       postReplyEntry(6002, { id: 7001 }),
@@ -470,6 +491,7 @@ test("an open worth-fixing-now thread is replied-to + resolved FROM ROUND 4", as
       const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
       assert.equal(result.round, 4);
       assert.equal(result.deferredResolved, 1);
+      assert.equal(result.followUpIssueNumber, 9500);
     },
   ));
 });
@@ -480,6 +502,7 @@ test("an unresolved nice-to-have thread is replied-to + resolved immediately, at
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6200, niceToHaveBody),
       patchReviewCommentEntry(6200),
       postReplyEntry(6200, { id: 7100 }),
@@ -501,6 +524,7 @@ test("an unresolved nit thread is replied-to + resolved immediately, at round 1"
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6250, nitBody),
       patchReviewCommentEntry(6250),
       {
@@ -546,6 +570,7 @@ test("a legacy severity=defer marker posts a reply in the canonical vocabulary",
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6300, legacyBody),
       patchReviewCommentEntry(6300),
       {
@@ -589,6 +614,7 @@ test("a deferral target whose REST-fetched body has LEADING WHITESPACE before th
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6600, ` ${wfnBody("5555555555555555")}`),
       patchReviewCommentEntry(6600),
       postReplyEntry(6600, { id: 7600 }),
@@ -608,6 +634,7 @@ test("a finding whose own text quotes the literal 'disposition=deferred' token s
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6500, body),
       patchReviewCommentEntry(6500),
       postReplyEntry(6500, { id: 7500 }),
@@ -620,11 +647,16 @@ test("a finding whose own text quotes the literal 'disposition=deferred' token s
 });
 
 test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition field is already deferred", async () => {
-  const alreadyStamped = `${buildFindingMarker({ fp: "1111000011110000", severity: "worth-fixing-now", angle: "perf", round: 1, disposition: "deferred" })}\n**worth-fixing-now** (\`perf\`): stale cache`;
+  // Already carries its follow-up issue link (#1807): a legitimately-stamped,
+  // still-unresolved marker (e.g. an interrupted retry) always does.
+  const alreadyStamped = `${buildFindingMarker({ fp: "1111000011110000", severity: "worth-fixing-now", angle: "perf", round: 1, disposition: "deferred", issue: 9500 })}\n**worth-fixing-now** (\`perf\`): stale cache`;
   const thread = threadNode({ id: "THREAD_D", path: "src/cache.mjs", line: 9, commentId: 6501, body: alreadyStamped });
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      // The batch's follow-up issue is already known from this same thread's
+      // own marker, so the pass APPENDS to it rather than creating a new one.
+      appendFollowUpIssueEntry(9500),
       getReviewCommentEntry(6501, alreadyStamped),
       // No patchReviewCommentEntry: a PATCH here would overflow the stub and
       // fail the test — the already-stamped guard must skip straight to
@@ -633,7 +665,9 @@ test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition
       resolveThreadEntry("THREAD_D"),
     ],
     async ({ env, ghCommand, repoRoot }) => {
-      assert.equal((await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot })).deferredResolved, 1);
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.deferredResolved, 1);
+      assert.equal(result.followUpIssueNumber, 9500);
     },
   ));
 });
@@ -688,6 +722,7 @@ test("#1672 (c): a round-4 medium thread IS defer-closed (past the default windo
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(9003, mediumBody),
       patchReviewCommentEntry(9003),
       postReplyEntry(9003, { id: 9103 }),
@@ -731,7 +766,7 @@ test("#1672 guard: a disposition=deferred stamp on a question thread is rejected
     async ({ env, ghCommand, repoRoot }) => {
       await assert.rejects(
         () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
-        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=question.*isDeferredAtRound=false/s,
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=question.*reason=out-of-window/s,
       );
     },
   ));
@@ -749,7 +784,27 @@ test("#1672 guard: a disposition=deferred stamp on an in-window medium thread is
     async ({ env, ghCommand, repoRoot }) => {
       await assert.rejects(
         () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
-        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=medium.*round=1.*isDeferredAtRound=false/s,
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=medium.*round=1.*reason=out-of-window/s,
+      );
+    },
+  ));
+});
+
+// #1807 AC6: GATE-EXEC-THREAD-DISPOSITION also refuses a disposition=deferred
+// stamp that carries no linked follow-up issue number — an in-window
+// deferral is otherwise legitimate (a nit at round 1), so only the missing
+// issue link trips this guard.
+test("#1807 guard: a disposition=deferred stamp with no linked follow-up issue number is rejected (throws, does not silently skip)", async () => {
+  const stampedNoIssue = `${buildFindingMarker({ fp: "0101010101010101", severity: "nit", angle: "naming", round: 1, disposition: "deferred" })}\n**nit** (\`naming\`): casing nit`;
+  const thread = threadNode({ id: "THREAD_NIT_NO_ISSUE", path: "src/naming.mjs", line: 4, commentId: 9007, body: stampedNoIssue });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    // No issue-create/GET/PATCH/reply/resolve entries: the scan runs before
+    // any of those, and a regression that proceeded would overflow the stub.
+    roundEntries({ threads: [thread] }),
+    async ({ env, ghCommand, repoRoot }) => {
+      await assert.rejects(
+        () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=nit.*reason=missing-issue-link/s,
       );
     },
   ));
@@ -835,6 +890,7 @@ test("a thread whose body exceeds the 200-char listing excerpt is disposed from 
   await withLedgerFile(makeLedger({ findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("pre_approval_gate", 4), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6400, longBody),
       patchReviewCommentEntry(6400),
       postReplyEntry(6400, { id: 7400 }),
@@ -954,6 +1010,7 @@ test("#1581 (a): a per-gate worthFixingNowFixWindow is honored by the dispositio
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStubAndConfig(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 3), threads: [thread] }),
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(7100, wfnBody("1111111111111111")),
       patchReviewCommentEntry(7100),
       postReplyEntry(7100, { id: 8100 }),
@@ -1051,6 +1108,7 @@ test("#1585: unresolvedGateThreadCount reflects the subtraction (must-fix stays,
     [
       ...roundEntries({ threads: [mustFix, niceToHave] }),
       // The disposition pass defers ONLY the nice-to-have (must-fix never defers).
+      createFollowUpIssueEntry(9500),
       getReviewCommentEntry(8002, niceToHaveBodyStr),
       patchReviewCommentEntry(8002),
       postReplyEntry(8002, { id: 7800 }),

--- a/test/github/close-gate-findings.test.mjs
+++ b/test/github/close-gate-findings.test.mjs
@@ -181,6 +181,19 @@ function patchReviewCommentEntry(commentId) {
   };
 }
 
+// #1809: before creating, ensureFollowUpIssue now resolves against GitHub
+// itself whenever the caller has no local existingIssueNumber (here: no
+// thread marker yet carries an `issue=` field) — a `gh issue list --search`
+// call precedes every `createFollowUpIssueEntry` fixture below. Returns no
+// match by default (`matches: []`), so the flow falls through to create.
+function listFollowUpIssuesEntry({ matches = [] } = {}) {
+  return {
+    assertArgs: ["issue", "list", "--repo", REPO, "--state", "open"],
+    assertArgContains: ["--search"],
+    stdout: `${JSON.stringify(matches)}\n`,
+  };
+}
+
 // #1807: before stamping any target, the disposition pass creates (or, when
 // this PR already has one, appends to) the PR's ONE tracked follow-up issue
 // for the round's whole batch. `gh issue create` prints the created issue's
@@ -481,6 +494,7 @@ test("an open worth-fixing-now thread is replied-to + resolved FROM ROUND 4", as
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6002, wfnBody("1111111111111111")),
       patchReviewCommentEntry(6002),
@@ -502,6 +516,7 @@ test("an unresolved nice-to-have thread is replied-to + resolved immediately, at
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6200, niceToHaveBody),
       patchReviewCommentEntry(6200),
@@ -524,6 +539,7 @@ test("an unresolved nit thread is replied-to + resolved immediately, at round 1"
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6250, nitBody),
       patchReviewCommentEntry(6250),
@@ -570,6 +586,7 @@ test("a legacy severity=defer marker posts a reply in the canonical vocabulary",
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6300, legacyBody),
       patchReviewCommentEntry(6300),
@@ -614,6 +631,7 @@ test("a deferral target whose REST-fetched body has LEADING WHITESPACE before th
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6600, ` ${wfnBody("5555555555555555")}`),
       patchReviewCommentEntry(6600),
@@ -634,6 +652,7 @@ test("a finding whose own text quotes the literal 'disposition=deferred' token s
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6500, body),
       patchReviewCommentEntry(6500),
@@ -668,6 +687,33 @@ test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition
       const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
       assert.equal(result.deferredResolved, 1);
       assert.equal(result.followUpIssueNumber, 9500);
+    },
+  ));
+});
+
+// #1809 cross-path: no thread on THIS PR carries an `issue=` marker yet (this
+// pass's own local channel is empty), but judge-pass.mjs already created the
+// PR's follow-up issue via its own DISJOINT --ledger-out cache — a defer
+// judge-pass ran through never stamps a thread marker's `issue=` field (it
+// runs before any finding is posted as a review thread). closeGateFindings
+// must resolve that existing issue via GitHub (`gh issue list --search`)
+// rather than mint a second one.
+test("#1809: no local issue= marker yet, but GitHub already has this PR's follow-up issue (created by judge-pass) — appends, does not create a duplicate", async () => {
+  const thread = openWfnThread({ commentId: 6700, fp: "2222222222222222", id: "THREAD_XPATH" });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    [
+      ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry({ matches: [{ number: 4242, title: `Deferred gate findings for ${REPO}#${PR}`, state: "open", labels: [] }] }),
+      appendFollowUpIssueEntry(4242),
+      getReviewCommentEntry(6700, wfnBody("2222222222222222")),
+      patchReviewCommentEntry(6700),
+      postReplyEntry(6700, { id: 7700 }),
+      resolveThreadEntry("THREAD_XPATH"),
+    ],
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.deferredResolved, 1);
+      assert.equal(result.followUpIssueNumber, 4242, "links judge-pass's already-created issue, never a new one");
     },
   ));
 });
@@ -722,6 +768,7 @@ test("#1672 (c): a round-4 medium thread IS defer-closed (past the default windo
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(9003, mediumBody),
       patchReviewCommentEntry(9003),
@@ -890,6 +937,7 @@ test("a thread whose body exceeds the 200-char listing excerpt is disposed from 
   await withLedgerFile(makeLedger({ findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("pre_approval_gate", 4), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(6400, longBody),
       patchReviewCommentEntry(6400),
@@ -1010,6 +1058,7 @@ test("#1581 (a): a per-gate worthFixingNowFixWindow is honored by the dispositio
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStubAndConfig(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 3), threads: [thread] }),
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(7100, wfnBody("1111111111111111")),
       patchReviewCommentEntry(7100),
@@ -1108,6 +1157,7 @@ test("#1585: unresolvedGateThreadCount reflects the subtraction (must-fix stays,
     [
       ...roundEntries({ threads: [mustFix, niceToHave] }),
       // The disposition pass defers ONLY the nice-to-have (must-fix never defers).
+      listFollowUpIssuesEntry(),
       createFollowUpIssueEntry(9500),
       getReviewCommentEntry(8002, niceToHaveBodyStr),
       patchReviewCommentEntry(8002),

--- a/test/github/close-gate-findings.test.mjs
+++ b/test/github/close-gate-findings.test.mjs
@@ -673,9 +673,12 @@ test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition
   await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
     [
       ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [thread] }),
-      // The batch's follow-up issue is already known from this same thread's
-      // own marker, so the pass APPENDS to it rather than creating a new one.
-      appendFollowUpIssueEntry(9500),
+      // #1809 round-3 (idempotency): every target in the batch is ALREADY
+      // stamped, so the pass reuses issue=9500 straight off the thread's own
+      // marker — no `gh issue list --search`, no `gh issue create`, and no
+      // `gh issue comment` append. No listFollowUpIssuesEntry/
+      // createFollowUpIssueEntry/appendFollowUpIssueEntry here: any of those
+      // calls would overflow the stub and fail the test.
       getReviewCommentEntry(6501, alreadyStamped),
       // No patchReviewCommentEntry: a PATCH here would overflow the stub and
       // fail the test — the already-stamped guard must skip straight to
@@ -686,6 +689,67 @@ test("stampDeferredDisposition skips the PATCH when the marker's OWN disposition
     async ({ env, ghCommand, repoRoot }) => {
       const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
       assert.equal(result.deferredResolved, 1);
+      assert.equal(result.followUpIssueNumber, 9500);
+    },
+  ));
+});
+
+// #1809 round-3 (idempotency): a batch of MULTIPLE targets that are ALL
+// already stamped `disposition=deferred issue=<n>` (e.g. a retry after every
+// PATCH landed but the run was interrupted before any reply+resolve) must
+// perform ZERO follow-up-issue gh calls (no search, no create, no append) —
+// only reuse the linked issue number and finish the reply+resolve.
+test("a disposition pass where EVERY target is already stamped performs no create and no append (pure retry)", async () => {
+  const first = `${buildFindingMarker({ fp: "aaaa1111aaaa1111", severity: "worth-fixing-now", angle: "perf", round: 1, disposition: "deferred", issue: 9500 })}\n**worth-fixing-now** (\`perf\`): stale cache A`;
+  const second = `${buildFindingMarker({ fp: "bbbb2222bbbb2222", severity: "nice-to-have", angle: "naming", round: 1, disposition: "deferred", issue: 9500 })}\n**nice-to-have** (\`naming\`): casing nit B`;
+  const threadA = threadNode({ id: "THREAD_A", path: "src/cache.mjs", line: 9, commentId: 6801, body: first });
+  const threadB = threadNode({ id: "THREAD_B", path: "src/naming.mjs", line: 4, commentId: 6802, body: second });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    [
+      ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [threadA, threadB] }),
+      // No listFollowUpIssuesEntry/createFollowUpIssueEntry/appendFollowUpIssueEntry:
+      // both targets are already stamped, so ensureFollowUpIssue is never called.
+      getReviewCommentEntry(6801, first),
+      postReplyEntry(6801, { id: 7801 }),
+      resolveThreadEntry("THREAD_A"),
+      getReviewCommentEntry(6802, second),
+      postReplyEntry(6802, { id: 7802 }),
+      resolveThreadEntry("THREAD_B"),
+    ],
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.deferredResolved, 2);
+      assert.equal(result.followUpIssueNumber, 9500);
+    },
+  ));
+});
+
+// #1809 round-3 (idempotency): a MIXED batch — one target already stamped
+// (a carried-over retry), one target not yet stamped — appends to the
+// follow-up issue exactly ONCE, carrying only the UNSTAMPED target's entry,
+// and reuses the already-linked issue number rather than minting a new one.
+test("a mixed disposition pass appends once, for only the unstamped target, reusing the already-linked issue", async () => {
+  const stamped = `${buildFindingMarker({ fp: "cccc3333cccc3333", severity: "worth-fixing-now", angle: "perf", round: 1, disposition: "deferred", issue: 9500 })}\n**worth-fixing-now** (\`perf\`): stale cache C`;
+  const unstamped = wfnBody("dddd4444dddd4444");
+  const threadStamped = threadNode({ id: "THREAD_STAMPED", path: "src/cache.mjs", line: 9, commentId: 6901, body: stamped });
+  const threadUnstamped = threadNode({ id: "THREAD_UNSTAMPED", path: "src/cache.mjs", line: 11, commentId: 6902, body: unstamped });
+  await withLedgerFile(makeLedger({ gate: "draft_gate", findings: [] }), (ledgerPath) => withGhStub(
+    [
+      ...roundEntries({ issueComments: roundHistory("draft_gate", 4), threads: [threadStamped, threadUnstamped] }),
+      // Exactly one append, reusing issue=9500 found on the stamped thread's
+      // own marker — no search, no create, and no second append.
+      appendFollowUpIssueEntry(9500),
+      getReviewCommentEntry(6901, stamped),
+      postReplyEntry(6901, { id: 7901 }),
+      resolveThreadEntry("THREAD_STAMPED"),
+      getReviewCommentEntry(6902, unstamped),
+      patchReviewCommentEntry(6902),
+      postReplyEntry(6902, { id: 7902 }),
+      resolveThreadEntry("THREAD_UNSTAMPED"),
+    ],
+    async ({ env, ghCommand, repoRoot }) => {
+      const result = await closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot });
+      assert.equal(result.deferredResolved, 2);
       assert.equal(result.followUpIssueNumber, 9500);
     },
   ));

--- a/test/github/gate-finding-surface.test.mjs
+++ b/test/github/gate-finding-surface.test.mjs
@@ -911,6 +911,31 @@ test("#1809 round-2: buildFollowUpIssueBody survives the REAL guardCommentBodyNo
   assert.doesNotMatch(body, /#\d/);
 });
 
+// #1809 pre-approval: a CONSECUTIVE-run of number-signs before digits (e.g. a
+// doubled sign) must be fully stripped — an earlier regex removed only the
+// innermost sign, leaving a residual that still auto-links and trips the guard.
+test("#1809 pre-approval: doubled/tripled number-signs before digits are fully stripped on both paths", async () => {
+  const entries = [{ fingerprint: "8888888888888888", severity: "medium", angle: "run-of-###55", summary: "duplicate of ##987 and also ###12" }];
+  const body = buildFollowUpIssueBody({ repo: "o/r", pr: 7, entries });
+  assert.doesNotThrow(() => guardCommentBodyNoIssuePrIds(body, { ref: "test doubled-sign create body" }));
+  assert.doesNotMatch(body, /#\d/);
+  assert.match(body, /duplicate of 987 and also 12/);
+  assert.match(body, /run-of-55/);
+
+  const runCalls = [];
+  const run = async (ghCommand, args) => {
+    runCalls.push(args);
+    return { code: 0, stdout: "https://github.com/o/r/issues/909#issuecomment-1\n", stderr: "" };
+  };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 7, entries, existingIssueNumber: 909 },
+    { run },
+  );
+  assert.deepEqual(result, { issueNumber: 909, created: false });
+  const bodyArg = runCalls[0][runCalls[0].indexOf("--body") + 1];
+  assert.doesNotMatch(bodyArg, /#\d/);
+});
+
 test("#1809 round-2: ensureFollowUpIssue's create path calls the REAL createIssue (real guard exposure) without throwing, and the id is neutralized", async () => {
   const entries = [{ fingerprint: "5555555555555555", severity: "medium", angle: "perf", summary: "duplicates #123456 behavior" }];
   const runCalls = [];

--- a/test/github/gate-finding-surface.test.mjs
+++ b/test/github/gate-finding-surface.test.mjs
@@ -947,3 +947,31 @@ test("#1809 round-2: ensureFollowUpIssue's append path calls the REAL commentIss
   assert.doesNotMatch(bodyArg, /#\d/);
   assert.match(bodyArg, /references 42 in the doc/);
 });
+
+// #1809 round-3: the untrusted `angle` field flows through the SAME
+// neutralizeBareIssuePrIds render path as `summary` and lands inside the
+// guarded body. The summary-only real-guard tests above would pass while an
+// angle-path neutralization regression reproduced the round-2 defer-ordering
+// abort, so exercise a hash-digit angle through the REAL guard on both paths.
+test("#1809 round-3: a bare id in the untrusted angle field survives the REAL guard on create and append", async () => {
+  const entries = [{ fingerprint: "7777777777777777", severity: "medium", angle: "regression-of-#321", summary: "plain summary" }];
+  const body = buildFollowUpIssueBody({ repo: "o/r", pr: 7, entries });
+  assert.doesNotThrow(() => guardCommentBodyNoIssuePrIds(body, { ref: "test angle create body" }));
+  assert.doesNotMatch(body, /#\d/);
+  assert.match(body, /regression-of-321/);
+
+  // Append path through the real commentIssue guard must not throw either.
+  const runCalls = [];
+  const run = async (ghCommand, args) => {
+    runCalls.push(args);
+    return { code: 0, stdout: "https://github.com/o/r/issues/909#issuecomment-1\n", stderr: "" };
+  };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 7, entries, existingIssueNumber: 909 },
+    { run },
+  );
+  assert.deepEqual(result, { issueNumber: 909, created: false });
+  const bodyArg = runCalls[0][runCalls[0].indexOf("--body") + 1];
+  assert.doesNotMatch(bodyArg, /#\d/);
+  assert.match(bodyArg, /regression-of-321/);
+});

--- a/test/github/gate-finding-surface.test.mjs
+++ b/test/github/gate-finding-surface.test.mjs
@@ -8,10 +8,13 @@ import { containsBareCopilotSummon } from "../../scripts/_core-helpers.mjs";
 import {
   buildCommentableLineSet,
   buildFindingMarker,
+  buildFollowUpIssueBody,
+  buildFollowUpIssueTitle,
   buildReviewHeaderMarker,
   collectSuppressedFingerprints,
   collectVerdictHeadShas,
   createGateReview,
+  ensureFollowUpIssue,
   fingerprintFinding,
   isDeferredAtRound,
   isLocatableFinding,
@@ -67,18 +70,39 @@ test("fingerprintFinding trims files[0]: an untrimmed path fingerprints identica
 
 test("buildFindingMarker / parseFindingMarker round-trip", () => {
   const marker = buildFindingMarker({ fp: "0123456789abcdef", severity: "high", angle: "security", round: 2 });
-  assert.deepEqual(parseFindingMarker(marker), { fp: "0123456789abcdef", severity: "high", angle: "security", round: 2, disposition: null });
+  assert.deepEqual(parseFindingMarker(marker), { fp: "0123456789abcdef", severity: "high", angle: "security", round: 2, disposition: null, issue: null });
 });
 
 test("buildFindingMarker / parseFindingMarker round-trip: a legacy-spelled severity still parses and normalizes on read", () => {
   const marker = buildFindingMarker({ fp: "0123456789abcdef", severity: "must-fix", angle: "security", round: 2 });
   assert.ok(marker.includes("severity=must-fix"), "the marker itself carries the spelling it was built with");
-  assert.deepEqual(parseFindingMarker(marker), { fp: "0123456789abcdef", severity: "high", angle: "security", round: 2, disposition: null });
+  assert.deepEqual(parseFindingMarker(marker), { fp: "0123456789abcdef", severity: "high", angle: "security", round: 2, disposition: null, issue: null });
 });
 
 test("buildFindingMarker with a disposition round-trips through parseFindingMarker", () => {
   const marker = buildFindingMarker({ fp: "0123456789abcdef", severity: "nice-to-have", angle: "naming", round: 1, disposition: "deferred" });
   assert.equal(parseFindingMarker(marker).disposition, "deferred");
+});
+
+// #1807: the follow-up issue number a `disposition=deferred` finding is
+// tracked on (GATE-EXEC-DEFERRAL-RECORD) round-trips through the marker too.
+test("buildFindingMarker with an issue number round-trips through parseFindingMarker", () => {
+  const marker = buildFindingMarker({ fp: "0123456789abcdef", severity: "nice-to-have", angle: "naming", round: 1, disposition: "deferred", issue: 42 });
+  assert.match(marker, /disposition=deferred issue=42 -->$/);
+  const parsed = parseFindingMarker(marker);
+  assert.equal(parsed.disposition, "deferred");
+  assert.equal(parsed.issue, 42);
+});
+
+test("buildFindingMarker rejects a non-positive-integer issue", () => {
+  assert.throws(
+    () => buildFindingMarker({ fp: "0123456789abcdef", severity: "nice-to-have", angle: "naming", round: 1, disposition: "deferred", issue: 0 }),
+    /issue must be a positive integer/,
+  );
+  assert.throws(
+    () => buildFindingMarker({ fp: "0123456789abcdef", severity: "nice-to-have", angle: "naming", round: 1, disposition: "deferred", issue: 1.5 }),
+    /issue must be a positive integer/,
+  );
 });
 
 test("buildFindingMarker throws on a disposition value other than \"deferred\"", () => {
@@ -665,5 +689,64 @@ test("#1731: updateGateReview refuses a verdict body containing a raw issue/PR i
       { ghCommand: "gh", runChild },
     ),
     /comment-id-guard refused to emit gate verdict comment body.*#1731/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #1807: follow-up issue for deferred findings — one issue per PR, batched
+// ---------------------------------------------------------------------------
+
+function followUpEntries() {
+  return [
+    { fingerprint: "1111111111111111", severity: "low", angle: "naming", summary: "casing nit" },
+    { fingerprint: "2222222222222222", severity: "medium", angle: "perf", summary: "stale cache" },
+  ];
+}
+
+test("buildFollowUpIssueTitle / buildFollowUpIssueBody: one issue per PR, every entry listed", () => {
+  const title = buildFollowUpIssueTitle({ repo: "o/r", pr: 42 });
+  assert.equal(title, "Deferred gate findings for o/r#42");
+  const body = buildFollowUpIssueBody({ repo: "o/r", pr: 42, entries: followUpEntries() });
+  assert.match(body, /https:\/\/github\.com\/o\/r\/pull\/42/);
+  assert.match(body, /`1111111111111111`.*\*\*low\*\*.*casing nit/);
+  assert.match(body, /`2222222222222222`.*\*\*medium\*\*.*stale cache/);
+});
+
+test("ensureFollowUpIssue: no existing issue creates ONE issue for the whole batch", async () => {
+  const createCalls = [];
+  const createIssue = async (opts) => {
+    createCalls.push(opts);
+    return { ok: true, issueNumber: 101, url: `https://github.com/${opts.repo}/issues/101` };
+  };
+  const commentIssue = async () => { throw new Error("must not append when no issue exists yet"); };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    { createIssue, commentIssue },
+  );
+  assert.deepEqual(result, { issueNumber: 101, created: true });
+  assert.equal(createCalls.length, 1);
+  assert.equal(createCalls[0].repo, "o/r");
+});
+
+test("ensureFollowUpIssue: an existing issue number appends a comment instead of creating a duplicate", async () => {
+  const createIssue = async () => { throw new Error("must not create a duplicate issue"); };
+  const commentCalls = [];
+  const commentIssue = async (opts) => {
+    commentCalls.push(opts);
+    return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
+  };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: 101 },
+    { createIssue, commentIssue },
+  );
+  assert.deepEqual(result, { issueNumber: 101, created: false });
+  assert.equal(commentCalls.length, 1);
+  assert.equal(commentCalls[0].issue, 101);
+});
+
+test("ensureFollowUpIssue rejects an empty entries array", async () => {
+  await assert.rejects(
+    () => ensureFollowUpIssue({ repo: "o/r", pr: 42, entries: [], existingIssueNumber: null }, {}),
+    /entries must be a non-empty array/,
   );
 });

--- a/test/github/gate-finding-surface.test.mjs
+++ b/test/github/gate-finding-surface.test.mjs
@@ -15,6 +15,7 @@ import {
   collectVerdictHeadShas,
   createGateReview,
   ensureFollowUpIssue,
+  findFollowUpIssueOnGitHub,
   fingerprintFinding,
   isDeferredAtRound,
   isLocatableFinding,
@@ -712,32 +713,38 @@ test("buildFollowUpIssueTitle / buildFollowUpIssueBody: one issue per PR, every 
   assert.match(body, /`2222222222222222`.*\*\*medium\*\*.*stale cache/);
 });
 
-test("ensureFollowUpIssue: no existing issue creates ONE issue for the whole batch", async () => {
+function noMatchListIssues() {
+  return async () => ({ ok: true, issues: [] });
+}
+
+test("ensureFollowUpIssue: no existing issue, no GitHub match, creates ONE issue for the whole batch", async () => {
   const createCalls = [];
   const createIssue = async (opts) => {
     createCalls.push(opts);
     return { ok: true, issueNumber: 101, url: `https://github.com/${opts.repo}/issues/101` };
   };
   const commentIssue = async () => { throw new Error("must not append when no issue exists yet"); };
+  const listIssues = noMatchListIssues();
   const result = await ensureFollowUpIssue(
     { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
-    { createIssue, commentIssue },
+    { createIssue, commentIssue, listIssues },
   );
   assert.deepEqual(result, { issueNumber: 101, created: true });
   assert.equal(createCalls.length, 1);
   assert.equal(createCalls[0].repo, "o/r");
 });
 
-test("ensureFollowUpIssue: an existing issue number appends a comment instead of creating a duplicate", async () => {
+test("ensureFollowUpIssue: an existing issue number appends a comment instead of creating a duplicate, and never searches GitHub", async () => {
   const createIssue = async () => { throw new Error("must not create a duplicate issue"); };
   const commentCalls = [];
   const commentIssue = async (opts) => {
     commentCalls.push(opts);
     return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
   };
+  const listIssues = async () => { throw new Error("must not search GitHub when the caller already knows the issue"); };
   const result = await ensureFollowUpIssue(
     { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: 101 },
-    { createIssue, commentIssue },
+    { createIssue, commentIssue, listIssues },
   );
   assert.deepEqual(result, { issueNumber: 101, created: false });
   assert.equal(commentCalls.length, 1);
@@ -749,4 +756,130 @@ test("ensureFollowUpIssue rejects an empty entries array", async () => {
     () => ensureFollowUpIssue({ repo: "o/r", pr: 42, entries: [], existingIssueNumber: null }, {}),
     /entries must be a non-empty array/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// #1809: cross-path convergence — GitHub is the source of truth when the
+// caller's own local channel doesn't know of a follow-up issue yet.
+// ---------------------------------------------------------------------------
+
+test("findFollowUpIssueOnGitHub: returns null when no open issue matches this PR's exact title", async () => {
+  const listIssues = async (opts) => {
+    assert.equal(opts.repo, "o/r");
+    assert.equal(opts.state, "open");
+    assert.match(opts.search, /Deferred gate findings for o\/r#42/);
+    return { ok: true, issues: [{ number: 5, title: "Deferred gate findings for o/r#99 (different PR)", state: "open", labels: [] }] };
+  };
+  const result = await findFollowUpIssueOnGitHub({ repo: "o/r", pr: 42 }, { listIssues });
+  assert.equal(result, null);
+});
+
+test("findFollowUpIssueOnGitHub: returns the matching issue number on an exact title match", async () => {
+  const listIssues = async () => ({
+    ok: true,
+    issues: [{ number: 777, title: "Deferred gate findings for o/r#42", state: "open", labels: [] }],
+  });
+  const result = await findFollowUpIssueOnGitHub({ repo: "o/r", pr: 42 }, { listIssues });
+  assert.equal(result, 777);
+});
+
+test("ensureFollowUpIssue: no local existingIssueNumber but GitHub already has this PR's open follow-up issue — appends, does not create a duplicate", async () => {
+  const createIssue = async () => { throw new Error("must not create a duplicate issue when GitHub already has one"); };
+  const commentCalls = [];
+  const commentIssue = async (opts) => {
+    commentCalls.push(opts);
+    return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
+  };
+  const listIssues = async () => ({
+    ok: true,
+    issues: [{ number: 555, title: "Deferred gate findings for o/r#42", state: "open", labels: [] }],
+  });
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    { createIssue, commentIssue, listIssues },
+  );
+  assert.deepEqual(result, { issueNumber: 555, created: false });
+  assert.equal(commentCalls.length, 1);
+  assert.equal(commentCalls[0].issue, 555);
+});
+
+// The scenario from the finding: one path (modelled here as caller A) defers
+// first and creates issue N; a second, independent path (caller B) — which
+// has NO local knowledge of N (its own idempotency channel is disjoint) —
+// defers on the SAME PR next. Both calls share only a fake in-memory GitHub
+// issue store, exactly like judge-pass.mjs and close-gate-findings.mjs share
+// only the real GitHub API. B must link N, never mint a second issue. Then
+// the reverse ordering (B first, A second) must hold too.
+function fakeGitHubIssueStore() {
+  const issues = [];
+  let nextNumber = 1000;
+  return {
+    createIssue: async (opts) => {
+      const issueNumber = nextNumber;
+      nextNumber += 1;
+      issues.push({ number: issueNumber, title: opts.title, state: "open", labels: [] });
+      return { ok: true, issueNumber, url: `https://github.com/${opts.repo}/issues/${issueNumber}` };
+    },
+    commentIssue: async (opts) => ({ ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` }),
+    listIssues: async () => ({ ok: true, issues: issues.filter((i) => i.state === "open") }),
+  };
+}
+
+test("ensureFollowUpIssue: judge-pass-style caller defers first, close-gate-findings-style caller defers second — links the SAME issue", async () => {
+  const gh = fakeGitHubIssueStore();
+  const first = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    gh,
+  );
+  assert.equal(first.created, true);
+  const second = await ensureFollowUpIssue(
+    // The second (disjoint-cache) caller also has no local existingIssueNumber.
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    gh,
+  );
+  assert.deepEqual(second, { issueNumber: first.issueNumber, created: false });
+});
+
+test("ensureFollowUpIssue: close-gate-findings-style caller defers first, judge-pass-style caller defers second — links the SAME issue (order reversed)", async () => {
+  const gh = fakeGitHubIssueStore();
+  const first = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    gh,
+  );
+  assert.equal(first.created, true);
+  const second = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries: followUpEntries(), existingIssueNumber: null },
+    gh,
+  );
+  assert.deepEqual(second, { issueNumber: first.issueNumber, created: false });
+});
+
+// ---------------------------------------------------------------------------
+// #1809: guard symmetry — a finding's own untrusted summary must not throw on
+// the append path (commentIssue's guardCommentBodyNoIssuePrIds) while
+// silently leaking on the create path.
+// ---------------------------------------------------------------------------
+
+test("buildFollowUpIssueBody / buildFollowUpIssueAppendComment: a bare #<digits> in a finding summary is entity-encoded, never raw, on both the create and append render paths", async () => {
+  const entries = [{ fingerprint: "3333333333333333", severity: "low", angle: "naming", summary: "duplicates #123 behavior" }];
+  const createBody = buildFollowUpIssueBody({ repo: "o/r", pr: 42, entries });
+  assert.doesNotMatch(createBody, /[^&]#123\b/);
+  assert.match(createBody, /&#35;123/);
+
+  const listIssues = async () => ({ ok: true, issues: [] });
+  const commentCalls = [];
+  const commentIssue = async (opts) => {
+    commentCalls.push(opts);
+    return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
+  };
+  // The append path must not throw: guardCommentBodyNoIssuePrIds
+  // (comment-id-guard.mjs) fails closed on a raw `#<digits>` token, so this
+  // only passes if formatDeferredFindingEntry already neutralized it.
+  await ensureFollowUpIssue(
+    { repo: "o/r", pr: 42, entries, existingIssueNumber: 101 },
+    { commentIssue, listIssues },
+  );
+  assert.equal(commentCalls.length, 1);
+  assert.doesNotMatch(commentCalls[0].body, /[^&]#123\b/);
+  assert.match(commentCalls[0].body, /&#35;123/);
 });

--- a/test/github/gate-finding-surface.test.mjs
+++ b/test/github/gate-finding-surface.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 
 import { containsBareCopilotSummon } from "../../scripts/_core-helpers.mjs";
+import { guardCommentBodyNoIssuePrIds } from "@dev-loops/core/github/comment-id-guard";
 import {
   buildCommentableLineSet,
   buildFindingMarker,
@@ -858,13 +859,22 @@ test("ensureFollowUpIssue: close-gate-findings-style caller defers first, judge-
 // #1809: guard symmetry — a finding's own untrusted summary must not throw on
 // the append path (commentIssue's guardCommentBodyNoIssuePrIds) while
 // silently leaking on the create path.
+//
+// Round-2: entity-encoding (`&#35;123`) is NOT guard-safe — the guard decodes
+// numeric character references before scanning, so `&#35;123` resolves right
+// back to `#123` and the guard refuses it exactly like the raw form. The
+// rendered text must instead never leave a `#` adjacent to digits at all.
 // ---------------------------------------------------------------------------
 
-test("buildFollowUpIssueBody / buildFollowUpIssueAppendComment: a bare #<digits> in a finding summary is entity-encoded, never raw, on both the create and append render paths", async () => {
+test("buildFollowUpIssueBody / buildFollowUpIssueAppendComment: a bare #<digits> in a finding summary never survives to a `#`-adjacent-digits form on either render path", async () => {
   const entries = [{ fingerprint: "3333333333333333", severity: "low", angle: "naming", summary: "duplicates #123 behavior" }];
   const createBody = buildFollowUpIssueBody({ repo: "o/r", pr: 42, entries });
-  assert.doesNotMatch(createBody, /[^&]#123\b/);
-  assert.match(createBody, /&#35;123/);
+  // The hash is stripped outright: the id still reads (as "123"), but never as
+  // a `#<digits>` auto-link token, and no entity-encoded form either (the
+  // round-1 shape the guard's decode step defeats).
+  assert.doesNotMatch(createBody, /#\d/);
+  assert.doesNotMatch(createBody, /&#35;/);
+  assert.match(createBody, /duplicates 123 behavior/);
 
   const listIssues = async () => ({ ok: true, issues: [] });
   const commentCalls = [];
@@ -880,6 +890,60 @@ test("buildFollowUpIssueBody / buildFollowUpIssueAppendComment: a bare #<digits>
     { commentIssue, listIssues },
   );
   assert.equal(commentCalls.length, 1);
-  assert.doesNotMatch(commentCalls[0].body, /[^&]#123\b/);
-  assert.match(commentCalls[0].body, /&#35;123/);
+  assert.doesNotMatch(commentCalls[0].body, /#\d/);
+  assert.doesNotMatch(commentCalls[0].body, /&#35;/);
+  assert.match(commentCalls[0].body, /duplicates 123 behavior/);
+});
+
+// #1809 round-2 CRITICAL: every prior test in this section stubbed
+// `commentIssue`/`createIssue`, bypassing the REAL
+// `guardCommentBodyNoIssuePrIds` — that is exactly how the round-1
+// entity-encoding regression (guard-defeated by its own decode step) slipped
+// through review. These feed a finding summary carrying a bare `#<digits>`
+// token through the ACTUAL guard (imported directly, and via the real
+// `commentIssue`/`createIssue` from @dev-loops/core/github/issue-ops), for
+// BOTH the create body and the append comment, and assert it does not throw
+// and the rendered body carries no auto-linking bare id.
+test("#1809 round-2: buildFollowUpIssueBody survives the REAL guardCommentBodyNoIssuePrIds unchanged (create path)", () => {
+  const entries = [{ fingerprint: "4444444444444444", severity: "high", angle: "security", summary: "see #987654 for context" }];
+  const body = buildFollowUpIssueBody({ repo: "o/r", pr: 7, entries });
+  assert.doesNotThrow(() => guardCommentBodyNoIssuePrIds(body, { ref: "test create body" }));
+  assert.doesNotMatch(body, /#\d/);
+});
+
+test("#1809 round-2: ensureFollowUpIssue's create path calls the REAL createIssue (real guard exposure) without throwing, and the id is neutralized", async () => {
+  const entries = [{ fingerprint: "5555555555555555", severity: "medium", angle: "perf", summary: "duplicates #123456 behavior" }];
+  const runCalls = [];
+  const run = async (ghCommand, args) => {
+    runCalls.push(args);
+    // Mimic `gh issue create`'s stdout: the created issue URL.
+    return { code: 0, stdout: "https://github.com/o/r/issues/909\n", stderr: "" };
+  };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 7, entries, existingIssueNumber: null },
+    { run, listIssues: async () => ({ ok: true, issues: [] }) },
+  );
+  assert.deepEqual(result, { issueNumber: 909, created: true });
+  // The body actually handed to `gh issue create --body <...>` carries no bare
+  // issue/PR id.
+  const bodyArg = runCalls[0][runCalls[0].indexOf("--body") + 1];
+  assert.doesNotMatch(bodyArg, /#\d/);
+  assert.match(bodyArg, /duplicates 123456 behavior/);
+});
+
+test("#1809 round-2: ensureFollowUpIssue's append path calls the REAL commentIssue (real guard exposure) without throwing, and the id is neutralized", async () => {
+  const entries = [{ fingerprint: "6666666666666666", severity: "low", angle: "naming", summary: "references #42 in the doc" }];
+  const runCalls = [];
+  const run = async (ghCommand, args) => {
+    runCalls.push(args);
+    return { code: 0, stdout: "https://github.com/o/r/issues/909#issuecomment-1\n", stderr: "" };
+  };
+  const result = await ensureFollowUpIssue(
+    { repo: "o/r", pr: 7, entries, existingIssueNumber: 909 },
+    { run },
+  );
+  assert.deepEqual(result, { issueNumber: 909, created: false });
+  const bodyArg = runCalls[0][runCalls[0].indexOf("--body") + 1];
+  assert.doesNotMatch(bodyArg, /#\d/);
+  assert.match(bodyArg, /references 42 in the doc/);
 });

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -129,6 +129,38 @@ test("writeGateFindingsLog rejects non-array findings JSON", async () => {
   }, /array/);
 });
 
+test("writeGateFindingsLog fails closed on a malformed fingerprint shape", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{ severity: "low", angle: "scope", summary: "x", fingerprint: "not-16-hex" }]),
+    });
+  }, /fingerprint must be a 16-char lowercase hex string/);
+});
+
+test("writeGateFindingsLog accepts a valid 16-hex fingerprint", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "wgfl-fp-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{ severity: "low", angle: "scope", summary: "x", fingerprint: "0123456789abcdef" }]),
+      tmpRoot: dir,
+    });
+    const written = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(written.findings[0].fingerprint, "0123456789abcdef");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseWriteGateFindingsLogCliArgs rejects missing required args", () => {
   assert.throws(() => {
     parseWriteGateFindingsLogCliArgs([

--- a/test/loop/judge-pass.test.mjs
+++ b/test/loop/judge-pass.test.mjs
@@ -9,6 +9,7 @@ import {
   runJudgePass,
   validateCliArgs,
 } from "../../scripts/loop/judge-pass.mjs";
+import { fingerprintFinding } from "../../scripts/github/_gate-finding-surface.mjs";
 
 const HEAD = "0123456789abcdef";
 const HEAD_8 = HEAD.slice(0, 8);
@@ -218,9 +219,10 @@ test("judgePassCli resolves a relative findings-file against repo-root (#1658)",
 // follow-up GitHub issue. Stub `createIssue`/`commentIssue` — the same
 // dependency-injection seam create-issue.test.mjs/comment-issue.test.mjs stub
 // — so this never hits the real API.
-function stubIssueDeps({ issueNumber = 9001 } = {}) {
+function stubIssueDeps({ issueNumber = 9001, existingGithubIssues = [] } = {}) {
   const createCalls = [];
   const commentCalls = [];
+  const listCalls = [];
   const createIssue = async (opts) => {
     createCalls.push(opts);
     return { ok: true, issueNumber, url: `https://github.com/${opts.repo}/issues/${issueNumber}` };
@@ -229,7 +231,15 @@ function stubIssueDeps({ issueNumber = 9001 } = {}) {
     commentCalls.push(opts);
     return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
   };
-  return { createIssue, commentIssue, createCalls, commentCalls };
+  // #1809: ensureFollowUpIssue now searches GitHub before creating whenever the
+  // caller's own local ledger cache doesn't already know a follow-up issue
+  // number — stub it to "no match" by default (returning `existingGithubIssues`
+  // otherwise) so a test never hits the real API.
+  const listIssues = async (opts) => {
+    listCalls.push(opts);
+    return { ok: true, issues: existingGithubIssues };
+  };
+  return { createIssue, commentIssue, listIssues, createCalls, commentCalls, listCalls };
 }
 
 test("judgePassCli writes the act list and enriched ledger for a wrapped ledger", async () => {
@@ -257,7 +267,7 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
     ),
   );
   const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
-  const { createIssue, commentIssue, createCalls, commentCalls } = stubIssueDeps();
+  const { createIssue, commentIssue, listIssues, createCalls, commentCalls } = stubIssueDeps();
   const payload = await judgePassCli(
     {
       repo: "mfittko/dev-loops",
@@ -269,7 +279,7 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
       out: actPath,
       ledgerOut: outLedgerPath,
     },
-    { repoRoot: tmpDir, createIssue, commentIssue },
+    { repoRoot: tmpDir, createIssue, commentIssue, listIssues },
   );
   assert.equal(payload.ok, true);
   assert.equal(payload.actCount, 1);
@@ -309,7 +319,7 @@ test("judgePassCli defer is idempotent across a re-run: the already-linked findi
   const first = stubIssueDeps({ issueNumber: 4242 });
   await judgePassCli(
     { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
-    { repoRoot: tmpDir, createIssue: first.createIssue, commentIssue: first.commentIssue },
+    { repoRoot: tmpDir, createIssue: first.createIssue, commentIssue: first.commentIssue, listIssues: first.listIssues },
   );
   assert.equal(first.createCalls.length, 1);
 
@@ -318,10 +328,11 @@ test("judgePassCli defer is idempotent across a re-run: the already-linked findi
   const second = stubIssueDeps({ issueNumber: 9999 });
   await judgePassCli(
     { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
-    { repoRoot: tmpDir, createIssue: second.createIssue, commentIssue: second.commentIssue },
+    { repoRoot: tmpDir, createIssue: second.createIssue, commentIssue: second.commentIssue, listIssues: second.listIssues },
   );
   assert.equal(second.createCalls.length, 0, "no duplicate issue created on re-run");
   assert.equal(second.commentCalls.length, 0, "nothing new to append on a pure retry");
+  assert.equal(second.listCalls.length, 0, "a pure retry with a known prior issue number never searches GitHub");
   const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
   assert.equal(enriched.findings[0].followUpIssueNumber, 4242, "reuses the FIRST run's issue number");
 });
@@ -336,10 +347,10 @@ test("judgePassCli reject records a fingerprint audit entry and creates no issue
   await writeFile(ledgerPath, JSON.stringify({ overallVerdict: "findings_present", findings: [finding({ summary: "out of scope" })] }));
   await writeFile(verdictPath, JSON.stringify(verdict({ dispositions: [{ index: 0, disposition: "reject", rationale: "below the defer bar", criterion: "NG-1" }] })));
   const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
-  const { createIssue, commentIssue, createCalls, commentCalls } = stubIssueDeps();
+  const { createIssue, commentIssue, listIssues, createCalls, commentCalls } = stubIssueDeps();
   await judgePassCli(
     { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
-    { repoRoot: tmpDir, createIssue, commentIssue },
+    { repoRoot: tmpDir, createIssue, commentIssue, listIssues },
   );
   assert.equal(createCalls.length, 0);
   assert.equal(commentCalls.length, 0);
@@ -350,4 +361,66 @@ test("judgePassCli reject records a fingerprint audit entry and creates no issue
   assert.equal(entry.severity, "high");
   assert.equal(entry.angle, "correctness");
   assert.equal(entry.followUpIssueNumber, undefined);
+});
+
+// #1809: cross-path convergence — close-gate-findings.mjs's severity/round
+// defer may have already created this PR's follow-up issue via a thread
+// marker judge-pass never sees. judge-pass's OWN --ledger-out cache is empty
+// (first-ever run of THIS pass), so it must resolve the existing issue via
+// GitHub itself rather than mint a duplicate.
+test("judgePassCli: no local prior issue, but GitHub already has this PR's follow-up issue — appends instead of creating a duplicate", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "judge-pass-cross-path-"));
+  const ledgerPath = path.join(tmpDir, "ledger.json");
+  const verdictPath = path.join(tmpDir, "judge-verdict.json");
+  const outLedgerPath = path.join(tmpDir, "enriched.json");
+  await writeFile(ledgerPath, JSON.stringify({ overallVerdict: "findings_present", findings: [finding({ summary: "defer this", severity: "low" })] }));
+  await writeFile(verdictPath, JSON.stringify(verdict({ dispositions: [{ index: 0, disposition: "defer", rationale: "follow-up", followUpDraft: { title: "t", body: "b" } }] })));
+  const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
+  const { createIssue, commentIssue, listIssues, createCalls, commentCalls, listCalls } = stubIssueDeps({
+    existingGithubIssues: [{ number: 6500, title: "Deferred gate findings for mfittko/dev-loops#1658", state: "open", labels: [] }],
+  });
+  await judgePassCli(
+    { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
+    { repoRoot: tmpDir, createIssue, commentIssue, listIssues },
+  );
+  assert.equal(createCalls.length, 0, "must not create a duplicate — close-gate-findings already created one");
+  assert.equal(commentCalls.length, 1);
+  assert.equal(commentCalls[0].issue, 6500);
+  assert.equal(listCalls.length, 1, "searches GitHub exactly once since the local cache is empty");
+  const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
+  assert.equal(enriched.findings[0].followUpIssueNumber, 6500);
+});
+
+// #1809 finding 4 (coverage gap): the branch where a prior --ledger-out
+// already links a follow-up issue AND this round defers a NEW (not
+// previously linked) finding — must append to that same issue via
+// commentIssue, using the local fast path (no GitHub search needed since the
+// issue number is already known).
+test("judgePassCli: a NEW deferral in a later round appends to the PR's already-linked follow-up issue (no search, no duplicate)", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "judge-pass-append-round-"));
+  const ledgerPath = path.join(tmpDir, "ledger.json");
+  const verdictPath = path.join(tmpDir, "judge-verdict.json");
+  const outLedgerPath = path.join(tmpDir, "enriched.json");
+  // Simulate a prior round's own output: one finding already linked to issue 7000.
+  const priorFinding = finding({ summary: "already deferred", severity: "low" });
+  await writeFile(outLedgerPath, JSON.stringify({
+    overallVerdict: "findings_present",
+    findings: [{ ...priorFinding, judgeDisposition: "defer", fingerprint: fingerprintFinding(priorFinding), followUpIssueNumber: 7000 }],
+  }));
+  // This round's fresh findings-file carries a DIFFERENT finding (distinct
+  // summary -> distinct fingerprint), disposed defer.
+  await writeFile(ledgerPath, JSON.stringify({ overallVerdict: "findings_present", findings: [finding({ summary: "a new finding to defer", severity: "low" })] }));
+  await writeFile(verdictPath, JSON.stringify(verdict({ dispositions: [{ index: 0, disposition: "defer", rationale: "follow-up", followUpDraft: { title: "t", body: "b" } }] })));
+  const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
+  const { createIssue, commentIssue, listIssues, createCalls, commentCalls, listCalls } = stubIssueDeps();
+  await judgePassCli(
+    { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
+    { repoRoot: tmpDir, createIssue, commentIssue, listIssues },
+  );
+  assert.equal(createCalls.length, 0, "must not create a second issue for the same PR");
+  assert.equal(commentCalls.length, 1);
+  assert.equal(commentCalls[0].issue, 7000);
+  assert.equal(listCalls.length, 0, "the local ledger already knows the issue number — no GitHub search needed");
+  const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
+  assert.equal(enriched.findings[0].followUpIssueNumber, 7000);
 });

--- a/test/loop/judge-pass.test.mjs
+++ b/test/loop/judge-pass.test.mjs
@@ -214,6 +214,24 @@ test("judgePassCli resolves a relative findings-file against repo-root (#1658)",
   assert.equal(JSON.parse(await readFile(path.join(tmpDir, "enriched.json"), "utf8")).findings[0].judgeDisposition, "act");
 });
 
+// #1807: a `defer` disposition creates (or appends to) the PR's ONE tracked
+// follow-up GitHub issue. Stub `createIssue`/`commentIssue` — the same
+// dependency-injection seam create-issue.test.mjs/comment-issue.test.mjs stub
+// — so this never hits the real API.
+function stubIssueDeps({ issueNumber = 9001 } = {}) {
+  const createCalls = [];
+  const commentCalls = [];
+  const createIssue = async (opts) => {
+    createCalls.push(opts);
+    return { ok: true, issueNumber, url: `https://github.com/${opts.repo}/issues/${issueNumber}` };
+  };
+  const commentIssue = async (opts) => {
+    commentCalls.push(opts);
+    return { ok: true, repo: opts.repo, issue: opts.issue, commentUrl: `https://github.com/${opts.repo}/issues/${opts.issue}#issuecomment-1` };
+  };
+  return { createIssue, commentIssue, createCalls, commentCalls };
+}
+
 test("judgePassCli writes the act list and enriched ledger for a wrapped ledger", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "judge-pass-"));
   const ledgerPath = path.join(tmpDir, "ledger.json");
@@ -239,6 +257,7 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
     ),
   );
   const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
+  const { createIssue, commentIssue, createCalls, commentCalls } = stubIssueDeps();
   const payload = await judgePassCli(
     {
       repo: "mfittko/dev-loops",
@@ -250,7 +269,7 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
       out: actPath,
       ledgerOut: outLedgerPath,
     },
-    { repoRoot: tmpDir },
+    { repoRoot: tmpDir, createIssue, commentIssue },
   );
   assert.equal(payload.ok, true);
   assert.equal(payload.actCount, 1);
@@ -261,6 +280,74 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
   const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
   assert.equal(enriched.overallVerdict, "findings_present");
   assert.equal(enriched.findings[0].judgeDisposition, "act");
+  assert.ok(typeof enriched.findings[0].fingerprint, "string");
   assert.equal(enriched.findings[1].judgeDisposition, "defer");
+  assert.equal(enriched.findings[1].followUpIssueNumber, 9001);
   assert.equal(enriched.scopeDrift.verdict, "within_scope");
+  // ONE issue created for the round's batch of defers; no comment-append call
+  // on a first-ever run (nothing prior to append to).
+  assert.equal(createCalls.length, 1);
+  assert.equal(commentCalls.length, 0);
+  assert.match(createCalls[0].body, /defer this/);
+});
+
+// #1807 idempotency: re-running the pass over the SAME --ledger-out path
+// (a retry, or the next round re-linking the same PR) must not create a
+// duplicate issue for a finding it already linked.
+test("judgePassCli defer is idempotent across a re-run: the already-linked finding reuses its issue with no gh call", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "judge-pass-idempotent-"));
+  const ledgerPath = path.join(tmpDir, "ledger.json");
+  const verdictPath = path.join(tmpDir, "judge-verdict.json");
+  const outLedgerPath = path.join(tmpDir, "enriched.json");
+  const deferredFinding = finding({ summary: "defer this", severity: "medium" });
+  await writeFile(ledgerPath, JSON.stringify({ overallVerdict: "findings_present", findings: [deferredFinding] }));
+  await writeFile(
+    verdictPath,
+    JSON.stringify(verdict({ dispositions: [{ index: 0, disposition: "defer", rationale: "follow-up", followUpDraft: { title: "t", body: "b" } }] })),
+  );
+  const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
+  const first = stubIssueDeps({ issueNumber: 4242 });
+  await judgePassCli(
+    { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
+    { repoRoot: tmpDir, createIssue: first.createIssue, commentIssue: first.commentIssue },
+  );
+  assert.equal(first.createCalls.length, 1);
+
+  // Re-run with the SAME inputs (same fresh findings-file, same verdict) —
+  // the prior enriched.json already links fingerprint -> 4242.
+  const second = stubIssueDeps({ issueNumber: 9999 });
+  await judgePassCli(
+    { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
+    { repoRoot: tmpDir, createIssue: second.createIssue, commentIssue: second.commentIssue },
+  );
+  assert.equal(second.createCalls.length, 0, "no duplicate issue created on re-run");
+  assert.equal(second.commentCalls.length, 0, "nothing new to append on a pure retry");
+  const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
+  assert.equal(enriched.findings[0].followUpIssueNumber, 4242, "reuses the FIRST run's issue number");
+});
+
+// #1807 AC3: a `reject` disposition records fingerprint/severity/angle in the
+// ledger and creates no issue.
+test("judgePassCli reject records a fingerprint audit entry and creates no issue", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "judge-pass-reject-"));
+  const ledgerPath = path.join(tmpDir, "ledger.json");
+  const verdictPath = path.join(tmpDir, "judge-verdict.json");
+  const outLedgerPath = path.join(tmpDir, "enriched.json");
+  await writeFile(ledgerPath, JSON.stringify({ overallVerdict: "findings_present", findings: [finding({ summary: "out of scope" })] }));
+  await writeFile(verdictPath, JSON.stringify(verdict({ dispositions: [{ index: 0, disposition: "reject", rationale: "below the defer bar", criterion: "NG-1" }] })));
+  const { judgePassCli } = await import("../../scripts/loop/judge-pass.mjs");
+  const { createIssue, commentIssue, createCalls, commentCalls } = stubIssueDeps();
+  await judgePassCli(
+    { repo: "mfittko/dev-loops", pr: "1658", gate: "draft_gate", headSha: HEAD, findingsFile: ledgerPath, judgeVerdict: verdictPath, ledgerOut: outLedgerPath },
+    { repoRoot: tmpDir, createIssue, commentIssue },
+  );
+  assert.equal(createCalls.length, 0);
+  assert.equal(commentCalls.length, 0);
+  const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
+  const [entry] = enriched.findings;
+  assert.equal(entry.judgeDisposition, "reject");
+  assert.equal(typeof entry.fingerprint, "string");
+  assert.equal(entry.severity, "high");
+  assert.equal(entry.angle, "correctness");
+  assert.equal(entry.followUpIssueNumber, undefined);
 });

--- a/test/loop/judge-pass.test.mjs
+++ b/test/loop/judge-pass.test.mjs
@@ -290,7 +290,7 @@ test("judgePassCli writes the act list and enriched ledger for a wrapped ledger"
   const enriched = JSON.parse(await readFile(outLedgerPath, "utf8"));
   assert.equal(enriched.overallVerdict, "findings_present");
   assert.equal(enriched.findings[0].judgeDisposition, "act");
-  assert.ok(typeof enriched.findings[0].fingerprint, "string");
+  assert.strictEqual(typeof enriched.findings[0].fingerprint, "string");
   assert.equal(enriched.findings[1].judgeDisposition, "defer");
   assert.equal(enriched.findings[1].followUpIssueNumber, 9001);
   assert.equal(enriched.scopeDrift.verdict, "within_scope");


### PR DESCRIPTION
## Objective

Make gate `defer` dispositions durable and tracker-first. Today a `defer` only stamps a thread marker plus the ephemeral `tmp/` findings ledger, which is lost on cleanup ("later means never") and violates the work-origin rule. This change makes `defer` always create a tracked GitHub issue, so a deferred finding re-attaches via its issue, not by reading a local ledger.

Closes #1807.

## In scope

Disposition vocabulary is exactly `act` / `defer` (issue created) / `reject`:
- **act** — fixer pass, commit (unchanged).
- **defer** — creates or appends to ONE tracked follow-up issue per PR, batched: the first `defer` on a PR creates the issue (title `Deferred gate findings for <repo>#<pr>`, body listing every deferred finding); every later `defer` on the same PR appends to that same issue. The created issue number is recorded on the thread marker and in the durable ledger.
- **reject** — a one-line audit entry in the ledger, no issue.

The one-issue-per-PR invariant is enforced by making GitHub itself the source of truth. `ensureFollowUpIssue` resolves any existing open follow-up issue for the PR by searching for the deterministic title `Deferred gate findings for <repo>#<pr>` (exact-title match, lowest issue number) before creating; both defer paths route through it, so their local ledger/marker records are caches, not the authority. This is why the two independent defer paths cannot mint two issues for one PR.

Wiring:
- `scripts/github/_gate-finding-surface.mjs`: shared `buildFollowUpIssueTitle`/`buildFollowUpIssueBody`/`buildFollowUpIssueAppendComment`/`ensureFollowUpIssue` (DI seam for `createIssue`/`commentIssue`/`listIssues`, defaulting to the sanctioned `@dev-loops/core/github/issue-ops` wrappers — never raw `gh`). `ensureFollowUpIssue` searches GitHub for the existing per-PR issue before creating. Marker grammar extended with an optional `issue=<n>` field. Bare id tokens in rendered finding text are neutralized so they neither auto-link nor trip the comment-id guard.
- `packages/core/src/github/issue-ops.mjs`: `listIssues` gains an optional `search` passthrough (the minimal enabler for the title search).
- `scripts/loop/judge-pass.mjs`: attaches a fingerprint to every judge-disposed finding and, on `defer`, creates/links the PR's one follow-up issue via `ensureFollowUpIssue` (its `--ledger-out` read-back is a fast-path cache; the GitHub search is the authority).
- `scripts/github/close-gate-findings.mjs`: the severity/round auto-defer thread path resolves one follow-up issue for the round's whole batch before stamping; `stampDeferredDisposition` requires and stamps `issue=<n>`; `detectContractViolatingDeferredStamps` (`GATE-EXEC-THREAD-DISPOSITION`) now also fails closed on a `disposition=deferred` stamp with no linked issue. `dispositionMessage` references the tracked issue instead of "ledger only" wording.
- `scripts/github/write-gate-findings-log.mjs`: passes through `fingerprint`/`followUpIssueNumber` so a judge-enriched ledger is not stripped on re-validation.
- Docs: `GATE-EXEC-DEFERRAL-RECORD` and the judge merge-seam section rewritten to the tracked-issue requirement, batching, and reject's issue-free audit entry; `.claude/` mirror regenerated.

## Explicit non-goals

- Backfilling issues for deferrals recorded under the old ledger-only scheme.
- Recording `reject` findings in the tracker (audit stays ledger-local).
- Changing the severity → disposition selection logic beyond the vocabulary and issue-creation wiring.
- Changing the fixer's `act` fix-and-commit path.
- Auto-closing or auto-prioritizing the created follow-up issues.

## Known limitation

`renderNonLocatableBlock` (body-filed non-thread deferrals in `upsert-checkpoint-verdict.mjs`) still stamps `disposition=deferred` at pure render time with no issue link — that call site has no I/O access, and AC1's "no defer path resolves a thread" language is thread-scoped, so it is out of scope here. Candidate for a follow-up.

## Acceptance criteria

- [x] A `defer` disposition creates a follow-up GitHub issue via the sanctioned wrapper (never raw `gh`); no `defer` path resolves a thread without a linked issue number.
- [x] Thread marker and durable ledger both record the created issue number.
- [x] A `reject` records a one-line audit ledger entry and creates no issue.
- [x] No "deferred to ledger only" wording remains in ledger, markers, `dispositionMessage`/`windowReason`, judge output, or gate contract docs.
- [x] Issue creation is idempotent per PR (one batched follow-up issue), not per fingerprint; a re-run appends rather than duplicating.
- [x] The `GATE-EXEC-THREAD-DISPOSITION` scan refuses a `defer` stamp without a linked issue number, fail-closed.
- [x] Tests cover: defer creates+links (stubbed), defer re-run idempotent, reject audit entry, missing-issue-link contract violation. Suites green.
