### PR TITLE
feat(config): configurable postMerge.actions hook (closes #1457)

### DIFF
--- a/.claude/hooks/_main-checkout-ff.mjs
+++ b/.claude/hooks/_main-checkout-ff.mjs
@@ -96,3 +96,37 @@ export function buildWorktreeCleanupCommand(mainCheckout, prNumber) {
   // non-fatal with `|| true` — removal must never break a merge-completion flow.
   return `if [ -f ${script} ]; then node ${script} --repo-root ${quotedMain} --pr "${pr}"; fi || true`;
 }
+
+/**
+ * Overall timeout (ms) for the post-merge actions runner invocation. Generous:
+ * the runner itself bounds each declared action by its own timeoutMs/verify
+ * budget (each individually capped at the config-schema ceiling), and this is
+ * only the outer harness-hook guard against a runner that never returns.
+ */
+export const POST_MERGE_ACTIONS_TIMEOUT_MS = 900_000;
+
+/**
+ * Build the best-effort `postMerge.actions` runner command (#1457): the shared,
+ * dependency-free command string both harness hooks (Pi `post-merge-update`,
+ * Claude `post-tool-use-merge`) run after a successful merge, for the repo that
+ * merged. Existence-guarded (a checkout without the runner script is a silent
+ * no-op) and non-fatal (`|| true` — a runner failure must never break a
+ * merge-completion flow; the runner itself reports per-action failures in its
+ * own JSON result). `mainCheckout` and the script path are POSIX
+ * single-quoted; `prNumber` (when a valid positive integer) is passed as a
+ * double-quoted `--pr` argument — never interpolated into `run`/`verify`
+ * command strings, which the runner executes verbatim from the repo's own
+ * `.devloops`.
+ *
+ * @param {string} mainCheckout - Absolute path to the main (primary) git checkout.
+ * @param {string | number | undefined} [prNumber] - Merged PR number, when known.
+ * @returns {string} the runner command (always non-empty; a missing PR number
+ *   just omits `--pr`, since `onlyIfChanged` scoping bypasses cleanly without one).
+ */
+export function buildPostMergeActionsCommand(mainCheckout, prNumber) {
+  const quotedMain = shellQuotePath(mainCheckout);
+  const script = shellQuotePath(path.join(mainCheckout, "scripts", "loop", "run-post-merge-actions.mjs"));
+  const pr = String(prNumber ?? "").trim();
+  const prArg = /^[0-9]+$/u.test(pr) ? ` --pr "${pr}"` : "";
+  return `if [ -f ${script} ]; then node ${script} --repo-root ${quotedMain}${prArg}; fi || true`;
+}

--- a/.claude/hooks/post-tool-use-merge.mjs
+++ b/.claude/hooks/post-tool-use-merge.mjs
@@ -16,7 +16,15 @@
 import { execFileSync, execSync } from "node:child_process";
 import { isMergeCapableCommand, extractPrNumberFromGhPrMergeAnywhere } from "./_bash-command-classify.mjs";
 import { parseMainWorktreePath } from "./_worktree-guard.mjs";
-import { buildMainCheckoutFastForwardCommand, WORKTREE_CLEANUP_TIMEOUT_MS, MAIN_CHECKOUT_FF_FETCH_TIMEOUT_MS, MAIN_CHECKOUT_FF_MERGE_TIMEOUT_MS, buildWorktreeCleanupCommand } from "./_main-checkout-ff.mjs";
+import {
+  buildMainCheckoutFastForwardCommand,
+  WORKTREE_CLEANUP_TIMEOUT_MS,
+  MAIN_CHECKOUT_FF_FETCH_TIMEOUT_MS,
+  MAIN_CHECKOUT_FF_MERGE_TIMEOUT_MS,
+  buildWorktreeCleanupCommand,
+  buildPostMergeActionsCommand,
+  POST_MERGE_ACTIONS_TIMEOUT_MS,
+} from "./_main-checkout-ff.mjs";
 
 import { readHookInput } from "./_hook-io.mjs";
 
@@ -76,6 +84,31 @@ if (typeof command === "string" && isMergeCapableCommand(command)) {
           `[dev-loops] post-merge: worktree cleanup skipped (best-effort): ${reason}\n`,
         );
       }
