### PR TITLE
refactor(projects): migrate ghGraphql/ghJson copies to shared helper (closes #1696)

### DIFF
--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
-import { runChild as coreRunChild } from "../cli/primitives.mjs";
 import { main as moveQueueItemMain } from "../projects/move-queue-item.mjs";
+import { ghGraphql } from "../github/gh.mjs";
 
 const DEFAULT_NON_SUCCESS_COLUMN = "Backlog";
 
@@ -314,31 +314,6 @@ const LIST_ORG_PROJECTS = [
   "  }",
   "}"
 ].join("\n");
-
-async function ghGraphql(query, vars, env, runChild) {
-  const child = runChild ?? coreRunChild;
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await child(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = JSON.parse(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
-}
 
 async function resolveOwner(login, env, runChild) {
   const userPayload = await ghGraphql(GET_USER_ID, { login }, env, runChild);

--- a/packages/core/src/projects/list-queue-items.mjs
+++ b/packages/core/src/projects/list-queue-items.mjs
@@ -1,6 +1,6 @@
 import { runChild as _runChild } from "../cli/primitives.mjs";
-import { parseJsonText } from "../github/review-threads.mjs";
 import { resolveProjectSelector, findProject } from "./resolve-project.mjs";
+import { ghGraphql } from "../github/gh.mjs";
 
 // ── Validation ───────────────────────────────────────────────────────────
 
@@ -28,32 +28,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
 }
 
 // ── GraphQL fragments ────────────────────────────────────────────────────

--- a/packages/core/src/projects/move-queue-item.mjs
+++ b/packages/core/src/projects/move-queue-item.mjs
@@ -1,8 +1,8 @@
 import { runChild as _runChild } from "../cli/primitives.mjs";
-import { parseJsonText } from "../github/review-threads.mjs";
 import { runPickupRefinementGate } from "../loop/issue-refinement-artifact.mjs";
 import { loadStateColumnMap, LOGICAL_COLUMN } from "../loop/queue-board-sync.mjs";
 import { resolveProjectSelector, findProject, parseItemRef } from "./resolve-project.mjs";
+import { ghGraphql } from "../github/gh.mjs";
 
 // ── Validation ───────────────────────────────────────────────────────────
 
@@ -27,32 +27,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
 }
 
 // ── GraphQL fragments ────────────────────────────────────────────────────

--- a/scripts/projects/add-queue-item.mjs
+++ b/scripts/projects/add-queue-item.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveProjectSelector, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { loadStateColumnMap, LOGICAL_COLUMN, nonSuccessBoardColumn } from "@dev-loops/core/loop/queue-board-sync";
 import { runPickupRefinementGate } from "@dev-loops/core/loop/issue-refinement-artifact";
+import { ghGraphql } from "@dev-loops/core/github/gh";
 
 const USAGE = `Usage: dev-loops queue add --repo <owner/name> [--project <number|id>] --item <number>
        dev-loops project add … (back-compat alias for "queue add")
@@ -171,32 +172,6 @@ function validateRepo(repo) {
     throw Object.assign(new Error(`--repo must be exactly owner/name, got "${repo}"`), { code: "INVALID_REPO" });
   }
   return repo;
-}
-
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild, { allowErrors = false } = {}) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (!allowErrors && payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
 }
 
 // ── GraphQL fragments ────────────────────────────────────────────────────

--- a/scripts/projects/archive-done-items.mjs
+++ b/scripts/projects/archive-done-items.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveSettings, parseProjectRef, findProject, applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
+import { ghGraphql } from "@dev-loops/core/github/gh";
 
 const USAGE = `Usage: dev-loops queue archive-done --repo <owner/name> [--project <number|id|board-uri>] [--older-than <duration>] [--dry-run]
        (dev-loops project archive-done … is a back-compat alias)
@@ -143,28 +144,6 @@ function parseDuration(raw) {
     throw Object.assign(new Error(`--older-than must be a positive amount, got "${raw}"`), { code: "INVALID_DURATION" });
   }
   return n * UNIT_MS[m[2]];
-}
-
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild("gh", ["api", "graphql", "--field", `query=${query}`, ...fieldArgs], env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
 }
 
 // ── GraphQL fragments ────────────────────────────────────────────────────

--- a/scripts/projects/ensure-queue-board.mjs
+++ b/scripts/projects/ensure-queue-board.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveSettings } from "./_resolve-project.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { ghGraphql } from "@dev-loops/core/github/gh";
 
 const USAGE = `Usage: dev-loops queue ensure --repo <owner/name> [--project <number>] [--title <title>] [--link-repo <owner/name>] [--repair-rename]
        (dev-loops project ensure … is a back-compat alias)
@@ -148,32 +149,6 @@ function validateRepo(repo) {
     );
   }
   return repo;
-}
-
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
 }
 
 // ── Query/mutation fragments ────────────────────────────────────────────

--- a/scripts/projects/list-parked-unrefined-items.mjs
+++ b/scripts/projects/list-parked-unrefined-items.mjs
@@ -110,6 +110,22 @@ function parseCliArgs(argv) {
   return args;
 }
 
+// Fixed-bound concurrency limiter: runs `fn` over `items` in chunks of `limit`,
+// preserving result order (index-stable) regardless of per-item completion
+// order — same fail-closed semantics as a sequential loop (a chunk's
+// Promise.all rejects immediately on the first per-item throw).
+async function mapConcurrent(items, limit, fn) {
+  const results = new Array(items.length);
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    const chunkResults = await Promise.all(chunk.map((item) => fn(item)));
+    for (let j = 0; j < chunkResults.length; j++) results[i + j] = chunkResults[j];
+  }
+  return results;
+}
+
+const BODY_FETCH_CONCURRENCY = 4;
+
 async function main(args, { env = process.env, runChild = _runChild, cwd = process.cwd() } = {}) {
   // The park column is where the enqueue fail-safe diverts un-refined issues.
   const parkedColumn = nonSuccessBoardColumn(cwd);
@@ -119,18 +135,17 @@ async function main(args, { env = process.env, runChild = _runChild, cwd = proce
   );
   const items = listed.items ?? [];
 
-  const unrefined = [];
-  for (const item of items) {
+  const perItem = await mapConcurrent(items, BODY_FETCH_CONCURRENCY, async (item) => {
     // Issue-only: a PR in the park column is not gated by the refinement check.
-    if (item.issueNumber == null) continue;
+    if (item.issueNumber == null) return null;
     const body = await fetchIssueBody(
       { repo: args.repo, issue: item.issueNumber },
       { env, runChild },
     );
     const artifact = detectIssueRefinementArtifact({ body, issueNumber: item.issueNumber });
     // finding !== null is the explicit "has NO refinement artifact" signal.
-    if (artifact.finding === null) continue;
-    unrefined.push({
+    if (artifact.finding === null) return null;
+    return {
       issueNumber: item.issueNumber,
       title: item.title ?? null,
       url: item.url ?? null,
@@ -140,8 +155,9 @@ async function main(args, { env = process.env, runChild = _runChild, cwd = proce
       // The three artifact sources any ONE of which clears the gate — the same
       // single-source vocabulary the enqueue gate reports (one taxonomy, no drift).
       missing: [...REFINEMENT_ARTIFACT_SOURCES],
-    });
-  }
+    };
+  });
+  const unrefined = perItem.filter((x) => x !== null);
 
   return { ok: true, parkedColumn, items: unrefined };
 }

--- a/scripts/projects/list-parked-unrefined-items.mjs
+++ b/scripts/projects/list-parked-unrefined-items.mjs
@@ -112,8 +112,10 @@ function parseCliArgs(argv) {
 
 // Fixed-bound concurrency limiter: runs `fn` over `items` in chunks of `limit`,
 // preserving result order (index-stable) regardless of per-item completion
-// order — same fail-closed semantics as a sequential loop (a chunk's
-// Promise.all rejects immediately on the first per-item throw).
+// order. Fail-closed: a chunk's Promise.all rejects on the first per-item
+// throw and propagates it (like a sequential loop). Unlike a sequential loop
+// it does not cancel the chunk's other in-flight calls — Promise.all cannot —
+// so siblings already started run to completion before the rejection surfaces.
 async function mapConcurrent(items, limit, fn) {
   const results = new Array(items.length);
   for (let i = 0; i < items.length; i += limit) {

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -5,7 +5,7 @@
 // derived column differs from their current Status. Backlog/Next Up ordering is
 // left untouched (items that derive null are skipped). Idempotent: a second run
 // over a converged board performs no moves.
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { applyDevloopsBoard } from "./_resolve-project.mjs";
@@ -13,7 +13,7 @@ import { main as listQueueItems } from "./list-queue-items.mjs";
 import { main as moveQueueItem } from "./move-queue-item.mjs";
 import { detectLinkedIssuePr } from "../github/detect-linked-issue-pr.mjs";
 import { planReconcile, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
-import { runChild as _runChild } from "../_cli-primitives.mjs";
+import { ghJson } from "@dev-loops/core/github/gh";
 
 const USAGE = `Usage: dev-loops queue reconcile --repo <owner/name> [--project <number|id|board-uri>]
        (dev-loops project reconcile … is a back-compat alias)
