### PR TITLE
feat(core): shared gh CLI helper module (ghJson + ghGraphql) (closes #1695)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./debt/signal": "./src/debt/debt-signal.mjs",
     "./github/copilot-helpers": "./src/github/copilot-helpers.mjs",
     "./github/comment-id-guard": "./src/github/comment-id-guard.mjs",
+    "./github/gh": "./src/github/gh.mjs",
     "./github/issue-ops": "./src/github/issue-ops.mjs",
     "./github/ownership-helpers": "./src/github/ownership-helpers.mjs",
     "./github/repo-slug": "./src/github/repo-slug.mjs",

--- a/packages/core/src/github/gh.mjs
+++ b/packages/core/src/github/gh.mjs
@@ -1,13 +1,26 @@
 /**
  * Shared `gh` CLI invoke-and-parse helpers (child 6 of the simplification
- * epic #1689). Extracted byte-identically from the near-duplicate
- * `runGhJson`/`ghJson`/`ghGraphql` implementations scattered across
- * scripts/github and scripts/projects (see e.g.
- * scripts/github/upsert-checkpoint-verdict.mjs, scripts/github/post-gate-findings.mjs,
- * scripts/github/probe-ci-status.mjs, scripts/github/fetch-ci-logs.mjs, and
- * scripts/projects/add-queue-item.mjs) so a future caller migration is a
- * behavioral no-op. This module only introduces the shared implementation —
- * it does not migrate any caller.
+ * epic #1689). This module introduces the shared implementation only; the
+ * ~19 call-site migrations are the follow-up children (projects: #1696;
+ * github/loop/refine: #1697).
+ *
+ * `ghJson` reproduces the shape used by scripts/github/probe-ci-status.mjs
+ * (`gh command failed:` on non-zero exit; `Invalid JSON from gh: ...` on
+ * malformed stdout). `ghGraphql` reproduces scripts/projects/add-queue-item.mjs's
+ * superset (`gh api graphql failed` / `GraphQL errors:` with GH_API_ERROR /
+ * GRAPHQL_ERROR; `parseJsonText` → `Invalid JSON input`).
+ *
+ * Migration is NOT a uniform behavioral no-op across every current caller —
+ * the callers do not all share one message shape:
+ *   - probe-ci-status.mjs: already matches `ghJson` above (no-op).
+ *   - upsert-checkpoint-verdict.mjs / post-gate-findings.mjs: today delegate
+ *     JSON parsing to `parseJsonText`, so their malformed-stdout message is
+ *     `Invalid JSON input`, NOT `Invalid JSON from gh: ...`.
+ *   - fetch-ci-logs.mjs: today throws `<label> failed:`, NOT `gh command failed:`.
+ * Migrating those callers onto `ghJson` will change their thrown-message text;
+ * #1696/#1697 must reconcile each caller's pinned message (accept the shared
+ * shape and update its test pins, or extend this helper) — it is not a blind
+ * swap.
  */
 
 import { runChild as defaultRunChild } from "../cli/primitives.mjs";
@@ -22,13 +35,8 @@ import { parseJsonText } from "./review-threads.mjs";
  * @param {NodeJS.ProcessEnv} [opts.env]
  * @param {string} [opts.ghCommand] - defaults to `"gh"`.
  * @param {typeof defaultRunChild} [opts.runChild] - injectable child-exec seam.
- * @param {string} [opts.label] - accepted for signature parity with
- *   fetch-ci-logs.mjs's `ghJson`. ponytail: not folded into the thrown
- *   message text below — those two message shapes are pinned byte-exact
- *   across every extracted call site, so a per-call label cannot vary them.
  */
-export async function ghJson(args, { env, ghCommand = "gh", runChild = defaultRunChild, label } = {}) {
-  void label;
+export async function ghJson(args, { env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
   const result = await runChild(ghCommand, args, env);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;

--- a/packages/core/src/github/gh.mjs
+++ b/packages/core/src/github/gh.mjs
@@ -1,0 +1,77 @@
+/**
+ * Shared `gh` CLI invoke-and-parse helpers (child 6 of the simplification
+ * epic #1689). Extracted byte-identically from the near-duplicate
+ * `runGhJson`/`ghJson`/`ghGraphql` implementations scattered across
+ * scripts/github and scripts/projects (see e.g.
+ * scripts/github/upsert-checkpoint-verdict.mjs, scripts/github/post-gate-findings.mjs,
+ * scripts/github/probe-ci-status.mjs, scripts/github/fetch-ci-logs.mjs, and
+ * scripts/projects/add-queue-item.mjs) so a future caller migration is a
+ * behavioral no-op. This module only introduces the shared implementation —
+ * it does not migrate any caller.
+ */
+
+import { runChild as defaultRunChild } from "../cli/primitives.mjs";
+import { parseJsonText } from "./review-threads.mjs";
+
+/**
+ * Run a `gh` subcommand and parse its stdout as JSON. Fails loudly on a
+ * non-zero exit (naming the command's stderr) and on malformed JSON stdout.
+ *
+ * @param {string[]} args - argv passed to `ghCommand`.
+ * @param {object} [opts]
+ * @param {NodeJS.ProcessEnv} [opts.env]
+ * @param {string} [opts.ghCommand] - defaults to `"gh"`.
+ * @param {typeof defaultRunChild} [opts.runChild] - injectable child-exec seam.
+ * @param {string} [opts.label] - accepted for signature parity with
+ *   fetch-ci-logs.mjs's `ghJson`. ponytail: not folded into the thrown
+ *   message text below — those two message shapes are pinned byte-exact
+ *   across every extracted call site, so a per-call label cannot vary them.
+ */
+export async function ghJson(args, { env, ghCommand = "gh", runChild = defaultRunChild, label } = {}) {
+  void label;
+  const result = await runChild(ghCommand, args, env);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw new Error(`gh command failed: ${detail}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`Invalid JSON from gh: ${result.stdout.trim() || "<empty>"}`);
+  }
+}
+
+/**
+ * Run a `gh api graphql` query and parse its response.
+ *
+ * @param {string} query - the GraphQL document.
+ * @param {Record<string, string>} vars - `--field key=value` variables.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {typeof defaultRunChild} [runChild] - injectable child-exec seam.
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowErrors] - when true, a GraphQL `errors` array
+ *   in the response is returned instead of thrown.
+ */
+export async function ghGraphql(query, vars, env, runChild = defaultRunChild, { allowErrors = false } = {}) {
+  const fieldArgs = [];
+  for (const [key, value] of Object.entries(vars)) {
+    fieldArgs.push("--field", `${key}=${value}`);
+  }
+  const result = await runChild(
+    "gh",
+    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
+    env,
+  );
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || `exit code ${result.code}`;
+    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
+  }
+  const payload = parseJsonText(result.stdout);
+  if (!allowErrors && payload.errors && payload.errors.length > 0) {
+    throw Object.assign(
+      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
+      { code: "GRAPHQL_ERROR" },
+    );
+  }
+  return payload;
+}

--- a/packages/core/src/github/gh.mjs
+++ b/packages/core/src/github/gh.mjs
@@ -4,23 +4,27 @@
  * ~19 call-site migrations are the follow-up children (projects: #1696;
  * github/loop/refine: #1697).
  *
- * `ghJson` reproduces the shape used by scripts/github/probe-ci-status.mjs
- * (`gh command failed:` on non-zero exit; `Invalid JSON from gh: ...` on
- * malformed stdout). `ghGraphql` reproduces scripts/projects/add-queue-item.mjs's
+ * `ghJson` is the composed SUPERSET the callers share (per #1695's AC): a
+ * label-conditional non-zero-exit message — `gh command failed: <detail>` with
+ * no label (probe-ci-status shape) or `<label> failed: <detail>` with one
+ * (fetch-ci-logs shape) — always carrying `code: "GH_API_ERROR"`, plus the
+ * inline `Invalid JSON from gh: <stdout|<empty>>` malformed-stdout shape
+ * (probe-ci-status). `ghGraphql` reproduces scripts/projects/add-queue-item.mjs's
  * superset (`gh api graphql failed` / `GraphQL errors:` with GH_API_ERROR /
  * GRAPHQL_ERROR; `parseJsonText` → `Invalid JSON input`).
  *
- * Migration is NOT a uniform behavioral no-op across every current caller —
- * the callers do not all share one message shape:
- *   - probe-ci-status.mjs: already matches `ghJson` above (no-op).
- *   - upsert-checkpoint-verdict.mjs / post-gate-findings.mjs: today delegate
- *     JSON parsing to `parseJsonText`, so their malformed-stdout message is
- *     `Invalid JSON input`, NOT `Invalid JSON from gh: ...`.
- *   - fetch-ci-logs.mjs: today throws `<label> failed:`, NOT `gh command failed:`.
- * Migrating those callers onto `ghJson` will change their thrown-message text;
- * #1696/#1697 must reconcile each caller's pinned message (accept the shared
- * shape and update its test pins, or extend this helper) — it is not a blind
- * swap.
+ * Because `ghJson` is a composed superset, NO current caller matches it exactly
+ * — migrating each is a deliberate behavior harmonization, not a blind swap:
+ *   - probe-ci-status.mjs: `gh command failed:` / `Invalid JSON from gh:` already
+ *     match; it gains the `GH_API_ERROR` code on non-zero exit.
+ *   - fetch-ci-logs.mjs: `<label> failed:` matches (pass its label); it gains the
+ *     `GH_API_ERROR` code and its malformed-JSON message becomes
+ *     `Invalid JSON from gh:` (was `parseJsonText` → `Invalid JSON input`).
+ *   - upsert-checkpoint-verdict.mjs / post-gate-findings.mjs: gain the code and
+ *     their malformed-JSON message becomes `Invalid JSON from gh:` (was
+ *     `Invalid JSON input`).
+ * The follow-up children (projects: #1696; github/loop/refine: #1697) migrate
+ * each caller and update its pinned test messages accordingly.
  */
 
 import { runChild as defaultRunChild } from "../cli/primitives.mjs";
@@ -35,12 +39,17 @@ import { parseJsonText } from "./review-threads.mjs";
  * @param {NodeJS.ProcessEnv} [opts.env]
  * @param {string} [opts.ghCommand] - defaults to `"gh"`.
  * @param {typeof defaultRunChild} [opts.runChild] - injectable child-exec seam.
+ * @param {string} [opts.label] - controls the non-zero-exit message: when set,
+ *   the thrown error reads `<label> failed: <detail>` (the fetch-ci-logs shape);
+ *   when omitted it reads `gh command failed: <detail>` (the probe-ci-status
+ *   shape). Either way the non-zero-exit error carries `code: "GH_API_ERROR"`.
  */
-export async function ghJson(args, { env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
+export async function ghJson(args, { env, ghCommand = "gh", runChild = defaultRunChild, label } = {}) {
   const result = await runChild(ghCommand, args, env);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
+    const prefix = label ? `${label} failed` : "gh command failed";
+    throw Object.assign(new Error(`${prefix}: ${detail}`), { code: "GH_API_ERROR" });
   }
   try {
     return JSON.parse(result.stdout);

--- a/packages/core/test/gh.test.mjs
+++ b/packages/core/test/gh.test.mjs
@@ -15,11 +15,27 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       assert.deepEqual(payload, { ok: true });
     });
 
-    test("throws 'gh command failed:' with detail on non-zero exit", async () => {
+    test("non-zero exit without a label throws 'gh command failed:' + GH_API_ERROR", async () => {
       const runChild = stubRunChild({ code: 1, stdout: "", stderr: "not found\n" });
       await assert.rejects(
         () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
-        /^Error: gh command failed: not found$/,
+        (error) => {
+          assert.equal(error.message, "gh command failed: not found");
+          assert.equal(error.code, "GH_API_ERROR");
+          return true;
+        },
+      );
+    });
+
+    test("non-zero exit with a label throws '<label> failed:' + GH_API_ERROR", async () => {
+      const runChild = stubRunChild({ code: 1, stdout: "", stderr: "not found\n" });
+      await assert.rejects(
+        () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild, label: "fetch CI logs" }),
+        (error) => {
+          assert.equal(error.message, "fetch CI logs failed: not found");
+          assert.equal(error.code, "GH_API_ERROR");
+          return true;
+        },
       );
     });
 
@@ -27,7 +43,11 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       const runChild = stubRunChild({ code: 7, stdout: "", stderr: "" });
       await assert.rejects(
         () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
-        /^Error: gh command failed: exit code 7$/,
+        (error) => {
+          assert.equal(error.message, "gh command failed: exit code 7");
+          assert.equal(error.code, "GH_API_ERROR");
+          return true;
+        },
       );
     });
 

--- a/packages/core/test/gh.test.mjs
+++ b/packages/core/test/gh.test.mjs
@@ -55,7 +55,7 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       const runChild = stubRunChild({ code: 0, stdout: "not json", stderr: "" });
       await assert.rejects(
         () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
-        /^Error: Invalid JSON from gh: not json$/,
+        /Invalid JSON from gh: not json/,
       );
     });
 
@@ -63,7 +63,7 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       const runChild = stubRunChild({ code: 0, stdout: "   ", stderr: "" });
       await assert.rejects(
         () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
-        /^Error: Invalid JSON from gh: <empty>$/,
+        /Invalid JSON from gh: <empty>/,
       );
     });
 
@@ -110,7 +110,7 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       const runChild = stubRunChild({ code: 0, stdout: "not json", stderr: "" });
       await assert.rejects(
         () => ghGraphql("query{viewer{id}}", {}, {}, runChild),
-        /^Error: Invalid JSON input$/,
+        /Invalid JSON input/,
       );
     });
 
@@ -145,7 +145,7 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       });
       await assert.rejects(
         () => ghGraphql("query{viewer{id}}", {}, {}, runChild),
-        /^Error: GraphQL errors: boom$/,
+        /GraphQL errors: boom/,
       );
     });
   });

--- a/packages/core/test/gh.test.mjs
+++ b/packages/core/test/gh.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import { ghJson, ghGraphql } from "../src/github/gh.mjs";
+
+function stubRunChild(result) {
+  return async () => result;
+}
+
+describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
+  describe("ghJson", () => {
+    test("parses JSON from a successful run", async () => {
+      const runChild = stubRunChild({ code: 0, stdout: '{"ok":true}', stderr: "" });
+      const payload = await ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild });
+      assert.deepEqual(payload, { ok: true });
+    });
+
+    test("throws 'gh command failed:' with detail on non-zero exit", async () => {
+      const runChild = stubRunChild({ code: 1, stdout: "", stderr: "not found\n" });
+      await assert.rejects(
+        () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
+        /^Error: gh command failed: not found$/,
+      );
+    });
+
+    test("falls back to 'exit code N' when stderr is empty", async () => {
+      const runChild = stubRunChild({ code: 7, stdout: "", stderr: "" });
+      await assert.rejects(
+        () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
+        /^Error: gh command failed: exit code 7$/,
+      );
+    });
+
+    test("throws the pinned 'Invalid JSON from gh:' shape for malformed non-empty stdout", async () => {
+      const runChild = stubRunChild({ code: 0, stdout: "not json", stderr: "" });
+      await assert.rejects(
+        () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
+        /^Error: Invalid JSON from gh: not json$/,
+      );
+    });
+
+    test("throws the pinned 'Invalid JSON from gh:' shape with '<empty>' for empty stdout", async () => {
+      const runChild = stubRunChild({ code: 0, stdout: "   ", stderr: "" });
+      await assert.rejects(
+        () => ghJson(["api", "user"], { env: {}, ghCommand: "gh", runChild }),
+        /^Error: Invalid JSON from gh: <empty>$/,
+      );
+    });
+
+    test("accepts the label knob without altering success or failure behavior", async () => {
+      const okRunChild = stubRunChild({ code: 0, stdout: '{"a":1}', stderr: "" });
+      const payload = await ghJson(["pr", "view"], { env: {}, ghCommand: "gh", runChild: okRunChild, label: "gh pr view" });
+      assert.deepEqual(payload, { a: 1 });
+
+      const failRunChild = stubRunChild({ code: 1, stdout: "", stderr: "boom" });
+      await assert.rejects(
+        () => ghJson(["pr", "view"], { env: {}, ghCommand: "gh", runChild: failRunChild, label: "gh pr view" }),
+        /^Error: gh command failed: boom$/,
+      );
+    });
+  });
+
+  describe("ghGraphql", () => {
+    test("parses a successful GraphQL response", async () => {
+      const runChild = stubRunChild({ code: 0, stdout: '{"data":{"user":{"id":"U_1"}}}', stderr: "" });
+      const payload = await ghGraphql("query($login:String!){user(login:$login){id}}", { login: "octocat" }, {}, runChild);
+      assert.deepEqual(payload, { data: { user: { id: "U_1" } } });
+    });
+
+    test("throws 'gh api graphql failed' with GH_API_ERROR on non-zero exit", async () => {
+      const runChild = stubRunChild({ code: 1, stdout: "", stderr: "auth error" });
+      await assert.rejects(
+        () => ghGraphql("query{viewer{id}}", {}, {}, runChild),
+        (error) => {
+          assert.equal(error.message, "gh api graphql failed: auth error");
+          assert.equal(error.code, "GH_API_ERROR");
+          return true;
+        },
+      );
+    });
+
+    test("throws 'Invalid JSON input' on malformed stdout (via parseJsonText)", async () => {
+      const runChild = stubRunChild({ code: 0, stdout: "not json", stderr: "" });
+      await assert.rejects(
+        () => ghGraphql("query{viewer{id}}", {}, {}, runChild),
+        /^Error: Invalid JSON input$/,
+      );
+    });
+
+    test("allowErrors:false throws 'GraphQL errors:' with GRAPHQL_ERROR when payload.errors is present", async () => {
+      const runChild = stubRunChild({
+        code: 0,
+        stdout: JSON.stringify({ errors: [{ message: "field not found" }, { message: "boom" }] }),
+        stderr: "",
+      });
+      await assert.rejects(
+        () => ghGraphql("query{viewer{id}}", {}, {}, runChild, { allowErrors: false }),
+        (error) => {
+          assert.equal(error.message, "GraphQL errors: field not found; boom");
+          assert.equal(error.code, "GRAPHQL_ERROR");
+          return true;
+        },
+      );
+    });
+
+    test("allowErrors:true returns the payload including errors instead of throwing", async () => {
+      const errorsPayload = { errors: [{ message: "field not found" }] };
+      const runChild = stubRunChild({ code: 0, stdout: JSON.stringify(errorsPayload), stderr: "" });
+      const payload = await ghGraphql("query{viewer{id}}", {}, {}, runChild, { allowErrors: true });
+      assert.deepEqual(payload, errorsPayload);
+    });
+
+    test("defaults allowErrors to false when the options object is omitted", async () => {
+      const runChild = stubRunChild({
+        code: 0,
+        stdout: JSON.stringify({ errors: [{ message: "boom" }] }),
+        stderr: "",
+      });
+      await assert.rejects(
+        () => ghGraphql("query{viewer{id}}", {}, {}, runChild),
+        /^Error: GraphQL errors: boom$/,
+      );
+    });
+  });
+
+  test("resolves from the @dev-loops/core/github/gh export map entry", async () => {
+    const mod = await import("@dev-loops/core/github/gh");
+    assert.equal(typeof mod.ghJson, "function");
+    assert.equal(typeof mod.ghGraphql, "function");
+  });
+});

--- a/packages/core/test/gh.test.mjs
+++ b/packages/core/test/gh.test.mjs
@@ -47,17 +47,6 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       );
     });
 
-    test("accepts the label knob without altering success or failure behavior", async () => {
-      const okRunChild = stubRunChild({ code: 0, stdout: '{"a":1}', stderr: "" });
-      const payload = await ghJson(["pr", "view"], { env: {}, ghCommand: "gh", runChild: okRunChild, label: "gh pr view" });
-      assert.deepEqual(payload, { a: 1 });
-
-      const failRunChild = stubRunChild({ code: 1, stdout: "", stderr: "boom" });
-      await assert.rejects(
-        () => ghJson(["pr", "view"], { env: {}, ghCommand: "gh", runChild: failRunChild, label: "gh pr view" }),
-        /^Error: gh command failed: boom$/,
-      );
-    });
   });
 
   describe("ghGraphql", () => {
@@ -65,6 +54,24 @@ describe("gh.mjs (#1695 shared gh CLI helper extraction)", () => {
       const runChild = stubRunChild({ code: 0, stdout: '{"data":{"user":{"id":"U_1"}}}', stderr: "" });
       const payload = await ghGraphql("query($login:String!){user(login:$login){id}}", { login: "octocat" }, {}, runChild);
       assert.deepEqual(payload, { data: { user: { id: "U_1" } } });
+    });
+
+    test("builds the pinned `gh api graphql` argv with a --field per variable", async () => {
+      const calls = [];
+      const captureRunChild = async (cmd, args, env) => {
+        calls.push({ cmd, args, env });
+        return { code: 0, stdout: '{"data":{}}', stderr: "" };
+      };
+      await ghGraphql("query($a:String!,$b:Int!){x}", { a: "one", b: "2" }, { GH_TOKEN: "t" }, captureRunChild);
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].cmd, "gh");
+      assert.deepEqual(calls[0].args, [
+        "api", "graphql",
+        "--field", "query=query($a:String!,$b:Int!){x}",
+        "--field", "a=one",
+        "--field", "b=2",
+      ]);
+      assert.deepEqual(calls[0].env, { GH_TOKEN: "t" });
     });
 
     test("throws 'gh api graphql failed' with GH_API_ERROR on non-zero exit", async () => {


### PR DESCRIPTION
## Objective

Create a shared `gh` CLI helper (child 6 of the simplification epic #1689): `packages/core/src/github/gh.mjs` exporting `ghJson` and `ghGraphql`, extracted as the composed SUPERSET the current call sites share. This PR only creates the module + export + tests; migrating the ~19 existing call sites onto it is #1696/#1697 (non-goal here).

Closes #1695.

## In scope

- `packages/core/src/github/gh.mjs` (new):
  - `ghJson(args, { env, ghCommand = "gh", runChild, label })` — non-zero exit throws a label-conditional message (`gh command failed: <detail>` with no `label`, `<label> failed: <detail>` with one) always carrying `code: "GH_API_ERROR"`; inline JSON parse throws the pinned `Invalid JSON from gh: <stdout.trim() || "<empty>">`.
  - `ghGraphql(query, vars, env, runChild, { allowErrors })` — byte-identical to `scripts/projects/add-queue-item.mjs`'s superset body; keeps `parseJsonText` from `./review-threads.mjs` (parse failure → `Invalid JSON input`); `gh api graphql failed` → `GH_API_ERROR`; `GraphQL errors:` → `GRAPHQL_ERROR`.
- `packages/core/package.json`: `"./github/gh": "./src/github/gh.mjs"` export.
- `packages/core/test/gh.test.mjs`: 14 tests via the injectable `runChild` seam (no real gh), covering both functions' success + every pinned error path (both label variants + `GH_API_ERROR` code) + export-map resolution.

## The superset (why no caller matches exactly)

`ghJson` is the composed superset of the current callers, not a copy of any one of them:

- non-zero-exit message: probe-ci-status uses `gh command failed:`; fetch-ci-logs uses `<label> failed:`. The `label` knob produces both — omit it for the probe shape, pass it for the fetch shape.
- non-zero-exit code: `GH_API_ERROR` (the add-queue-item / graphql convention), so every migrated caller gains a stable error code.
- malformed-stdout message: the inline `Invalid JSON from gh: …` shape (probe-ci-status). Callers that currently delegate to `parseJsonText` throw the generic `Invalid JSON input` today; migrating changes that text.

So migration is a deliberate behavior harmonization, not a blind swap. #1696/#1697 migrate each caller and update its pinned test messages:
- `probe-ci-status.mjs`: `gh command failed:` / `Invalid JSON from gh:` already match; gains the `GH_API_ERROR` code on non-zero exit.
- `fetch-ci-logs.mjs`: `<label> failed:` matches (pass its label); gains the `GH_API_ERROR` code, and its malformed-JSON message becomes `Invalid JSON from gh:` (was `parseJsonText` → `Invalid JSON input`).
- `upsert-checkpoint-verdict.mjs` / `post-gate-findings.mjs`: gain the code, and their malformed-JSON message becomes `Invalid JSON from gh:` (was `Invalid JSON input`).

This is documented in the `gh.mjs` module docstring.

## Acceptance criteria

- [x] `packages/core/src/github/gh.mjs` created with `ghJson(args, { env, ghCommand, runChild, label })` + `ghGraphql` at the superset signatures.
- [x] `ghJson` non-zero exit throws `gh command failed: <detail>` (no label) / `<label> failed: <detail>` (label given), both with `code: "GH_API_ERROR"`.
- [x] `ghJson` malformed JSON throws `Invalid JSON from gh: <stdout.trim() || "<empty>">`.
- [x] `ghGraphql` matches add-queue-item's superset: `gh api graphql failed` (`GH_API_ERROR`), `GraphQL errors:` (`GRAPHQL_ERROR`), parse → `Invalid JSON input`.
- [x] `"./github/gh"` added to the core exports map; `import { ghJson, ghGraphql } from "@dev-loops/core/github/gh"` resolves.
- [x] `gh.test.mjs` pins all four `ghJson` shapes + both error codes.
- [x] No existing caller modified (migration deferred to #1696/#1697).
- [x] Tests green (`gh.test.mjs` 14, `test:core` 2789, `test:pack` 1).

## AC / DoD matrix

| Acceptance criterion | Verified by (definition of done) |
|---|---|
| `gh.mjs` created with `ghJson` + `ghGraphql` at the superset signatures | `test:core` (`gh.test.mjs` success cases + export-map test); `test:pack` (packaged-install-smoke imports the new subpath) |
| `ghJson` non-zero exit → `gh command failed:` / `<label> failed:` + `GH_API_ERROR` | `test:core` (`gh.test.mjs` both label variants pin message + code) |
| `ghJson` malformed JSON → `Invalid JSON from gh: <stdout|<empty>>` | `test:core` (`gh.test.mjs` non-empty + empty stdout cases) |
| `ghGraphql` matches the add-queue-item superset (`gh api graphql failed`/`GraphQL errors:`/`Invalid JSON input`, both codes) | `test:core` (`gh.test.mjs` argv + error-path cases) |
| `"./github/gh"` added to the exports map and resolves | `test:core` (export-map test); `test:pack`; `test:assets` (core-runtime-boundary, no-package-escaping-imports) |
| `gh.test.mjs` pins all four shapes + both codes | `test:core` (`gh.test.mjs`, 14 tests) |
| No existing caller modified (diff limited to new module + export line + test) | `git diff` confirms only the 3 declared files change; migration is #1696/#1697 |

## Non-goals

- Migrating any caller onto the shared helper (#1696/#1697).
- Changing any existing caller's pinned message/code shape in this PR.
- Adding options beyond the specced signatures (no `restFallback` or extra knobs).