+    }
+  }
+
+  // Post-merge configured actions (postMerge.actions, #1457): a repo declaring
+  // this family in its .devloops runs its own local actions (sync checkout,
+  // restart a local service, smoke check) after merge. Existence-guarded (a
+  // checkout without the runner script is a silent no-op) and non-fatal — a
+  // runner failure never blocks this hook, which always exits 0. The runner
+  // itself stays silent (no stdout) when the repo declares no postMerge.actions,
+  // so relaying its output here produces zero new log lines for that case too.
+  if (mainCheckout) {
+    let output = "";
+    try {
+      output = execSync(buildPostMergeActionsCommand(mainCheckout, prNumber), {
+        cwd: mainCheckout,
+        timeout: POST_MERGE_ACTIONS_TIMEOUT_MS,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch (error) {
+      output = (error?.stdout ?? "").toString();
+    }
+    const trimmed = output.trim();
+    if (trimmed) {
+      process.stderr.write(`[dev-loops] post-merge: post-merge actions: ${trimmed}\n`);
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Key surfaces:
 - **Gates** — per-gate `requireCi` CI-precondition toggle (`gates.draft.requireCi`, `gates.preApproval.requireCi`; default `true`). Set a gate's `requireCi: false` to opt that gate out of the CI precondition — e.g. a repo with no CI can run the loop end-to-end instead of blocking at the gate.
 - **Refinement** — fan-out count and mode for parallel review variants; `refinement.maxCopilotRounds` caps Copilot re-review rounds (default `5`). Set `maxCopilotRounds: 0` to disable the Copilot gate entirely — local-harness-only review (`draft_gate → pre_approval_gate`), useful when the repo has no Copilot reviewer configured.
 - **UI review** — the `uiReview` surface configures the `/loop-review-ui` route (per-project run/boot command, login recipe, log/exception patterns)
+- **Post-merge actions** — `postMerge.actions` declares local actions (sync checkout, restart a local service, smoke check) a harness hook runs sequentially, in order, after the dev-loop's merge succeeds. Each action needs `name` + `run`; optional `onlyIfChanged` scopes it to the merged PR's changed files (plain substring matching, not a glob/regex — a pattern matches when any changed file path *contains* it), `verify` polls a command until it exits 0, and `timeoutMs`/`verifyTimeoutMs`/`verifyIntervalMs` bound the run/verify/poll timing. Absent (the default) means no action runs. See `packages/core/src/loop/run-post-merge-actions.mjs` for the runner and `scripts/loop/run-post-merge-actions.mjs` for the CLI both harness hooks invoke.
 - **Autonomy** — which gates require operator confirmation
 - **Workflow defaults** — retrospective enforcement, draft-first posture, dev-mode policy
 
@@ -147,7 +148,7 @@ Full details: the shipped defaults in `packages/core/src/config/extension-defaul
 
 From **1.0**, `dev-loops` follows [semantic versioning](https://semver.org/) for its public surface — breaking changes to it bump the major version:
 
-- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `autonomy.*`, and `workflow.*`. The authoritative validator is the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` is generated from it (`node scripts/generate-config-schema.mjs`) and covers the full file-level surface — only cross-field refinements stay zod-only.
+- **The `.devloops` configuration surface** — gate angles, personas, `gates.*` (including each gate's `requireCi` toggle and `gates.preApproval.requireCi`), `refinement.*`, `uiReview.*`, `postMerge.*`, `autonomy.*`, and `workflow.*`. The authoritative validator is the config loader in `packages/core/src/config/config.mjs`; `schemas/dev-loop-config.schema.json` is generated from it (`node scripts/generate-config-schema.mjs`) and covers the full file-level surface — only cross-field refinements stay zod-only.
 - **The public `dev-loop` command and skill surface** — the natural-language `dev-loop` router and the named `/loop-*` entrypoints.
 - **The routing contract** — the [Public Dev Loop Contract](./skills/docs/public-dev-loop-contract.md).
 

--- a/extension/post-merge-update.ts
+++ b/extension/post-merge-update.ts
@@ -13,9 +13,11 @@ import { parseMainWorktreePath } from '@dev-loops/core/loop/worktree-guard';
 import {
   buildMainCheckoutFastForwardCommand,
   buildWorktreeCleanupCommand,
+  buildPostMergeActionsCommand,
   WORKTREE_CLEANUP_TIMEOUT_MS,
   MAIN_CHECKOUT_FF_FETCH_TIMEOUT_MS,
   MAIN_CHECKOUT_FF_MERGE_TIMEOUT_MS,
+  POST_MERGE_ACTIONS_TIMEOUT_MS,
 } from '@dev-loops/core/loop/main-checkout-ff';
 
 // The bash-command classifiers now live in `@dev-loops/core/loop/bash-command-classify` so the
@@ -69,6 +71,11 @@ type PostMergeUpdateHookState = {
   updateInFlight: boolean;
   pendingRepoRoot: string | null;
   pendingPrNumber: number | null;
+  // Set on ANY successful merge-capable command in ANY repo (not slug-gated like
+  // pendingPostMergeUpdate, which only tracks the dev-loops self-update flow):
+  // postMerge.actions (#1457) is a consumer-repo opt-in feature, so it must run
+  // for the repo that merged regardless of its slug.
+  pendingPostMergeActionsRoot: string | null;
 };
 
 type CreatePostMergeUpdateHookOptions = {
@@ -168,6 +175,13 @@ async function resolveRepoContextSafe(
   }
 }
 
+function markPendingPostMergeActions(state: PostMergeUpdateHookState, repoContext: RepoContext): void {
+  if (!repoContext.repoRoot) {
+    return;
+  }
+  state.pendingPostMergeActionsRoot ??= repoContext.repoRoot;
+}
+
 async function queueIfEligible(
   state: PostMergeUpdateHookState,
   resolveRepoContext: (cwd: string) => Promise<RepoContext>,
@@ -179,11 +193,20 @@ async function queueIfEligible(
   }
 
   const repoContext = await resolveRepoContextSafe(resolveRepoContext, cwd);
-  if (!repoContext?.repoRoot || repoContext.repoSlug !== TARGET_REPO_SLUG) {
+  if (!repoContext?.repoRoot) {
     return false;
   }
 
-  markPendingUpdate(state, command, repoContext);
+  // postMerge.actions (#1457) runs for the repo that merged regardless of slug.
+  markPendingPostMergeActions(state, repoContext);
+
+  if (repoContext.repoSlug === TARGET_REPO_SLUG) {
+    markPendingUpdate(state, command, repoContext);
+  }
+
+  // A resolved repo root means the caller should still capture the PR number (used
+  // by both the dev-loops update pipeline and postMerge.actions), even for a repo
+  // whose slug doesn't match TARGET_REPO_SLUG.
   return true;
 }
 
@@ -304,6 +327,56 @@ async function removeMergedWorktree(
   }
 }
 
+/**
+ * Run the repo's declared `postMerge.actions` (#1457), for the repo that
+ * merged — regardless of its slug (unlike the dev-loops self-update pipeline,
+ * this is a consumer opt-in feature). Resolves the main checkout the same way
+ * fastForwardMainCheckout/removeMergedWorktree do, then runs the shared
+ * existence-guarded runner command. The runner itself stays silent (no
+ * stdout) when the repo declares no postMerge.actions, so this only notifies
+ * when the runner actually produced output (something ran/skipped/failed) or
+ * genuinely errored — never throws out of `onAgentEnd`.
+ */
+async function runPostMergeActionsForRepo(
+  runCommand: (args: RunCommandArgs) => Promise<RunCommandResult>,
+  pendingRoot: string,
+  prNumber: number | null,
+  ctx: Pick<HarnessContext, 'hasUI' | 'ui'>,
+): Promise<void> {
+  let mainCheckout = pendingRoot;
+  try {
+    const wtResult = await runCommand({
+      command: 'git worktree list',
+      cwd: pendingRoot,
+      timeout: MAIN_CHECKOUT_FF_FETCH_TIMEOUT_MS,
+    });
+    if (wtResult.code === 0 && !wtResult.killed) {
+      const resolved = parseMainWorktreePath(wtResult.stdout ?? '');
+      if (resolved) mainCheckout = resolved;
+    }
+  } catch {
+    // fall back to pendingRoot
+  }
+
+  try {
+    const result = await runCommand({
+      command: buildPostMergeActionsCommand(mainCheckout, prNumber ?? undefined),
+      cwd: mainCheckout,
+      timeout: POST_MERGE_ACTIONS_TIMEOUT_MS,
+    });
+    // Only the runner's own stdout (its final JSON result line) drives notification —
+    // the wrapped command is `... || true`, so a non-zero exit never surfaces here; a
+    // repo with no postMerge.actions produces no stdout at all (stays silent, AC11).
+    const output = trimToNull(result.stdout);
+    if (output) {
+      notify(ctx, `Post-merge actions: ${output}`, 'info');
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    notify(ctx, `Post-merge actions skipped (warning only): ${detail}`, 'warning');
+  }
+}
+
 export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOptions = {}) {
   const exec = options.exec ?? null;
 
@@ -321,6 +394,7 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
     updateInFlight: false,
     pendingRepoRoot: null,
     pendingPrNumber: null,
+    pendingPostMergeActionsRoot: null,
   };
 
   function reset(): void {
@@ -328,6 +402,7 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
     state.updateInFlight = false;
     state.pendingRepoRoot = null;
     state.pendingPrNumber = null;
+    state.pendingPostMergeActionsRoot = null;
   }
 
   return {
@@ -347,6 +422,8 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
       if (!command || event.isError) {
         return;
       }
+      // `pending`: a merge-capable command whose repo root resolved (any slug) — used
+      // by both the dev-loops update pipeline and postMerge.actions (#1457).
       const pending = await queueIfEligible(state, resolveRepoContext, command, ctx.cwd);
       if (pending) {
         const pr = extractPrNumberFromGhPrMergeAnywhere(command);
@@ -465,6 +542,7 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
 
         if (result.code === 0 && !result.killed) {
           markPendingUpdate(state, event.command, repoContext);
+          markPendingPostMergeActions(state, repoContext);
           const pr = extractPrNumberFromGhPrMergeAnywhere(event.command);
           if (pr !== null) state.pendingPrNumber = pr;
         }
@@ -491,7 +569,9 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
     },
 
     async onAgentEnd(_event: unknown, ctx: Pick<HarnessContext, 'cwd' | 'hasUI' | 'ui'>): Promise<void> {
-      if (!state.pendingPostMergeUpdate || state.updateInFlight) {
+      const shouldRunUpdate = state.pendingPostMergeUpdate;
+      const actionsRoot = state.pendingPostMergeActionsRoot;
+      if ((!shouldRunUpdate && !actionsRoot) || state.updateInFlight) {
         return;
       }
 
@@ -500,41 +580,57 @@ export function createPostMergeUpdateHook(options: CreatePostMergeUpdateHookOpti
       const pendingRoot = state.pendingRepoRoot ?? ctx.cwd;
 
       state.updateInFlight = true;
-      notify(ctx, `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+
+      if (shouldRunUpdate) {
+        notify(ctx, `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+
+        try {
+          const result = await runCommand({
+            command: POST_MERGE_UPDATE_COMMAND,
+            cwd: pendingRoot,
+            timeout: POST_MERGE_UPDATE_TIMEOUT_MS,
+          });
+
+          if (result.code === 0 && !result.killed) {
+            notify(ctx, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
+          } else {
+            notify(
+              ctx,
+              `Post-merge update failed (warning only): ${buildFailureSummary(result)}`,
+              'warning',
+            );
+          }
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          notify(ctx, `Post-merge update failed (warning only): ${detail}`, 'warning');
+        }
+      }
 
       try {
-        const result = await runCommand({
-          command: POST_MERGE_UPDATE_COMMAND,
-          cwd: pendingRoot,
-          timeout: POST_MERGE_UPDATE_TIMEOUT_MS,
-        });
-
-        if (result.code === 0 && !result.killed) {
-          notify(ctx, `Post-merge update completed: ${POST_MERGE_UPDATE_COMMAND}`, 'info');
-        } else {
-          notify(
-            ctx,
-            `Post-merge update failed (warning only): ${buildFailureSummary(result)}`,
-            'warning',
-          );
+        if (shouldRunUpdate) {
+          // Best-effort main-checkout fast-forward (#1596): the dev-loop merges remotely
+          // but never fast-forwarded the main checkout's local main, so read-only gate
+          // scripts ran stale code. Never throw out of onAgentEnd; reset() must still run.
+          await fastForwardMainCheckout(runCommand, pendingRoot, ctx).catch((error) => {
+            const detail = error instanceof Error ? error.message : String(error);
+            notify(ctx, `Post-merge main-checkout fast-forward skipped (warning only): ${detail}`, 'warning');
+          });
+          // Post-merge worktree removal (#1627): remove the merged branch's worktree from
+          // the main checkout, non-fatal (never throws out of onAgentEnd).
+          await removeMergedWorktree(runCommand, pendingRoot, state.pendingPrNumber, ctx).catch((error) => {
+            const detail = error instanceof Error ? error.message : String(error);
+            notify(ctx, `Post-merge worktree cleanup skipped (warning only): ${detail}`, 'warning');
+          });
         }
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        notify(ctx, `Post-merge update failed (warning only): ${detail}`, 'warning');
+        if (actionsRoot) {
+          // postMerge.actions (#1457): runs for the repo that merged regardless of
+          // slug, independently of the dev-loops-only update/FF/cleanup pipeline above.
+          await runPostMergeActionsForRepo(runCommand, actionsRoot, state.pendingPrNumber, ctx).catch((error) => {
+            const detail = error instanceof Error ? error.message : String(error);
+            notify(ctx, `Post-merge actions skipped (warning only): ${detail}`, 'warning');
+          });
+        }
       } finally {
-        // Best-effort main-checkout fast-forward (#1596): the dev-loop merges remotely
-        // but never fast-forwarded the main checkout's local main, so read-only gate
-        // scripts ran stale code. Never throw out of onAgentEnd; reset() must still run.
-        await fastForwardMainCheckout(runCommand, pendingRoot, ctx).catch((error) => {
-          const detail = error instanceof Error ? error.message : String(error);
-          notify(ctx, `Post-merge main-checkout fast-forward skipped (warning only): ${detail}`, 'warning');
-        });
-        // Post-merge worktree removal (#1627): remove the merged branch's worktree from
-        // the main checkout, non-fatal (never throws out of onAgentEnd).
-        await removeMergedWorktree(runCommand, pendingRoot, state.pendingPrNumber, ctx).catch((error) => {
-          const detail = error instanceof Error ? error.message : String(error);
-          notify(ctx, `Post-merge worktree cleanup skipped (warning only): ${detail}`, 'warning');
-        });
         reset();
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
     "./loop/reviewer-loop-state": "./src/loop/reviewer-loop-state.mjs",
     "./loop/run-context": "./src/loop/run-context.mjs",
     "./loop/run-inspection": "./src/loop/run-inspection.mjs",
+    "./loop/run-post-merge-actions": "./src/loop/run-post-merge-actions.mjs",
     "./loop/spike-exit-contract": "./src/loop/spike-exit-contract.mjs",
     "./loop/spike-intake-contract": "./src/loop/spike-intake-contract.mjs",
     "./loop/steering": "./src/loop/steering.mjs",

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -803,6 +803,48 @@ const UiReviewConfig = z.strictObject({
     .optional(),
 });
 
+// Default/ceiling bounds for a post-merge action's run/verify timing (#1457).
+// The default keeps a config-declared action from hanging a harness hook
+// forever when the author leaves timeoutMs unset; the ceiling caps how far a
+// config CAN push it — a config can only tighten these, never loosen past the
+// ceiling.
+export const POST_MERGE_ACTION_DEFAULT_TIMEOUT_MS = 120000;
+export const POST_MERGE_ACTION_TIMEOUT_CEILING_MS = 600000;
+export const POST_MERGE_VERIFY_DEFAULT_TIMEOUT_MS = 60000;
+export const POST_MERGE_VERIFY_TIMEOUT_CEILING_MS = 600000;
+export const POST_MERGE_VERIFY_DEFAULT_INTERVAL_MS = 2000;
+export const POST_MERGE_VERIFY_INTERVAL_CEILING_MS = 60000;
+
+/**
+ * One post-merge action (Stage: local consumer hook). `run` and `verify` are
+ * executed VERBATIM as the operator wrote them — same trust level as
+ * `uiReview.run.command` (this repo's own committed `.devloops`) — so callers
+ * must never build these strings by interpolating untrusted runtime data
+ * (PR titles, branch names, verify output) into them. `onlyIfChanged` is
+ * matched as DATA (plain substrings against changed file paths), never
+ * shelled out.
+ */
+const PostMergeActionConfig = z.strictObject({
+  name: z.string().trim().min(1),
+  run: z.string().trim().min(1),
+  onlyIfChanged: z.array(z.string().trim().min(1)).optional(),
+  verify: z.string().trim().min(1).optional(),
+  timeoutMs: z.number().int().min(1).max(POST_MERGE_ACTION_TIMEOUT_CEILING_MS).default(POST_MERGE_ACTION_DEFAULT_TIMEOUT_MS),
+  verifyTimeoutMs: z.number().int().min(1).max(POST_MERGE_VERIFY_TIMEOUT_CEILING_MS).default(POST_MERGE_VERIFY_DEFAULT_TIMEOUT_MS),
+  verifyIntervalMs: z.number().int().min(1).max(POST_MERGE_VERIFY_INTERVAL_CEILING_MS).default(POST_MERGE_VERIFY_DEFAULT_INTERVAL_MS),
+});
+
+/**
+ * `postMerge.actions`: consumer-declared local actions (sync checkout, restart
+ * a local service, smoke check) run sequentially, in declared order, after the
+ * dev-loop's merge succeeds. Mirrors `uiReview.run` as the config-shape,
+ * validation, and command-execution precedent. Absent (the default) means no
+ * action is declared — a repo without this family gets zero new hook commands.
+ */
+const PostMergeConfig = z.strictObject({
+  actions: z.array(PostMergeActionConfig).optional(),
+});
+
 /** Internal path whitelist for internal-only PR detection — flat array of regex strings */
 const InternalPatternsConfig = z.array(z.string().trim().min(1)).min(1);
 
@@ -856,6 +898,7 @@ export const DevLoopConfigSchema = z.strictObject({
   internalPathPatterns: InternalPatternsConfig.optional(),
   worktree: WorktreeConfig.optional(),
   uiReview: UiReviewConfig.optional(),
+  postMerge: PostMergeConfig.optional(),
 });
 
 // ============================================================================
@@ -931,6 +974,7 @@ export const FileConfigSchema = z.strictObject({
   internalPathPatterns: InternalPatternsConfig.describe("Regex whitelist for internal-only PR detection.").optional(),
   worktree: WorktreeConfig.partial().describe("Worktree provisioning: gitignored files/dirs copied or symlinked into fresh worktrees.").optional(),
   uiReview: UiReviewConfig.partial().describe("UI-review route recipes: per-project run/boot, dev-login, driven flows, and caps.").optional(),
+  postMerge: PostMergeConfig.partial().describe("Post-merge local hook actions (postMerge.actions): consumer-declared commands run sequentially, in order, after a merge succeeds — optionally scoped to changed-file substrings (onlyIfChanged) and polled for readiness (verify).").optional(),
   // 1.0 hard break (no dual-form): the deprecated `localPlanning` key (removed
   // behavior in #1088, tolerated-but-unread since) is dropped from the 1.0
   // schema entirely — an unknown key now fails closed like any other typo,
@@ -2871,6 +2915,35 @@ export function resolveUiReviewRunRecipe(config) {
     migrate,
     rowTeardown,
   };
+}
+
+/**
+ * Resolve `postMerge.actions` from the merged config into normalized, runner-ready
+ * action objects. `run`/`verify` are trimmed but otherwise passed through
+ * VERBATIM (never rebuilt by concatenation) — the runner executes them exactly
+ * as declared. Returns `[]` when `postMerge` is absent — a `.devloops` without
+ * this family produces zero actions (and so zero hook commands).
+ *
+ * @param {DevLoopConfig} config
+ * @returns {{ name: string, run: string, onlyIfChanged: string[]|null, verify: string|null,
+ *   timeoutMs: number, verifyTimeoutMs: number, verifyIntervalMs: number }[]}
+ */
+export function resolvePostMergeActions(config) {
+  const actions = config?.postMerge?.actions;
+  if (!Array.isArray(actions)) return [];
+  return actions
+    .filter((a) => a && typeof a.name === "string" && a.name.trim().length > 0 && typeof a.run === "string" && a.run.trim().length > 0)
+    .map((a) => ({
+      name: a.name.trim(),
+      run: a.run.trim(),
+      onlyIfChanged: Array.isArray(a.onlyIfChanged)
+        ? a.onlyIfChanged.filter((p) => typeof p === "string" && p.trim().length > 0).map((p) => p.trim())
+        : null,
+      verify: typeof a.verify === "string" && a.verify.trim().length > 0 ? a.verify.trim() : null,
+      timeoutMs: Number.isInteger(a.timeoutMs) ? a.timeoutMs : POST_MERGE_ACTION_DEFAULT_TIMEOUT_MS,
+      verifyTimeoutMs: Number.isInteger(a.verifyTimeoutMs) ? a.verifyTimeoutMs : POST_MERGE_VERIFY_DEFAULT_TIMEOUT_MS,
+      verifyIntervalMs: Number.isInteger(a.verifyIntervalMs) ? a.verifyIntervalMs : POST_MERGE_VERIFY_DEFAULT_INTERVAL_MS,
+    }));
 }
 
 /**

--- a/packages/core/src/loop/main-checkout-ff.mjs
+++ b/packages/core/src/loop/main-checkout-ff.mjs
@@ -95,3 +95,37 @@ export function buildWorktreeCleanupCommand(mainCheckout, prNumber) {
   // non-fatal with `|| true` — removal must never break a merge-completion flow.
   return `if [ -f ${script} ]; then node ${script} --repo-root ${quotedMain} --pr "${pr}"; fi || true`;
 }
+
+/**
+ * Overall timeout (ms) for the post-merge actions runner invocation. Generous:
+ * the runner itself bounds each declared action by its own timeoutMs/verify
+ * budget (each individually capped at the config-schema ceiling), and this is
+ * only the outer harness-hook guard against a runner that never returns.
+ */
+export const POST_MERGE_ACTIONS_TIMEOUT_MS = 900_000;
+
+/**
+ * Build the best-effort `postMerge.actions` runner command (#1457): the shared,
+ * dependency-free command string both harness hooks (Pi `post-merge-update`,
+ * Claude `post-tool-use-merge`) run after a successful merge, for the repo that
+ * merged. Existence-guarded (a checkout without the runner script is a silent
+ * no-op) and non-fatal (`|| true` — a runner failure must never break a
+ * merge-completion flow; the runner itself reports per-action failures in its
+ * own JSON result). `mainCheckout` and the script path are POSIX
+ * single-quoted; `prNumber` (when a valid positive integer) is passed as a
+ * double-quoted `--pr` argument — never interpolated into `run`/`verify`
+ * command strings, which the runner executes verbatim from the repo's own
+ * `.devloops`.
+ *
+ * @param {string} mainCheckout - Absolute path to the main (primary) git checkout.
+ * @param {string | number | undefined} [prNumber] - Merged PR number, when known.
+ * @returns {string} the runner command (always non-empty; a missing PR number
+ *   just omits `--pr`, since `onlyIfChanged` scoping bypasses cleanly without one).
+ */
+export function buildPostMergeActionsCommand(mainCheckout, prNumber) {
+  const quotedMain = shellQuotePath(mainCheckout);
+  const script = shellQuotePath(path.join(mainCheckout, "scripts", "loop", "run-post-merge-actions.mjs"));
+  const pr = String(prNumber ?? "").trim();
+  const prArg = /^[0-9]+$/u.test(pr) ? ` --pr "${pr}"` : "";
+  return `if [ -f ${script} ]; then node ${script} --repo-root ${quotedMain}${prArg}; fi || true`;
+}

--- a/packages/core/src/loop/run-post-merge-actions.mjs
+++ b/packages/core/src/loop/run-post-merge-actions.mjs
@@ -1,0 +1,145 @@
+/**
+ * Post-merge actions runner (config family: `postMerge.actions`, #1457).
+ *
+ * Runs a repo's declared `postMerge.actions` sequentially, in declared order,
+ * after the dev-loop's merge succeeds — sync a checkout, restart a local
+ * service, run a smoke check. Mirrors the `uiReview.run` recipe's shape and
+ * execution precedent (`packages/core/src/loop/ui-review-provision.mjs`).
+ *
+ * SECURITY: `action.run` / `action.verify` are executed VERBATIM as the
+ * operator declared them in the repo's own committed `.devloops` (same trust
+ * level as `uiReview.run.command`) — this module never builds a command string
+ * by concatenating runtime data (changed-file paths, verify output) into it.
+ * `onlyIfChanged` scoping matches changed-file paths as DATA (plain substring
+ * compare), never by shelling them out. Every `run`/`verify` invocation is
+ * bounded by its own timeout; `verify` polling is bounded by `verifyTimeoutMs`.
+ *
+ * Pure orchestration: the shell-out (`exec`) and clock (`now`/`delay`) are
+ * injected so this module is fully deterministic under test. The CLI wires the
+ * real seams (scripts/loop/run-post-merge-actions.mjs).
+ */
+
+/**
+ * True when at least one changed path contains at least one `onlyIfChanged`
+ * pattern (plain substring match — never a shell-out, never a regex).
+ */
+function matchesOnlyIfChanged(patterns, changedPaths) {
+  return patterns.some((pattern) => changedPaths.some((changedPath) => changedPath.includes(pattern)));
+}
+
+/**
+ * Decide whether `action` runs. Returns a skip-reason string, or `null` to run
+ * it. `changedPaths === null` means the changed-file list could not be
+ * resolved (no PR number, `gh pr diff` failure): AC5 requires an
+ * `onlyIfChanged` action to still run in that case (never silently skipped),
+ * so the bypass is a run, not a skip.
+ */
+function decideSkip(action, changedPaths) {
+  if (!Array.isArray(action.onlyIfChanged) || action.onlyIfChanged.length === 0) return null;
+  if (changedPaths === null) return null; // AC5: scoping unresolved — run unscoped
+  if (matchesOnlyIfChanged(action.onlyIfChanged, changedPaths)) return null;
+  return `no changed file matched onlyIfChanged (${action.onlyIfChanged.join(", ")})`;
+}
+
+/** Run `command` bounded by `timeoutMs` via the injected `exec` seam. */
+async function execBounded(exec, command, cwd, timeoutMs) {
+  let result;
+  try {
+    result = await exec(command, { cwd, timeoutMs });
+  } catch (err) {
+    return { ok: false, detail: (err && err.message) || String(err) };
+  }
+  if (result?.killed) return { ok: false, detail: `timed out after ${timeoutMs}ms` };
+  if (result?.code !== 0) {
+    const stderr = typeof result?.stderr === "string" ? result.stderr.trim() : "";
+    return { ok: false, detail: `exit code ${result?.code}${stderr ? `: ${stderr}` : ""}` };
+  }
+  return { ok: true, detail: null };
+}
+
+/**
+ * Poll `verifyCommand` (bounded per-attempt by the remaining budget) until it
+ * exits 0 or `verifyTimeoutMs` elapses. Mirrors the readiness poll in
+ * `ui-review-provision.mjs`'s `provisionAndBoot` (never a fixed sleep).
+ */
+async function pollVerify(exec, verifyCommand, cwd, verifyTimeoutMs, verifyIntervalMs, { delay, now }) {
+  const deadline = now() + verifyTimeoutMs;
+  let lastDetail = "verify never ran";
+  while (now() <= deadline) {
+    const attemptBudget = Math.max(1, deadline - now());
+    let result;
+    try {
+      result = await exec(verifyCommand, { cwd, timeoutMs: attemptBudget });
+    } catch (err) {
+      result = { code: 1, killed: false, stdout: "", stderr: (err && err.message) || String(err) };
+    }
+    if (!result?.killed && result?.code === 0) return { ok: true, detail: null };
+    lastDetail = result?.killed ? "verify command timed out" : `exit code ${result?.code}`;
+    if (now() + verifyIntervalMs > deadline) break; // would overshoot the deadline
+    await delay(verifyIntervalMs);
+  }
+  return { ok: false, detail: `verify exhausted after ${verifyTimeoutMs}ms (${lastDetail})` };
+}
+
+/**
+ * Run every declared action sequentially, in order, with cwd set to `cwd`
+ * (the resolved main checkout).
+ *
+ * @param {object} input
+ * @param {{name:string,run:string,onlyIfChanged:string[]|null,verify:string|null,
+ *   timeoutMs:number,verifyTimeoutMs:number,verifyIntervalMs:number}[]} input.actions
+ * @param {string[]|null} input.changedPaths - Changed file paths of the merged
+ *   PR, or `null` when unresolved (AC5 bypass).
+ * @param {string} [input.changedPathsUnavailableReason] - Why `changedPaths` is
+ *   `null` (e.g. "no PR number", "gh pr diff failed: ..."), surfaced in the
+ *   bypass warning so the AC5 "states why scoping was bypassed" reads clearly.
+ * @param {string} input.cwd - Absolute path to the main checkout.
+ * @param {object} seams
+ * @param {(command:string, opts:{cwd:string,timeoutMs:number})=>Promise<{code:number|null,killed:boolean,stdout:string,stderr:string}>} seams.exec
+ * @param {(ms:number)=>Promise<void>} [seams.delay]
+ * @param {()=>number} [seams.now]
+ * @param {(msg:string)=>void} [seams.log]
+ * @returns {Promise<{ok:boolean, results:{name:string,status:"ok"|"skipped"|"failed",detail:string|null}[]}>}
+ */
+export async function runPostMergeActions(
+  { actions = [], changedPaths = null, changedPathsUnavailableReason = "unknown reason", cwd },
+  { exec, delay = (ms) => new Promise((r) => setTimeout(r, ms)), now = () => Date.now(), log = () => {} } = {},
+) {
+  if (changedPaths === null && actions.some((a) => Array.isArray(a.onlyIfChanged) && a.onlyIfChanged.length > 0)) {
+    log(`WARNING: changed-file list unavailable (${changedPathsUnavailableReason}) — onlyIfChanged scoping bypassed (affected actions run unscoped)`);
+  }
+
+  const results = [];
+  for (const action of actions) {
+    const skipReason = decideSkip(action, changedPaths);
+    if (skipReason) {
+      log(`skip ${action.name}: ${skipReason}`);
+      results.push({ name: action.name, status: "skipped", detail: skipReason });
+      continue;
+    }
+
+    log(`run ${action.name}: ${action.run}`);
+    const runResult = await execBounded(exec, action.run, cwd, action.timeoutMs);
+    if (!runResult.ok) {
+      const detail = `run failed: ${runResult.detail}`;
+      log(`FAILED ${action.name}: ${detail}`);
+      results.push({ name: action.name, status: "failed", detail });
+      continue;
+    }
+
+    if (action.verify) {
+      log(`verify ${action.name}: ${action.verify}`);
+      const verifyResult = await pollVerify(exec, action.verify, cwd, action.verifyTimeoutMs, action.verifyIntervalMs, { delay, now });
+      if (!verifyResult.ok) {
+        log(`FAILED ${action.name}: ${verifyResult.detail}`);
+        results.push({ name: action.name, status: "failed", detail: verifyResult.detail });
+        continue;
+      }
+    }
+
+    log(`ok ${action.name}`);
+    results.push({ name: action.name, status: "ok", detail: null });
+  }
+
+  return { ok: results.every((r) => r.status !== "failed"), results };
+}

--- a/packages/core/src/loop/run-post-merge-actions.mjs
+++ b/packages/core/src/loop/run-post-merge-actions.mjs
@@ -74,7 +74,10 @@ async function pollVerify(exec, verifyCommand, cwd, verifyTimeoutMs, verifyInter
       result = { code: 1, killed: false, stdout: "", stderr: (err && err.message) || String(err) };
     }
     if (!result?.killed && result?.code === 0) return { ok: true, detail: null };
-    lastDetail = result?.killed ? "verify command timed out" : `exit code ${result?.code}`;
+    const verifyStderr = typeof result?.stderr === "string" ? result.stderr.trim() : "";
+    lastDetail = result?.killed
+      ? "verify command timed out"
+      : `exit code ${result?.code}${verifyStderr ? `: ${verifyStderr}` : ""}`;
     if (now() + verifyIntervalMs > deadline) break; // would overshoot the deadline
     await delay(verifyIntervalMs);
   }

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -50,6 +50,7 @@ import {
   resolveBaseBranch,
   resolveTrackerProvider,
   resolveTrackerBoard,
+  resolvePostMergeActions,
 } from "../src/config/config.mjs";
 // #1592: a few fixtures below deliberately keep pre-rename severity spellings
 // ("must-fix"/"worth-fixing-now"/"nice-to-have") as INPUT — this is
@@ -543,6 +544,107 @@ describe("schema validation", () => {
       version: 1,
       uiReview: { serverLogExceptionPattern: "[" },
     }).success);
+  });
+
+  // postMerge.actions (#1457): a repo's local post-merge hook actions.
+  test("S36b: postMerge.actions with only name+run parses, applying default timeouts", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "sync-checkout", run: "git pull" }] },
+    });
+    assert.ok(result.success);
+    const [action] = result.data.postMerge.actions;
+    assert.equal(action.name, "sync-checkout");
+    assert.equal(action.run, "git pull");
+    assert.equal(action.onlyIfChanged, undefined);
+    assert.equal(action.verify, undefined);
+    assert.equal(action.timeoutMs, 120000);
+    assert.equal(action.verifyTimeoutMs, 60000);
+    assert.equal(action.verifyIntervalMs, 2000);
+  });
+
+  test("S36c: postMerge.actions with the full optional shape parses", () => {
+    const result = DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: {
+        actions: [
+          {
+            name: "restart-service",
+            run: "make restart",
+            onlyIfChanged: ["src/", "config/"],
+            verify: "curl -sf http://localhost:3000/health",
+            timeoutMs: 30000,
+            verifyTimeoutMs: 15000,
+            verifyIntervalMs: 1000,
+          },
+        ],
+      },
+    });
+    assert.ok(result.success);
+  });
+
+  test("S36d: postMerge.actions rejects an action missing name or run", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ run: "git pull" }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "sync-checkout" }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "", run: "git pull" }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "sync-checkout", run: "" }] },
+    }).success);
+  });
+
+  test("S36e: postMerge.actions rejects an empty-string onlyIfChanged pattern", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "sync-checkout", run: "git pull", onlyIfChanged: [""] }] },
+    }).success);
+  });
+
+  test("S36f: postMerge.actions rejects a timeoutMs/verifyTimeoutMs/verifyIntervalMs past the ceiling or non-positive", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "a", run: "r", timeoutMs: 600001 }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "a", run: "r", verifyTimeoutMs: 0 }] },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "a", run: "r", verifyIntervalMs: 60001 }] },
+    }).success);
+  });
+
+  test("S36g: an unknown key inside postMerge or a postMerge action is rejected", () => {
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [], unknownKey: true },
+    }).success);
+    assert.ok(!DevLoopConfigSchema.safeParse({
+      version: 1,
+      postMerge: { actions: [{ name: "a", run: "r", unknownKey: true }] },
+    }).success);
+  });
+
+  test("S36h: a config without postMerge still parses exactly as before", () => {
+    const result = DevLoopConfigSchema.safeParse({ version: 1 });
+    assert.ok(result.success);
+    assert.equal(result.data.postMerge, undefined);
+  });
+
+  test("S36i: FileConfigSchema accepts postMerge.actions the same as DevLoopConfigSchema", () => {
+    const config = { version: 1, postMerge: { actions: [{ name: "sync-checkout", run: "git pull" }] } };
+    assert.ok(FileConfigSchema.safeParse(config).success);
+    assert.ok(!FileConfigSchema.safeParse({ version: 1, postMerge: { actions: [{ run: "git pull" }] } }).success);
   });
 
   // gates.size (fail-closed PR size/tier budget, Phase 1 — check-size-budget.mjs's