@@ -98,70 +98,79 @@ function parseCliArgs(argv) {
   return args;
 }
 
-async function ghJson(argv, { env, runChild }) {
-  const child = runChild ?? _runChild;
-  const result = await child("gh", argv, env);
-  if (result.code !== 0) {
-    const detail = result.stderr?.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh command failed: ${detail}`), { code: "GH_API_ERROR" });
+// Fixed-bound concurrency limiter: runs `fn` over `items` in chunks of `limit`,
+// preserving result order (index-stable) regardless of per-item completion
+// order — callers that need output in input order can rely on the returned
+// array without any extra bookkeeping.
+async function mapConcurrent(items, limit, fn) {
+  const results = new Array(items.length);
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    const chunkResults = await Promise.all(chunk.map((item) => fn(item)));
+    for (let j = 0; j < chunkResults.length; j++) results[i + j] = chunkResults[j];
   }
-  return parseJsonText(result.stdout);
+  return results;
 }
+
+const GATHER_CONCURRENCY = 4;
 
 // Real live-facts gatherer. For each item, resolve GitHub state into the fact
 // shape consumed by deriveReconcileColumn. Keyed by the stable item node id
 // (item.itemId), not the bare number, so a multi-repo board where two items
 // share a number (repo-A PR #5 vs repo-B issue #5) cannot collide. Per-item gh
 // failures are swallowed (best-effort): the item records all-null PR fields →
-// derives null → untouched.
+// derives null → untouched. Items are gathered with a fixed concurrency bound
+// (not fully sequential) — order of the returned Map's entries mirrors `items`.
 export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn } = {}) {
-  const byItemId = new Map();
-  for (const item of items) {
+  const eligible = items.filter((item) => {
     const number = item.prNumber != null ? item.prNumber : item.issueNumber;
-    if (number == null || item.itemId == null) continue;
+    if (number == null || item.itemId == null) return false;
     // Done is terminal for reconcile; planReconcile treats a missing fact as
     // unchanged. At loop startup (doneColumn set) we skip the gh calls for
     // Done items entirely — terminal + perf. An explicit `dev-loops queue
     // reconcile` run passes no doneColumn, so Done items ARE gathered and a
     // reopened/re-linked artifact can be moved back out of Done (recovery).
-    if (doneColumn != null && item.status === doneColumn) continue;
+    if (doneColumn != null && item.status === doneColumn) return false;
+    return true;
+  });
+
+  const entries = await mapConcurrent(eligible, GATHER_CONCURRENCY, async (item) => {
     try {
       if (item.prNumber != null) {
         const pr = await ghJson(["pr", "view", String(item.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
-        byItemId.set(item.itemId, {
+        return [item.itemId, {
           itemKind: "pr",
           issueState: null,
           prState: pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase(),
           prIsDraft: pr?.isDraft === true,
-        });
-      } else {
-        const issue = await ghJson(["issue", "view", String(item.issueNumber), "--repo", repo, "--json", "state"], { env, runChild });
-        const issueState = String(issue?.state ?? "").toUpperCase();
-        if (issueState === "CLOSED") {
-          byItemId.set(item.itemId, { itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null });
-          continue;
-        }
-        let prState = null;
-        let prIsDraft = null;
-        const linkage = await detectLinkedIssuePr({ repo, issue: item.issueNumber }, { env, runChild });
-        if (linkage?.hasOpenLinkedPr) {
-          const pr = await ghJson(["pr", "view", String(linkage.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
-          prState = pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase();
-          prIsDraft = pr?.isDraft === true;
-        }
-        byItemId.set(item.itemId, { itemKind: "issue", issueState: "OPEN", prState, prIsDraft });
+        }];
       }
+      const issue = await ghJson(["issue", "view", String(item.issueNumber), "--repo", repo, "--json", "state"], { env, runChild });
+      const issueState = String(issue?.state ?? "").toUpperCase();
+      if (issueState === "CLOSED") {
+        return [item.itemId, { itemKind: "issue", issueState: "CLOSED", prState: null, prIsDraft: null }];
+      }
+      let prState = null;
+      let prIsDraft = null;
+      const linkage = await detectLinkedIssuePr({ repo, issue: item.issueNumber }, { env, runChild });
+      if (linkage?.hasOpenLinkedPr) {
+        const pr = await ghJson(["pr", "view", String(linkage.prNumber), "--repo", repo, "--json", "state,isDraft,mergedAt"], { env, runChild });
+        prState = pr?.mergedAt ? "MERGED" : String(pr?.state ?? "").toUpperCase();
+        prIsDraft = pr?.isDraft === true;
+      }
+      return [item.itemId, { itemKind: "issue", issueState: "OPEN", prState, prIsDraft }];
     } catch {
       // Best-effort: record inert facts so the item derives null (untouched).
-      byItemId.set(item.itemId, {
+      return [item.itemId, {
         itemKind: item.prNumber != null ? "pr" : "issue",
         issueState: item.prNumber != null ? null : "OPEN",
         prState: null,
         prIsDraft: null,
-      });
+      }];
     }
-  }
-  return byItemId;
+  });
+
+  return new Map(entries);
 }
 
 async function main(args, { env = process.env, runChild, cwd = process.cwd(), listItems, gatherFacts, moveItem, skipTerminalColumn = false } = {}) {

--- a/scripts/projects/reconcile-queue.mjs
+++ b/scripts/projects/reconcile-queue.mjs
@@ -120,7 +120,8 @@ const GATHER_CONCURRENCY = 4;
 // share a number (repo-A PR #5 vs repo-B issue #5) cannot collide. Per-item gh
 // failures are swallowed (best-effort): the item records all-null PR fields →
 // derives null → untouched. Items are gathered with a fixed concurrency bound
-// (not fully sequential) — order of the returned Map's entries mirrors `items`.
+// (not fully sequential) — the returned Map's entry order mirrors the gathered
+// eligible items (the `items` order minus the skipped ineligible/Done ones).
 export async function gatherLiveFacts(items, repo, { env, runChild, doneColumn } = {}) {
   const eligible = items.filter((item) => {
     const number = item.prNumber != null ? item.prNumber : item.issueNumber;

--- a/scripts/projects/reorder-queue-item.mjs
+++ b/scripts/projects/reorder-queue-item.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveProjectSelector, findProject, applyDevloopsBoard, parseItemRef } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { ghGraphql } from "@dev-loops/core/github/gh";
 
 const USAGE = `Usage:
   dev-loops queue reorder --repo <owner/name> --project <number|id|board-uri> --item <number|node-id> [--after <number|node-id>]
@@ -153,32 +154,6 @@ function validateRepo(repo) {
   return repo;
 }
 
-// ── API helpers ──────────────────────────────────────────────────────────
-
-async function ghGraphql(query, vars, env, runChild = _runChild) {
-  const fieldArgs = [];
-  for (const [key, value] of Object.entries(vars)) {
-    fieldArgs.push("--field", `${key}=${value}`);
-  }
-  const result = await runChild(
-    "gh",
-    ["api", "graphql", "--field", `query=${query}`, ...fieldArgs],
-    env,
-  );
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw Object.assign(new Error(`gh api graphql failed: ${detail}`), { code: "GH_API_ERROR" });
-  }
-  const payload = parseJsonText(result.stdout);
-  if (payload.errors && payload.errors.length > 0) {
-    throw Object.assign(
-      new Error(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`),
-      { code: "GRAPHQL_ERROR" },
-    );
-  }
-  return payload;
-}
-
 // ── GraphQL fragments ────────────────────────────────────────────────────
 
 const GET_USER_ID = [
@@ -235,30 +210,6 @@ const GET_PROJECT_ITEMS_BY_CONTENT = [
   "            ... on Issue { __typename number repository { nameWithOwner } }",
   "            ... on PullRequest { __typename number repository { nameWithOwner } }",
   "          }",
-  "        }",
-  "      }",
-  "    }",
-  "  }",
-  "}"
-].join("\n");
-
-const GET_PROJECT_ITEM = [
-  "query($projectId:ID!, $itemId:ID!) {",
-  "  node(id:$projectId) {",
-  "    ... on ProjectV2 {",
-  "      item: item(id:$itemId) {",
-  "        id",
-  "        fieldValues(first:20) {",
-  "          nodes {",
-  "            ... on ProjectV2ItemFieldSingleSelectValue {",
-  "              field { ... on ProjectV2SingleSelectField { id name } }",
-  "              name",
-  "            }",
-  "          }",
-  "        }",
-  "        content {",
-  "          ... on Issue { __typename number title url }",
-  "          ... on PullRequest { __typename number title url }",
   "        }",
   "      }",
   "    }",
@@ -407,83 +358,6 @@ function resolveFromItems(items, itemRef, repo) {
   return describeItem(match);
 }
 
-// ── Resolve an item in a project by reference (number or node ID) ──────
-
-async function resolveProjectItem(projectId, itemRef, owner, repoName, repo, env, runChild) {
-  let itemId;
-  let issueNumber = null;
-  let prNumber = null;
-  let status = null;
-
-  if (itemRef.kind === "id") {
-    // Direct item node ID lookup
-    const itemPayload = await ghGraphql(GET_PROJECT_ITEM, {
-      projectId,
-      itemId: itemRef.value,
-    }, env, runChild);
-    const item = itemPayload?.data?.node?.item;
-    if (!item) {
-      throw Object.assign(
-        new Error(`Item "${itemRef.value}" not found in project`),
-        { code: "ITEM_NOT_FOUND" },
-      );
-    }
-    itemId = item.id;
-    const fvs = item.fieldValues?.nodes ?? [];
-    for (const fv of fvs) {
-      if (fv && fv.field && fv.field.name === "Status") {
-        status = fv.name;
-        break;
-      }
-    }
-    if (item.content) {
-      if (item.content.__typename === "Issue") {
-        issueNumber = item.content.number;
-      } else {
-        prNumber = item.content.number;
-      }
-    }
-  } else {
-    // Look up by issue/PR number in the project (paginated)
-    const targetNumber = itemRef.value;
-    const allItems = await fetchAllItems(projectId, env, runChild);
-
-    // Filter by matching repo AND number exactly
-    const matchingItems = allItems.filter((it) => {
-      if (!it.content) return false;
-      if (it.content.repository?.nameWithOwner !== repo) return false;
-      return it.content.number === targetNumber;
-    });
-
-    if (matchingItems.length === 0) {
-      throw Object.assign(
-        new Error(`Item #${targetNumber} not found in project for repo "${repo}"`),
-        { code: "ITEM_NOT_FOUND" },
-      );
-    }
-
-    // Use the first match (by position order)
-    const match = matchingItems[0];
-    itemId = match.id;
-    const fvs = match.fieldValues?.nodes ?? [];
-    for (const fv of fvs) {
-      if (fv && fv.field && fv.field.name === "Status") {
-        status = fv.name;
-        break;
-      }
-    }
-    if (match.content) {
-      if (match.content.__typename === "Issue") {
-        issueNumber = match.content.number;
-      } else {
-        prNumber = match.content.number;
-      }
-    }
-  }
-
-  return { itemId, issueNumber, prNumber, status };
-}
-
 // ── Exit code classification ────────────────────────────────────────────
 
 function classifyExitCode(err) {
@@ -519,16 +393,21 @@ function executePosition(projectId, itemId, afterId) {
 
 // ── Legacy flag form: --item [--after] ────────────────────────────────────
 
-async function mainFlagForm(args, { env, child, repo, owner, repoName, project }) {
+async function mainFlagForm(args, { env, child, repo, project }) {
   const itemRef = parseItemRef(args.item);
   let afterRef = null;
   if (args.after !== undefined) afterRef = parseItemRef(args.after, "--after");
 
-  const item = await resolveProjectItem(project.id, itemRef, owner, repoName, repo, env, child);
+  // Fetch the board item list ONCE, then resolve item/afterItem (and the
+  // dry-run snapshot) from that single list — mirrors mainSubcommand, avoiding
+  // up to 3 full-board re-scans (item lookup, after-item lookup, before snapshot).
+  const items = await fetchAllItems(project.id, env, child);
+
+  const item = resolveFromItems(items, itemRef, repo);
 
   let afterItem = null;
   if (afterRef) {
-    afterItem = await resolveProjectItem(project.id, afterRef, owner, repoName, repo, env, child);
+    afterItem = resolveFromItems(items, afterRef, repo);
     if (afterItem.itemId === item.itemId) {
       throw Object.assign(new Error("Cannot reorder an item after itself"), { code: "INVALID_AFTER" });
     }
@@ -538,7 +417,8 @@ async function mainFlagForm(args, { env, child, repo, owner, repoName, project }
 
   if (args.dryRun) {
     // Include the before snapshot for parity with the subcommand dry-run form.
-    const before = await snapshotOrder(project.id, repo, item.status ?? null, env, child);
+    // Reuses the already-fetched list (no extra fetch).
+    const before = snapshotFromItems(items, repo, item.status ?? null);
     return {
       ok: true,
       dryRun: true,
@@ -712,7 +592,7 @@ async function mainSubcommand(args, { env, child, repo, project }) {
 async function main(args, { env = process.env, runChild } = {}) {
   const child = runChild ?? _runChild;
   const repo = validateRepo(args.repo);
-  const [owner, repoName] = repo.split("/");
+  const [owner] = repo.split("/");
   const selector = resolveProjectSelector(args);
 
   // Fail closed: the legacy flag form takes no positional arguments. A stray
@@ -729,7 +609,7 @@ async function main(args, { env = process.env, runChild } = {}) {
   if (args._subcommand) {
     return mainSubcommand(args, { env, child, repo, project });
   }
-  return mainFlagForm(args, { env, child, repo, owner, repoName, project });
+  return mainFlagForm(args, { env, child, repo, project });
 }
 
 // ── CLI entrypoint ──────────────────────────────────────────────────────

--- a/test/projects/list-parked-unrefined-items.test.mjs
+++ b/test/projects/list-parked-unrefined-items.test.mjs
@@ -56,6 +56,22 @@ function boardRunChild({ columns = {}, bodies = {}, optionNames = ["Backlog", "N
 
 const run = (child) => main({ repo: "o/r", project: "7" }, { runChild: child, cwd: ISOLATED_CWD });
 
+// Wraps boardRunChild's `gh issue view` branch with a per-issue artificial
+// delay (ms), so within a concurrent chunk the gh calls SETTLE in a different
+// order than the items were listed. Used to prove the bounded-concurrency
+// path stitches results back into input order (index-stable) rather than
+// push-on-settle order.
+function delayedBoardRunChild({ delays = {}, ...opts }) {
+  const base = boardRunChild(opts);
+  return async (cmd, argv, env) => {
+    if (cmd === "gh" && argv[0] === "issue" && argv[1] === "view") {
+      const ms = delays[Number(argv[2])] ?? 0;
+      if (ms > 0) await new Promise((resolve) => setTimeout(resolve, ms));
+    }
+    return base(cmd, argv, env);
+  };
+}
+
 describe("list-parked-unrefined-items (#1258 discovery helper)", () => {
   it("returns un-refined issues parked in the park column, with reason + missing", async () => {
     const r = await run(boardRunChild({
@@ -153,5 +169,23 @@ describe("list-parked-unrefined-items (#1258 discovery helper)", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("preserves input order across concurrency chunks even when gh calls settle out of order (7 items, bound 4)", async () => {
+    // 7 items -> two chunks under the bound-4 limiter (4 then 3). Within EACH
+    // chunk, the first item's gh call is the slowest, so it SETTLES last while
+    // its siblings settle first — if the concurrency stitch ever regressed to
+    // push-on-settle instead of index-stable results[i+j], this item would land
+    // at the end of its chunk instead of its input position.
+    const issues = [1, 2, 3, 4, 5, 6, 7];
+    const columns = { Backlog: issues.map((n) => ({ issueNumber: n, title: `I${n}` })) };
+    const bodies = Object.fromEntries(issues.map((n) => [n, UNREFINED_BODY]));
+    // Chunk 1 = [1,2,3,4]: issue 1 resolves last. Chunk 2 = [5,6,7]: issue 5
+    // resolves last. Actual settle order per chunk: 2,3,4,1 then 6,7,5.
+    const delays = { 1: 30, 2: 0, 3: 5, 4: 10, 5: 20, 6: 0, 7: 5 };
+
+    const r = await run(delayedBoardRunChild({ columns, bodies, delays }));
+
+    assert.deepEqual(r.items.map((i) => i.issueNumber), issues);
   });
 });

--- a/test/projects/reorder-queue-item.test.mjs
+++ b/test/projects/reorder-queue-item.test.mjs
@@ -79,32 +79,6 @@ function emptyItemsResponse() {
   return getItemsByContentResponse([]);
 }
 
-function getProjectItemResponse(itemId, itemContent) {
-  return {
-    data: {
-      node: {
-        item: {
-          id: itemId,
-          fieldValues: {
-            nodes: [
-              {
-                field: { id: "PVTSSF_status", name: "Status" },
-                name: "Backlog",
-              },
-            ],
-          },
-          content: itemContent ?? {
-            __typename: "Issue",
-            number: 630,
-            title: "Test Issue",
-            url: "https://github.com/mfittko/dev-loops/issues/630",
-          },
-        },
-      },
-    },
-  };
-}
-
 function updatePositionResponse() {
   return {
     data: {
@@ -182,14 +156,9 @@ describe("reorder-queue-item — move to top (no --after)", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      {
-        payload: getProjectItemResponse("PVTI_item_x", {
-          __typename: "PullRequest",
-          number: 88,
-          title: "PR",
-          url: "...",
-        }),
-      },
+      // Single fetch-all-items call resolves the id-kind ref (mainFlagForm
+      // no longer issues a separate GET_PROJECT_ITEM lookup).
+      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_x", 88, "PullRequest")]) },
       { payload: updatePositionResponse() },
     ];
     const runChild = mockRunChild(responses);
@@ -223,14 +192,8 @@ describe("reorder-queue-item — move to top (no --after)", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      {
-        payload: getProjectItemResponse(hyphenId, {
-          __typename: "PullRequest",
-          number: 88,
-          title: "PR",
-          url: "...",
-        }),
-      },
+      // Single fetch-all-items call resolves the id-kind ref.
+      { payload: getItemsByContentResponse([makeItemNode(hyphenId, 88, "PullRequest")]) },
       { payload: updatePositionResponse() },
     ];
 
@@ -249,8 +212,11 @@ describe("reorder-queue-item — move after another item", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
-      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_625", 625)]) },
+      // Single fetch-all-items call resolves BOTH item and after-item.
+      { payload: getItemsByContentResponse([
+        makeItemNode("PVTI_item_630", 630),
+        makeItemNode("PVTI_item_625", 625),
+      ]) },
       { payload: updatePositionResponse() },
     ];
     const runChild = mockRunChild(responses);
@@ -282,8 +248,8 @@ describe("reorder-queue-item — move after another item", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
+      // Single fetch-all-items call: item 630 is present, after-ref 999 is not.
       { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
-      { payload: emptyItemsResponse() },
     ];
     const runChild = mockRunChild(responses);
 
@@ -300,7 +266,7 @@ describe("reorder-queue-item — move after another item", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
+      // Single fetch-all-items call; item and after-ref both resolve to 630.
       { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
     ];
     const runChild = mockRunChild(responses);
@@ -428,8 +394,12 @@ describe("reorder-queue-item — mutation input construction", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse([makeItemNode("PVTI_item_630", 630)]) },
-      { payload: getProjectItemResponse("PVTI_item_625", makeItemContent(625)) },
+      // Single fetch-all-items call resolves item 630 AND the after-ref (a
+      // node ID, "PVTI_item_625") from the same list.
+      { payload: getItemsByContentResponse([
+        makeItemNode("PVTI_item_630", 630),
+        makeItemNode("PVTI_item_625", 625),
+      ]) },
       { payload: updatePositionResponse() },
     ];
     const runChild = mockRunChild(responses);

--- a/test/projects/reorder-subcommands.test.mjs
+++ b/test/projects/reorder-subcommands.test.mjs
@@ -344,8 +344,7 @@ describe("reorder — legacy flag form", () => {
     const responses = [
       { payload: userPayload() },
       { payload: listUserProjectsResponse([EXISTING_PROJECT]) },
-      { payload: getItemsByContentResponse(items) }, // resolveProjectItem (number)
-      { payload: getItemsByContentResponse(items) }, // before snapshot
+      { payload: getItemsByContentResponse(items) }, // single fetch: resolve + before snapshot
     ];
     const runChild = mockRunChild(responses);
 
@@ -357,7 +356,15 @@ describe("reorder — legacy flag form", () => {
     assert.ok(result.ok);
     assert.strictEqual(result.dryRun, true);
     assert.strictEqual(result.mutations.length, 1);
-    assert.ok(Array.isArray(result.before), "before snapshot present in legacy dry-run");
+    assert.strictEqual(result.mutations[0].variables.itemId, "PVTI_b");
+    assert.deepStrictEqual(result.before, [
+      { itemId: "PVTI_b", issueNumber: 630, prNumber: null, status: "Next Up" },
+    ]);
+    // Only ONE fetch-all-items call (no separate resolve + snapshot fetch).
+    assert.strictEqual(
+      runChild.calls.filter((args) => args.some((a) => typeof a === "string" && a.startsWith("query="))).length,
+      3,
+    );
     assert.strictEqual(countMutations(runChild.calls), 0);
   });
 });


### PR DESCRIPTION
## Objective

Child 7 of the simplification epic #1689: migrate the projects-surface `gh` wrappers onto the shared helper landed in #1695, deleting the duplicated local wrapper bodies. Net **-229 lines** (12 files: 156 insertions, 385 deletions), including a small cross-chunk order-preservation test added for the AC7 concurrency change and two comment-accuracy clarifications from the Copilot round.

Closes #1696.

## In scope (done)

- Removed the local `ghGraphql` definition and routed every GraphQL call through `@dev-loops/core/github/gh` (scripts) / `../github/gh.mjs` (in-package) in all 7 files:
  - `scripts/projects/ensure-queue-board.mjs`, `reorder-queue-item.mjs`, `add-queue-item.mjs`, `archive-done-items.mjs`
  - `packages/core/src/projects/move-queue-item.mjs`, `list-queue-items.mjs`
  - `packages/core/src/loop/queue-board-sync.mjs`
- Removed the local `ghJson` in `scripts/projects/reconcile-queue.mjs` in favor of the shared helper (this child claims it; the rest of the ghJson/runGhJson copies are #1697).
- `add-queue-item`'s `allowErrors: true` call preserved via the shared helper's `{ allowErrors }` option (no local wrapper).
- `reorder-queue-item` `mainFlagForm` now fetches the board item list exactly once via `fetchAllItems` and resolves item / afterItem / dry-run snapshot from that one list (mirrors `mainSubcommand`; drops up to 3 full-board re-scans). Deleted the now-dead `resolveProjectItem` + `GET_PROJECT_ITEM` path.
- `list-parked-unrefined-items` and `reconcile-queue` (`gatherLiveFacts`) run their per-item `gh` calls at a fixed concurrency bound (4) via a small inline chunked limiter; per-item failures stay best-effort and output order matches the sequential version. No new dependency.

## Invariants preserved

- Error contract byte-exact: `gh api graphql failed` / `GH_API_ERROR`, `GraphQL errors:` / `GRAPHQL_ERROR`, `gh command failed` — all pinned test mocks pass.
- `runChild` injection still routes every `gh` invocation in every migrated file (explicit-runChild and local-`_runChild` call styles both kept).
- Migration is argv-transparent: only the two `reorder` test files changed, and only because AC6's fetch-once is an intended call-sequence change (assertions still verify resolved refs, mutation input, and now assert exactly one board-list fetch). All other suites' mocks are untouched.

## Dropped (noted per the issue's guidance)

- The unverified "Sweep follow-ups" (lift shared `resolveOwner`/`listAllProjects`/`fetchAllItems`, aliased user/org owner query, alias-batched archive mutations) were skipped: they change gh call count/order and would break sequence-based mocks without clear payoff. Left for a later pass if warranted.
- `reconcile-queue` `main()`'s per-item `move()` loop stays sequential (each move composes 5+ internal gh calls; parallelizing it is out of this AC's scope).

## Verification

- `node --test test/projects/` → 372 pass, 0 fail
- `node --test packages/core/test/queue-board-sync.test.mjs` → 45 pass, 0 fail
- `npm test` (full verify) → exit 0, 0 failures (core 2789, scripts 4167, assets 285, extension 126, dev-loop 38, pack 1, docs + workflows clean)

## Acceptance criteria

- [x] No local `ghGraphql` definition remains in the 7 files; every GraphQL call routes through the shared helper.
- [x] The local `ghJson` in `reconcile-queue.mjs` removed in favor of the shared helper.
- [x] `GH_API_ERROR` / `GRAPHQL_ERROR` thrown with the pinned prefixes at every migrated site (pinned tests pass).
- [x] `add-queue-item`'s `allowErrors` behavior preserved via the shared-helper option.
- [x] Injected `runChild` still routes every gh invocation in migrated files.
- [x] `reorder-queue-item` `mainFlagForm` fetches the board item list exactly once and resolves all refs + the dry-run snapshot from it.
- [x] `list-parked-unrefined-items` and `reconcile-queue` per-item gh calls run concurrently with a fixed bound; per-item failures best-effort; output order preserved.
- [x] No new dependency added.

## AC / DoD matrix

| Acceptance criterion | Verified by (definition of done) |
|---|---|
| No local `ghGraphql` def in 7 files; all route through shared helper | `node --test test/projects/`; `queue-board-sync.test.mjs`; `grep` shows no local defs |
| Local `ghJson` in `reconcile-queue.mjs` removed | `test/projects/` reconcile-queue suite |
| `GH_API_ERROR`/`GRAPHQL_ERROR` at every migrated site | pinned `test/projects/` suites (ensure-queue-board, add-queue-item, move-queue-item, list-queue-items) |
| `add-queue-item` `allowErrors` preserved | add-queue-item suite |
| Injected `runChild` routes calls, migration mocks unmodified | `test/projects/` suites; `queue-board-sync.test.mjs` |
| `reorder-queue-item` `mainFlagForm` fetches board list once | reorder-queue-item + reorder-subcommands suites (assert exactly one board-list fetch) |
| bounded-concurrent per-item calls, order preserved | list-parked-unrefined-items + reconcile-queue suites |
| no new dependency | full `npm test` green |

## Non-goals

- The shared helper itself (#1695, landed).
- Non-projects wrapper migrations — scripts/github, scripts/loop (beyond queue-board-sync), scripts/refine (#1697).
- Gate-tooling dedup (#1698), core/loop dedup beyond queue-board-sync (#1699), test-fixture consolidation (#1700).