@@ -5580,4 +5682,81 @@ test("gates.fanout.sequential: a .devloops merging it loads cleanly through the 
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }
+});
+
+describe("resolvePostMergeActions (#1457)", () => {
+  test("absent postMerge resolves to an empty array", () => {
+    assert.deepEqual(resolvePostMergeActions({ version: 1 }), []);
+    assert.deepEqual(resolvePostMergeActions(undefined), []);
+  });
+
+  test("resolves a full action verbatim, applying defaults for absent optional timing fields", () => {
+    const config = {
+      version: 1,
+      postMerge: { actions: [{ name: "  sync-checkout  ", run: "  git pull  " }] },
+    };
+    assert.deepEqual(resolvePostMergeActions(config), [
+      {
+        name: "sync-checkout",
+        run: "git pull",
+        onlyIfChanged: null,
+        verify: null,
+        timeoutMs: 120000,
+        verifyTimeoutMs: 60000,
+        verifyIntervalMs: 2000,
+      },
+    ]);
+  });
+
+  test("passes through onlyIfChanged, verify, and explicit timeouts unchanged", () => {
+    const config = {
+      version: 1,
+      postMerge: {
+        actions: [
+          {
+            name: "restart-service",
+            run: "make restart",
+            onlyIfChanged: ["src/", "config/"],
+            verify: "curl -sf http://localhost:3000/health",
+            timeoutMs: 30000,
+            verifyTimeoutMs: 15000,
+            verifyIntervalMs: 1000,
+          },
+        ],
+      },
+    };
+    assert.deepEqual(resolvePostMergeActions(config), [
+      {
+        name: "restart-service",
+        run: "make restart",
+        onlyIfChanged: ["src/", "config/"],
+        verify: "curl -sf http://localhost:3000/health",
+        timeoutMs: 30000,
+        verifyTimeoutMs: 15000,
+        verifyIntervalMs: 1000,
+      },
+    ]);
+  });
+
+  test("preserves declared order across multiple actions", () => {
+    const config = {
+      version: 1,
+      postMerge: {
+        actions: [
+          { name: "a", run: "run-a" },
+          { name: "b", run: "run-b" },
+          { name: "c", run: "run-c" },
+        ],
+      },
+    };
+    assert.deepEqual(resolvePostMergeActions(config).map((a) => a.name), ["a", "b", "c"]);
+  });
+
+  test("filters out a malformed action (blank name/run) rather than throwing", () => {
+    const config = {
+      version: 1,
+      postMerge: { actions: [{ name: "", run: "git pull" }, { name: "ok", run: "git pull" }] },
+    };
+    assert.deepEqual(resolvePostMergeActions(config).map((a) => a.name), ["ok"]);
+  });
 });

--- a/schemas/dev-loop-config.schema.json
+++ b/schemas/dev-loop-config.schema.json
@@ -1440,6 +1440,63 @@
       },
       "additionalProperties": false,
       "description": "UI-review route recipes: per-project run/boot, dev-login, driven flows, and caps."
+    },
+    "postMerge": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "run": {
+                "type": "string",
+                "minLength": 1
+              },
+              "onlyIfChanged": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "verify": {
+                "type": "string",
+                "minLength": 1
+              },
+              "timeoutMs": {
+                "default": 120000,
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 600000
+              },
+              "verifyTimeoutMs": {
+                "default": 60000,
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 600000
+              },
+              "verifyIntervalMs": {
+                "default": 2000,
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 60000
+              }
+            },
+            "required": [
+              "name",
+              "run"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "description": "Post-merge local hook actions (postMerge.actions): consumer-declared commands run sequentially, in order, after a merge succeeds — optionally scoped to changed-file substrings (onlyIfChanged) and polled for readiness (verify)."
     }
   },
   "required": [

--- a/scripts/loop/run-post-merge-actions.mjs
+++ b/scripts/loop/run-post-merge-actions.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for the `postMerge.actions` runner (#1457).
+ *
+ * Runs a repo's declared `postMerge.actions` (`.devloops`) sequentially, in
+ * declared order, with cwd set to the resolved MAIN checkout — never the
+ * ambient process cwd. `--repo-root` is only a starting point: this CLI
+ * re-derives the actual main checkout via `git worktree list` +
+ * `parseMainWorktreePath` (the same resolver `ui-review-provision.mjs` and
+ * both harness post-merge hooks use), so an invocation from inside a worktree
+ * still lands on the checkout the config/actions apply to.
+ *
+ * Changed-file scoping (`onlyIfChanged`) resolves the merged PR's changed
+ * paths via `gh pr diff <pr> --name-only` (the sanctioned path for this
+ * lookup) when `--pr` is given; a missing PR number or a `gh pr diff` failure
+ * bypasses scoping (every `onlyIfChanged` action runs unscoped) with a stated
+ * reason, never a silent skip (AC5).
+ *
+ * SECURITY: `run`/`verify` come from the repo's own committed `.devloops`
+ * (same trust level as `uiReview.run.command`) and are executed VERBATIM —
+ * this CLI never interpolates PR titles, branch names, changed-file paths, or
+ * verify output into a command string.
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { parseArgs } from "node:util";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { requireTokenValue } from "../_cli-primitives.mjs";
+import { loadDevLoopConfig, resolvePostMergeActions } from "@dev-loops/core/config";
+import { runPostMergeActions } from "@dev-loops/core/loop/run-post-merge-actions";
+import { parseMainWorktreePath } from "@dev-loops/core/loop/worktree-guard";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+
+const USAGE = `Usage:
+  run-post-merge-actions.mjs --repo-root <p> [--pr <n>]
+Run a repo's declared postMerge.actions (.devloops) sequentially, in order,
+after the dev-loop's merge succeeds.
+Required:
+  --repo-root <p>   Absolute path to a checkout in the repo (the main checkout
+                     is re-derived via \`git worktree list\`).
+Optional:
+  --pr <n>          Merged PR number; resolves onlyIfChanged scoping via
+                     \`gh pr diff --name-only\`. Absent scoping bypasses
+                     onlyIfChanged actions (they run unscoped) with a warning.
+  -h, --help        Show this help.
+Output (stdout, JSON):
+  { "ok": bool, "results": [{ "name", "status": "ok"|"skipped"|"failed", "detail" }] }
+Exit code: non-zero when any action failed; zero when all ran or were skipped cleanly.
+
+${JQ_OUTPUT_USAGE}`.trim();
+
+const parseError = buildParseError(USAGE);
+
+function parsePositiveInt(value, flag) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) throw parseError(`${flag} must be a positive integer`);
+  return n;
+}
+
+export function parseRunPostMergeActionsCliArgs(argv) {
+  const options = { help: false, repoRoot: undefined, pr: undefined };
+  const { tokens } = parseArgs({
+    args: [...argv],
+    options: {
+      help: { type: "boolean", short: "h" },
+      "repo-root": { type: "string" },
+      pr: { type: "string" },
+      ...JQ_OUTPUT_PARSE_OPTIONS,
+    },
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+  });
+  for (const token of tokens) {
+    if (token.kind === "positional") throw parseError(`Unknown argument: ${token.value}`);
+    if (token.kind !== "option") continue;
+    if (token.name === "help") {
+      options.help = true;
+      return options;
+    }
+    if (token.name === "repo-root") {
+      options.repoRoot = requireTokenValue(token, parseError, { flagPattern: /^-/u });
+      continue;
+    }
+    if (token.name === "pr") {
+      options.pr = parsePositiveInt(requireTokenValue(token, parseError, { flagPattern: /^-/u }), "--pr");
+      continue;
+    }
+    if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
+    throw parseError(`Unknown argument: ${token.rawName}`);
+  }
+  if (options.help) return options;
+  if (!options.repoRoot) throw parseError("Missing required --repo-root");
+  return options;
+}
+
+/** Resolve the main checkout from a starting checkout path — never trust cwd. */
+function resolveMainCheckout(repoRoot) {
+  try {
+    const listing = execFileSync("git", ["worktree", "list"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    return parseMainWorktreePath(listing) ?? repoRoot;
+  } catch {
+    return repoRoot;
+  }
+}
+
+const GH_PR_DIFF_TIMEOUT_MS = 30_000;
+
+/** Resolve the merged PR's changed file paths via `gh pr diff --name-only`, bounded. */
+function resolveChangedPaths(cwd, pr) {
+  if (pr === undefined) return { changedPaths: null, reason: "no PR number" };
+  try {
+    const out = execFileSync("gh", ["pr", "diff", String(pr), "--name-only"], {
+      cwd,
+      encoding: "utf8",
+      timeout: GH_PR_DIFF_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const changedPaths = out.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+    return { changedPaths, reason: null };
+  } catch (err) {
+    const detail = (err.stderr ?? err.message ?? "gh pr diff failed").toString().trim();
+    return { changedPaths: null, reason: `gh pr diff failed: ${detail}` };
+  }
+}
+
+/** Run `command` in `cwd`, bounded by `timeoutMs`. Never throws. */
+function exec(command, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    const child = spawn(command, { cwd, shell: true, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let killed = false;
+    const timer = setTimeout(() => {
+      killed = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout?.on("data", (d) => { stdout += d; });
+    child.stderr?.on("data", (d) => { stderr += d; });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, killed, stdout, stderr });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ code: 1, killed, stdout, stderr: err.message ?? String(err) });
+    });
+  });
+}
+
+export async function runCli(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr } = {}) {
+  const options = parseRunPostMergeActionsCliArgs(argv);
+  if (options.help) {
+    stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  const mainCheckout = resolveMainCheckout(options.repoRoot);
+  const { config } = await loadDevLoopConfig({ repoRoot: mainCheckout });
+  const actions = resolvePostMergeActions(config);
+
+  // No postMerge.actions declared: stay completely silent (no stdout, exit 0) so a
+  // repo without this family produces zero observable output from the harness hooks
+  // that shell out to this script (AC: zero new commands/log lines when unconfigured).
+  if (actions.length === 0) return;
+
+  const { changedPaths, reason } = resolveChangedPaths(mainCheckout, options.pr);
+  const result = await runPostMergeActions(
+    { actions, changedPaths, changedPathsUnavailableReason: reason ?? "unknown reason", cwd: mainCheckout },
+    { exec, log: (msg) => stderr.write(`[run-post-merge-actions] ${msg}\n`) },
+  );
+  process.exitCode = emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${formatCliError(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/contracts/claude-merge-hook-fast-forward.test.mjs
+++ b/test/contracts/claude-merge-hook-fast-forward.test.mjs
@@ -180,3 +180,89 @@ test("post-tool-use-merge hook runs post-merge worktree cleanup for the merged P
     await rm(tmp, { recursive: true, force: true });
   }
 });
+
+test("post-tool-use-merge hook invokes the postMerge.actions runner for the merged PR when it exists (#1457)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-post-merge-actions-hook-"));
+  const originDir = path.join(tmp, "origin");
+  const mainDir = path.join(tmp, "main");
+
+  try {
+    git(tmp, ["init", "-q", originDir]);
+    git(originDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+    git(originDir, ["config", "user.email", "test@example.com"]);
+    git(originDir, ["config", "user.name", "Test"]);
+    git(originDir, ["config", "commit.gpgsign", "false"]);
+    git(originDir, ["commit", "--allow-empty", "-q", "-m", "A"]);
+    git(originDir, ["commit", "--allow-empty", "-q", "-m", "B"]);
+    git(tmp, ["clone", "-q", originDir, mainDir]);
+
+    // The runner script exists in this main checkout; the hook must invoke it, running
+    // from the main checkout, and print its stdout as its own stderr note.
+    const scriptPath = path.join(mainDir, "scripts", "loop", "run-post-merge-actions.mjs");
+    await mkdir(path.dirname(scriptPath), { recursive: true });
+    const runLog = path.join(tmp, "actions.log");
+    await writeFile(
+      scriptPath,
+      `import fs from "node:fs";const a=process.argv.slice(2);` +
+        `fs.writeFileSync(${JSON.stringify(runLog)}, a.join(" "));` +
+        `process.stdout.write(JSON.stringify({ok:true,results:[{name:"sync",status:"ok",detail:null}]}));\n`,
+      { mode: 0o755 },
+    );
+
+    const res = spawnSync("node", [hookScript], {
+      input: JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr merge 42 --squash --delete-branch" },
+        cwd: mainDir,
+      }),
+      encoding: "utf8",
+      env: { ...process.env },
+      cwd: mainDir,
+    });
+
+    assert.equal(res.status, 0, `hook must exit 0 (got ${res.status}, stderr: ${res.stderr})`);
+    // Mutation anchor: if the postMerge.actions block in post-tool-use-merge.mjs is
+    // reverted, the runner is never invoked and this assertion fails.
+    const argv = execFileSync("cat", [runLog], { encoding: "utf8" }).trim();
+    assert.ok(argv.includes("--repo-root"), `expected --repo-root, got: ${argv}`);
+    assert.ok(argv.includes(mainDir), `expected the main checkout path (${mainDir}), got: ${argv}`);
+    assert.ok(argv.includes("--pr 42"), `expected --pr 42, got: ${argv}`);
+    assert.match(res.stderr, /post-merge actions: /, "hook must relay the runner's stdout");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("post-tool-use-merge hook is a silent no-op for postMerge.actions when the runner script is absent (#1457)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-post-merge-actions-noop-"));
+  const originDir = path.join(tmp, "origin");
+  const mainDir = path.join(tmp, "main");
+
+  try {
+    git(tmp, ["init", "-q", originDir]);
+    git(originDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+    git(originDir, ["config", "user.email", "test@example.com"]);
+    git(originDir, ["config", "user.name", "Test"]);
+    git(originDir, ["config", "commit.gpgsign", "false"]);
+    git(originDir, ["commit", "--allow-empty", "-q", "-m", "A"]);
+    git(originDir, ["commit", "--allow-empty", "-q", "-m", "B"]);
+    git(tmp, ["clone", "-q", originDir, mainDir]);
+    // No scripts/loop/run-post-merge-actions.mjs in this checkout.
+
+    const res = spawnSync("node", [hookScript], {
+      input: JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr merge 42 --squash --delete-branch" },
+        cwd: mainDir,
+      }),
+      encoding: "utf8",
+      env: { ...process.env },
+      cwd: mainDir,
+    });
+
+    assert.equal(res.status, 0, `hook must exit 0 (got ${res.status}, stderr: ${res.stderr})`);
+    assert.doesNotMatch(res.stderr, /post-merge actions/, "a checkout without the runner script must produce zero new log lines");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/extension-post-merge-update.test.mjs
+++ b/test/extension-post-merge-update.test.mjs
@@ -15,7 +15,7 @@ import {
   extractRepoFlagFromGhPrReady,
   normalizeGitHubRepoSlug,
 } from "../extension/post-merge-update.ts";
-import { buildMainCheckoutFastForwardCommand, buildWorktreeCleanupCommand } from "../packages/core/src/loop/main-checkout-ff.mjs";
+import { buildMainCheckoutFastForwardCommand, buildWorktreeCleanupCommand, buildPostMergeActionsCommand } from "../packages/core/src/loop/main-checkout-ff.mjs";
 
 function createUiCalls() {
   const notifications = [];
@@ -102,6 +102,8 @@ test("successful bash-tool gh pr merge queues and flushes one post-merge update 
     { command: buildMainCheckoutFastForwardCommand("/repo"), cwd: "/repo" },
     { command: "git worktree list", cwd: "/repo" },
     { command: buildWorktreeCleanupCommand("/repo", 373), cwd: "/repo" },
+    { command: "git worktree list", cwd: "/repo" },
+    { command: buildPostMergeActionsCommand("/repo", 373), cwd: "/repo" },
   ]);
   assert.deepEqual(notifications, [
     { message: `Post-merge update running: ${POST_MERGE_UPDATE_COMMAND}`, level: "info" },
@@ -109,11 +111,12 @@ test("successful bash-tool gh pr merge queues and flushes one post-merge update 
     { message: `Post-merge main-checkout fast-forward running: ${buildMainCheckoutFastForwardCommand("/repo")}`, level: "info" },
     { message: "Post-merge main-checkout fast-forward completed: local main advanced to origin/main", level: "info" },
     { message: "Post-merge worktree cleanup running for PR #373", level: "info" },
+    { message: "Post-merge actions: updated", level: "info" },
   ]);
   assert.equal(hook.getState().pendingPostMergeUpdate, false);
 
   await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
-  assert.equal(calls.length, 5);
+  assert.equal(calls.length, 7);
 });
 
 test("successful user_bash git merge queues and flushes one update", async () => {
@@ -147,6 +150,8 @@ test("successful user_bash git merge queues and flushes one update", async () =>
     { command: POST_MERGE_UPDATE_COMMAND, cwd: "/repo" },
     { command: "git worktree list", cwd: "/repo" },
     { command: buildMainCheckoutFastForwardCommand("/repo"), cwd: "/repo" },
+    { command: "git worktree list", cwd: "/repo" },
+    { command: buildPostMergeActionsCommand("/repo", undefined), cwd: "/repo" },
   ]);
 });
 
@@ -200,6 +205,75 @@ test("non-merge commands and non-target repos never trigger the update", async (
   assert.equal(result, undefined);
   assert.deepEqual(calls, []);
   assert.equal(hook.getState().pendingPostMergeUpdate, false);
+});
+
+// --- postMerge.actions: runs for the repo that merged, regardless of slug (#1457) ---
+
+test("postMerge.actions runs for a consumer repo via the agent bash tool, while pi-update stays gated to dev-loops", async () => {
+  const calls = [];
+  const runnerResult = { ok: true, results: [{ name: "sync-checkout", status: "ok", detail: null }] };
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: "other/repo" }),
+    runCommand: async ({ command, cwd }) => {
+      calls.push({ command, cwd });
+      if (command === "git worktree list") {
+        return { code: 0, stdout: "not a worktree listing", stderr: "", killed: false };
+      }
+      return { code: 0, stdout: JSON.stringify(runnerResult), stderr: "", killed: false };
+    },
+  });
+  const { ctx, notifications } = createUiCalls();
+
+  await hook.onToolResult({
+    toolName: "bash",
+    input: { command: "gh pr merge 55 --squash --delete-branch" },
+    isError: false,
+  }, ctx);
+
+  assert.equal(hook.getState().pendingPostMergeUpdate, false, "pi-update stays gated to the dev-loops repo");
+  assert.equal(hook.getState().pendingPostMergeActionsRoot, "/repo");
+
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(calls, [
+    { command: "git worktree list", cwd: "/repo" },
+    { command: buildPostMergeActionsCommand("/repo", 55), cwd: "/repo" },
+  ]);
+  assert.deepEqual(notifications, [
+    { message: `Post-merge actions: ${JSON.stringify(runnerResult)}`, level: "info" },
+  ]);
+  assert.equal(hook.getState().pendingPostMergeActionsRoot, null);
+});
+
+test("postMerge.actions stays silent when the runner produces no output (no postMerge.actions declared)", async () => {
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: "other/repo" }),
+    runCommand: async () => ({ code: 0, stdout: "", stderr: "", killed: false }),
+  });
+  const { ctx, notifications } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 55" }, isError: false }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(notifications, []);
+});
+
+test("postMerge.actions runner failure is a warning, never throws out of onAgentEnd", async () => {
+  const hook = createPostMergeUpdateHook({
+    resolveRepoContext: async (cwd) => ({ repoRoot: cwd, repoSlug: "other/repo" }),
+    runCommand: async ({ command }) => {
+      if (command === "git worktree list") return { code: 0, stdout: "", stderr: "", killed: false };
+      throw new Error("runner spawn failed");
+    },
+  });
+  const { ctx, notifications } = createUiCalls();
+
+  await hook.onToolResult({ toolName: "bash", input: { command: "gh pr merge 55" }, isError: false }, ctx);
+  await hook.onAgentEnd({ type: "agent_end", messages: [] }, ctx);
+
+  assert.deepEqual(notifications, [
+    { message: "Post-merge actions skipped (warning only): runner spawn failed", level: "warning" },
+  ]);
 });
 
 
@@ -265,6 +339,8 @@ test("multiple merge signals in one turn still run only one update", async () =>
     { command: buildMainCheckoutFastForwardCommand("/repo"), cwd: "/repo" },
     { command: "git worktree list", cwd: "/repo" },
     { command: buildWorktreeCleanupCommand("/repo", 373), cwd: "/repo" },
+    { command: "git worktree list", cwd: "/repo" },
+    { command: buildPostMergeActionsCommand("/repo", 373), cwd: "/repo" },
   ]);
 });
 

--- a/test/loop/run-post-merge-actions-cli.test.mjs
+++ b/test/loop/run-post-merge-actions-cli.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile, chmod, realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseRunPostMergeActionsCliArgs } from "../../scripts/loop/run-post-merge-actions.mjs";
+
+const scriptPath = path.resolve(fileURLToPath(new URL("../../scripts/loop/run-post-merge-actions.mjs", import.meta.url)));
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function makeMainCheckout(tmp) {
+  const originDir = path.join(tmp, "origin");
+  const mainDir = path.join(tmp, "main");
+  git(tmp, ["init", "-q", originDir]);
+  git(originDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+  git(originDir, ["config", "user.email", "test@example.com"]);
+  git(originDir, ["config", "user.name", "Test"]);
+  git(originDir, ["config", "commit.gpgsign", "false"]);
+  git(originDir, ["commit", "--allow-empty", "-q", "-m", "A"]);
+  git(tmp, ["clone", "-q", originDir, mainDir]);
+  return mainDir;
+}
+
+async function writeDevloops(repoRoot, yaml) {
+  await writeFile(path.join(repoRoot, ".devloops"), yaml);
+}
+
+test("parseRunPostMergeActionsCliArgs: requires --repo-root", () => {
+  assert.throws(() => parseRunPostMergeActionsCliArgs([]), /repo-root/);
+});
+
+test("parseRunPostMergeActionsCliArgs: parses --repo-root and --pr", () => {
+  const options = parseRunPostMergeActionsCliArgs(["--repo-root", "/r", "--pr", "42"]);
+  assert.equal(options.repoRoot, "/r");
+  assert.equal(options.pr, 42);
+});
+
+test("run-post-merge-actions CLI: a repo with no postMerge.actions is a silent no-op (exit 0, no stdout)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pma-cli-"));
+  try {
+    const mainDir = await makeMainCheckout(tmp);
+    await writeDevloops(mainDir, "version: 1\n");
+
+    const res = execFileSync("node", [scriptPath, "--repo-root", mainDir], { cwd: mainDir, encoding: "utf8" });
+    assert.equal(res, "", "no postMerge.actions declared must produce zero stdout");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run-post-merge-actions CLI: runs a declared action and exits 0 on success", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pma-cli-"));
+  try {
+    const mainDir = await makeMainCheckout(tmp);
+    const marker = path.join(tmp, "ran.marker");
+    const touchScript = path.join(tmp, "touch.mjs");
+    await writeFile(touchScript, `import fs from "node:fs";fs.writeFileSync(${JSON.stringify(marker)}, "ran");\n`);
+    await writeDevloops(
+      mainDir,
+      ["version: 1", "postMerge:", "  actions:", "    - name: touch-marker", `      run: node ${touchScript}`].join("\n"),
+    );
+
+    const res = execFileSync("node", [scriptPath, "--repo-root", mainDir], { cwd: mainDir, encoding: "utf8" });
+    const parsed = JSON.parse(res);
+    assert.equal(parsed.ok, true);
+    assert.deepEqual(parsed.results, [{ name: "touch-marker", status: "ok", detail: null }]);
+    assert.equal(execFileSync("cat", [marker], { encoding: "utf8" }), "ran");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run-post-merge-actions CLI: exits non-zero when an action fails", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pma-cli-"));
+  try {
+    const mainDir = await makeMainCheckout(tmp);
+    const boomScript = path.join(tmp, "boom.mjs");
+    await writeFile(boomScript, "process.exit(1);\n");
+    await writeDevloops(
+      mainDir,
+      ["version: 1", "postMerge:", "  actions:", "    - name: boom", `      run: node ${boomScript}`].join("\n"),
+    );
+
+    let stdout = "";
+    try {
+      execFileSync("node", [scriptPath, "--repo-root", mainDir], { cwd: mainDir, encoding: "utf8" });
+      assert.fail("expected the CLI to exit non-zero");
+    } catch (error) {
+      stdout = error.stdout;
+      assert.equal(error.status, 1);
+    }
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.results[0].status, "failed");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run-post-merge-actions CLI: re-derives the main checkout from a worktree path (never trusts --repo-root blindly)", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pma-cli-"));
+  try {
+    const mainDir = await makeMainCheckout(tmp);
+    const wtDir = path.join(tmp, "wt");
+    git(mainDir, ["worktree", "add", "--detach", wtDir]);
+
+    const marker = path.join(tmp, "cwd.marker");
+    const recordCwdScript = path.join(tmp, "record-cwd.mjs");
+    await writeFile(recordCwdScript, `import fs from "node:fs";fs.writeFileSync(${JSON.stringify(marker)}, process.cwd());\n`);
+    // postMerge.actions is only declared in the MAIN checkout's .devloops (loaded from
+    // the resolved main checkout, not the worktree passed as --repo-root).
+    await writeDevloops(
+      mainDir,
+      ["version: 1", "postMerge:", "  actions:", "    - name: record-cwd", `      run: node ${recordCwdScript}`].join("\n"),
+    );
+
+    execFileSync("node", [scriptPath, "--repo-root", wtDir], { cwd: wtDir, encoding: "utf8" });
+    const recordedCwd = execFileSync("cat", [marker], { encoding: "utf8" });
+    assert.equal(recordedCwd, await realpath(mainDir), "the action must run with cwd set to the resolved main checkout, not the worktree");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run-post-merge-actions CLI: onlyIfChanged scoping via gh pr diff --name-only", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pma-cli-"));
+  try {
+    const mainDir = await makeMainCheckout(tmp);
+    const marker = path.join(tmp, "scoped.marker");
+    await writeDevloops(
+      mainDir,
+      [
+        "version: 1",
+        "postMerge:",
+        "  actions:",
+        "    - name: scoped",
+        `      run: node -e "require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')"`,
+        "      onlyIfChanged:",
+        "        - src/",
+      ].join("\n"),
+    );
+
+    // A `gh` stub on PATH answering `pr diff <n> --name-only` with a changed-file list
+    // that does NOT match the onlyIfChanged pattern.
+    const binDir = path.join(tmp, "bin");
+    await mkdir(binDir, { recursive: true });
+    const ghStub = path.join(binDir, "gh");
+    await writeFile(ghStub, "#!/usr/bin/env sh\necho README.md\necho docs/guide.md\n");
+    await chmod(ghStub, 0o755);
+
+    const res = execFileSync("node", [scriptPath, "--repo-root", mainDir, "--pr", "7"], {
+      cwd: mainDir,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    });
+    const parsed = JSON.parse(res);
+    assert.equal(parsed.results[0].status, "skipped");
+    await assert.rejects(async () => {
+      await import("node:fs/promises").then((fs) => fs.access(marker));
+    });
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/loop/run-post-merge-actions.test.mjs
+++ b/test/loop/run-post-merge-actions.test.mjs
@@ -185,10 +185,10 @@ describe("runPostMergeActions (#1457)", () => {
     assert.equal(result.results[0].status, "ok");
   });
 
-  test("verify: exhausting the verify timeout without a 0 exit fails the action", async () => {
+  test("verify: exhausting the verify timeout without a 0 exit fails the action and surfaces the verify stderr", async () => {
     const exec = async (command) => {
       if (command === "run-it") return { code: 0, killed: false, stdout: "", stderr: "" };
-      return { code: 1, killed: false, stdout: "", stderr: "" }; // verify never succeeds
+      return { code: 1, killed: false, stdout: "", stderr: "  curl: (7) connection refused\n" }; // verify never succeeds
     };
     const actions = [action({ name: "svc", run: "run-it", verify: "curl -f /health", verifyTimeoutMs: 3000, verifyIntervalMs: 1000 })];
 
@@ -196,6 +196,8 @@ describe("runPostMergeActions (#1457)", () => {
 
     assert.equal(result.results[0].status, "failed");
     assert.match(result.results[0].detail, /verify exhausted after 3000ms/);
+    // The actual verify failure reason (trimmed stderr) must be surfaced for debuggability.
+    assert.match(result.results[0].detail, /curl: \(7\) connection refused/);
     assert.equal(result.ok, false);
   });
 

--- a/test/loop/run-post-merge-actions.test.mjs
+++ b/test/loop/run-post-merge-actions.test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import { runPostMergeActions } from "@dev-loops/core/loop/run-post-merge-actions";
+
+function makeClock(start = 0) {
+  let t = start;
+  return {
+    now: () => t,
+    delay: async (ms) => {
+      t += ms;
+    },
+  };
+}
+
+function action(overrides = {}) {
+  return {
+    name: "action",
+    run: "run-command",
+    onlyIfChanged: null,
+    verify: null,
+    timeoutMs: 1000,
+    verifyTimeoutMs: 1000,
+    verifyIntervalMs: 100,
+    ...overrides,
+  };
+}
+
+describe("runPostMergeActions (#1457)", () => {
+  test("runs every action sequentially, in declared order", async () => {
+    const calls = [];
+    const exec = async (command) => {
+      calls.push(command);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "a", run: "run-a" }), action({ name: "b", run: "run-b" }), action({ name: "c", run: "run-c" })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.deepEqual(calls, ["run-a", "run-b", "run-c"]);
+    assert.deepEqual(result.results.map((r) => r.name), ["a", "b", "c"]);
+    assert.deepEqual(result.results.map((r) => r.status), ["ok", "ok", "ok"]);
+    assert.equal(result.ok, true);
+  });
+
+  test("cwd passed to exec is always the resolved main checkout, never re-derived per action", async () => {
+    const cwds = [];
+    const exec = async (command, { cwd }) => {
+      cwds.push(cwd);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "a" }), action({ name: "b" })];
+
+    await runPostMergeActions({ actions, changedPaths: null, cwd: "/main/checkout" }, { exec, ...makeClock() });
+
+    assert.deepEqual(cwds, ["/main/checkout", "/main/checkout"]);
+  });
+
+  test("onlyIfChanged: a matching substring runs the action", async () => {
+    const calls = [];
+    const exec = async (command) => {
+      calls.push(command);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "restart", run: "make restart", onlyIfChanged: ["src/"] })];
+
+    const result = await runPostMergeActions(
+      { actions, changedPaths: ["src/app.js", "README.md"], cwd: "/repo" },
+      { exec, ...makeClock() },
+    );
+
+    assert.deepEqual(calls, ["make restart"]);
+    assert.equal(result.results[0].status, "ok");
+  });
+
+  test("onlyIfChanged: no changed path matches — the action is skipped and the reason is recorded", async () => {
+    const calls = [];
+    const exec = async (command) => {
+      calls.push(command);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "restart", run: "make restart", onlyIfChanged: ["src/"] })];
+
+    const result = await runPostMergeActions(
+      { actions, changedPaths: ["README.md", "docs/guide.md"], cwd: "/repo" },
+      { exec, ...makeClock() },
+    );
+
+    assert.deepEqual(calls, [], "the run command must never execute for a skipped action");
+    assert.equal(result.results[0].status, "skipped");
+    assert.match(result.results[0].detail, /onlyIfChanged/);
+    assert.equal(result.ok, true, "a clean skip is not a failure");
+  });
+
+  test("onlyIfChanged: unresolved changed-file list bypasses scoping (runs unscoped) and logs why", async () => {
+    const calls = [];
+    const logs = [];
+    const exec = async (command) => {
+      calls.push(command);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "restart", run: "make restart", onlyIfChanged: ["src/"] })];
+
+    const result = await runPostMergeActions(
+      { actions, changedPaths: null, changedPathsUnavailableReason: "no PR number", cwd: "/repo" },
+      { exec, log: (msg) => logs.push(msg), ...makeClock() },
+    );
+
+    assert.deepEqual(calls, ["make restart"], "onlyIfChanged must not silently skip when scoping is unresolved");
+    assert.equal(result.results[0].status, "ok");
+    assert.ok(
+      logs.some((l) => l.includes("WARNING") && l.includes("no PR number")),
+      `expected a warning stating why scoping was bypassed, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  test("an action with no onlyIfChanged always runs, scoping known or not", async () => {
+    const calls = [];
+    const exec = async (command) => {
+      calls.push(command);
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "always", run: "always-run" })];
+
+    await runPostMergeActions({ actions, changedPaths: ["README.md"], cwd: "/repo" }, { exec, ...makeClock() });
+    assert.deepEqual(calls, ["always-run"]);
+  });
+
+  test("a non-zero exit fails the action but subsequent actions still run", async () => {
+    const calls = [];
+    const exec = async (command) => {
+      calls.push(command);
+      if (command === "run-a") return { code: 1, killed: false, stdout: "", stderr: "boom" };
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "a", run: "run-a" }), action({ name: "b", run: "run-b" })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.deepEqual(calls, ["run-a", "run-b"], "action b must still run after action a fails");
+    assert.equal(result.results[0].status, "failed");
+    assert.match(result.results[0].detail, /exit code 1/);
+    assert.match(result.results[0].detail, /boom/);
+    assert.equal(result.results[1].status, "ok");
+    assert.equal(result.ok, false, "the overall result is a failure when any action failed");
+  });
+
+  test("a killed (timed-out) run reports the action as failed with the timeout named", async () => {
+    const exec = async () => ({ code: null, killed: true, stdout: "", stderr: "" });
+    const actions = [action({ name: "slow", run: "sleep 999", timeoutMs: 5000 })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(result.results[0].status, "failed");
+    assert.match(result.results[0].detail, /timed out after 5000ms/);
+    assert.equal(result.ok, false);
+  });
+
+  test("an exec rejection is treated as a run failure, not an unhandled rejection", async () => {
+    const exec = async () => {
+      throw new Error("spawn ENOENT");
+    };
+    const actions = [action({ name: "a" })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(result.results[0].status, "failed");
+    assert.match(result.results[0].detail, /spawn ENOENT/);
+  });
+
+  test("verify: polls until it exits 0, using the injected clock (no real waiting)", async () => {
+    let verifyCalls = 0;
+    const exec = async (command) => {
+      if (command === "run-it") return { code: 0, killed: false, stdout: "", stderr: "" };
+      // verify command: fail twice, then succeed
+      verifyCalls += 1;
+      if (verifyCalls < 3) return { code: 1, killed: false, stdout: "", stderr: "" };
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "svc", run: "run-it", verify: "curl -f /health", verifyTimeoutMs: 10000, verifyIntervalMs: 1000 })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(verifyCalls, 3);
+    assert.equal(result.results[0].status, "ok");
+  });
+
+  test("verify: exhausting the verify timeout without a 0 exit fails the action", async () => {
+    const exec = async (command) => {
+      if (command === "run-it") return { code: 0, killed: false, stdout: "", stderr: "" };
+      return { code: 1, killed: false, stdout: "", stderr: "" }; // verify never succeeds
+    };
+    const actions = [action({ name: "svc", run: "run-it", verify: "curl -f /health", verifyTimeoutMs: 3000, verifyIntervalMs: 1000 })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(result.results[0].status, "failed");
+    assert.match(result.results[0].detail, /verify exhausted after 3000ms/);
+    assert.equal(result.ok, false);
+  });
+
+  test("verify never runs when the run command itself fails", async () => {
+    let verifyCalled = false;
+    const exec = async (command) => {
+      if (command === "run-it") return { code: 1, killed: false, stdout: "", stderr: "run failed" };
+      verifyCalled = true;
+      return { code: 0, killed: false, stdout: "", stderr: "" };
+    };
+    const actions = [action({ name: "svc", run: "run-it", verify: "curl -f /health" })];
+
+    const result = await runPostMergeActions({ actions, changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(verifyCalled, false);
+    assert.equal(result.results[0].status, "failed");
+    assert.match(result.results[0].detail, /run failed/);
+  });
+
+  test("exit-code contract: ok is true when every action ran or was skipped cleanly", async () => {
+    const exec = async () => ({ code: 0, killed: false, stdout: "", stderr: "" });
+    const actions = [
+      action({ name: "runs", run: "run-a" }),
+      action({ name: "skipped", run: "run-b", onlyIfChanged: ["src/"] }),
+    ];
+
+    const result = await runPostMergeActions({ actions, changedPaths: ["README.md"], cwd: "/repo" }, { exec, ...makeClock() });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.results.map((r) => r.status), ["ok", "skipped"]);
+  });
+
+  test("no declared actions is a clean no-op", async () => {
+    const exec = async () => {
+      throw new Error("must never be called");
+    };
+    const result = await runPostMergeActions({ actions: [], changedPaths: null, cwd: "/repo" }, { exec, ...makeClock() });
+    assert.deepEqual(result, { ok: true, results: [] });
+  });
+});


### PR DESCRIPTION
## Objective

Add a configurable `postMerge.actions` hook to `.devloops` so a consumer repo can declaratively run local actions after the dev-loop's merge succeeds (sync the checkout, restart a long-lived local service, run a smoke check). Turns a manual post-merge runbook step into committed, enforced config. Mirrors the existing `uiReview.run` recipe precedent.

Closes #1457.

## In scope

- `packages/core/src/config/config.mjs`: `PostMergeActionConfig`/`PostMergeConfig` schemas wired into both `DevLoopConfigSchema` and `FileConfigSchema`; `resolvePostMergeActions(config)` resolver; bounded timeout defaults/ceilings. A `.devloops` without `postMerge` parses exactly as before; unknown keys inside `postMerge`/an action fail validation with a clear error.
- `packages/core/src/loop/run-post-merge-actions.mjs` (new): pure orchestrator — sequential in declared order, `onlyIfChanged` substring scoping (+ bypass-with-warning when the changed-file list can't be resolved), bounded `run` + `verify` polling, `{ok, results}` exit-code contract.
- `scripts/loop/run-post-merge-actions.mjs` (new): CLI — resolves the main checkout via `git worktree list` + `parseMainWorktreePath`, resolves changed paths via `gh pr diff --name-only`, silent when no actions are declared.
- `packages/core/src/loop/main-checkout-ff.mjs`: `buildPostMergeActionsCommand()` (existence-guarded, `|| true`, mirrors `buildWorktreeCleanupCommand`).
- `.claude/hooks/post-tool-use-merge.mjs`: invokes the runner after its existing FF/cleanup steps; always exits 0; silent no-op without the runner. Vendored `_main-checkout-ff.mjs` regenerated.
- `extension/post-merge-update.ts`: `onAgentEnd` invokes the runner for the merged repo regardless of slug; the `pi update` self-maintenance step stays gated to `mfittko/dev-loops`; runner failures are warning notifications, never thrown.
- `schemas/dev-loop-config.schema.json` regenerated; README `.devloops` reference updated.

## Security posture

- `run`/`verify` strings come from the repo's own committed `.devloops` (same trust level as `uiReview.run`) and are executed VERBATIM — never rebuilt by concatenating PR titles, branch names, changed-file paths, or verify output.
- `onlyIfChanged` matching is a plain substring compare against changed-file-path DATA, never a shell-out.
- All three timing knobs are schema-bounded (600000 / 600000 / 60000 ms ceilings) — a config can only tighten.
- Both hooks are fail-safe: existence-guarded `|| true`; the Claude hook always exits 0; the Pi hook's failure path is a warning notification, never a throw out of `onAgentEnd`.
- The main-checkout cwd is resolved via `parseMainWorktreePath`, not trusted from ambient cwd.

## Explicit non-goals

- Server-side / CI execution of these actions (client-side, post-merge only).
- Ungating the `pi update` self-maintenance step from `mfittko/dev-loops`.
- Interpolating any dynamic value into a command string.

## Known judgment call

AC11 ("zero new commands/log lines" without `postMerge`) is satisfied at the observable level (zero stdout/stderr, zero notifications). The existence-guarded `if [ -f script ]; then node script ...; fi || true` wrapper still spawns a silent node process that exits with no output — matching the existing `uiReview`/cleanup-worktree precedent of always attempting the guarded invocation.

## Acceptance criteria

- [x] `postMerge.actions` schema (name/run required; onlyIfChanged/verify/timeouts optional, bounded); unknown keys rejected; wired into both config schemas; absent postMerge parses unchanged.
- [x] Runner executes actions sequentially with cwd = main checkout (`parseMainWorktreePath`).
- [x] `onlyIfChanged` substring scoping; bypass-with-warning when changed files can't be resolved.
- [x] Per-action timeout; failures reported per action; subsequent actions still run.
- [x] `verify` polling until exit 0 or timeout; exhaustion = action failed.
- [x] Runner exit non-zero on any failure, zero when all ran/skipped cleanly.
- [x] Claude hook invokes runner (guarded, always exit 0); Pi hook invokes for the merged repo regardless of slug (pi-update stays dev-loops-gated); both fail-safe.
- [x] No-postMerge repo produces zero observable output from either hook.
- [x] Config-schema tests, runner unit tests, CLI tests, Pi hook tests, Claude hook contract tests, regenerated JSON schema + generated-schema test, asset no-drift, README updated. All suites green.
