### PR TITLE
refactor(scripts): migrate ghJson/runGhJson/ghApiJson copies to shared helper (closes #1697)

### DIFF
--- a/scripts/github/detect-checkpoint-evidence.mjs
+++ b/scripts/github/detect-checkpoint-evidence.mjs
@@ -4,7 +4,6 @@ import {
   buildParseError,
   formatCliError,
   isDirectCliRun,
-  parseJsonText,
   normalizeVerdictSurface,
   parseReviewThreads,
   summarizeGateReviewCommentMarkers,
@@ -25,6 +24,7 @@ import { fetchGithubReviewThreadsPayload } from "./capture-review-threads.mjs";
 import { countUnresolvedGateAuthoredThreadsFromRawNodes } from "./_gate-finding-surface.mjs";
 import { isGhBinaryMissing, restFetchPrView, restGetPaginatedJson } from "./_gh-rest-fallback.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson } from "@dev-loops/core/github/gh";
 import { FANOUT_PROVENANCE_MIN_REVIEWERS, GATE_FULL_LABEL, loadDevLoopConfig, resolveFanoutGroups, resolveGateAngleContract, resolveGateConfig, resolveLightMode, resolveRejectForeignAngles, resolveRequireFanoutEvidence, resolveRequireFanoutProvenance } from "@dev-loops/core/config";
 import { FANOUT_UNAVAILABLE_MESSAGE, GATE_CONFIG_KEY, checkFanoutAngleCoverage, countFreshDispatchUnits, fanoutReviewerPairingError, freshAngleNames, provenanceConsistencyError } from "@dev-loops/core/loop/gate-fanin";
 import { detectMergeBaseScope, isEligibleForLightMode } from "../loop/detect-change-scope.mjs";
@@ -212,20 +212,14 @@ export function parseDetectCheckpointEvidenceCliArgs(argv) {
 // and fails for any other reason (auth, rate limit, a real 404) is a genuine
 // error and is never silently retried through the REST fallback (#1358).
 async function runGhJson(args, { env, ghCommand, runChild = defaultRunChild, restFallback = null }) {
-  let result;
   try {
-    result = await runChild(ghCommand, args, env);
+    return await ghJson(args, { env, ghCommand, runChild });
   } catch (error) {
     if (restFallback && isGhBinaryMissing(error)) {
       return await restFallback();
     }
     throw error;
   }
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 2).join(" ")}` });
 }
 function normalizeIssueCommentsPayload(payload) {
   if (!Array.isArray(payload)) {

--- a/scripts/github/fetch-ci-logs.mjs
+++ b/scripts/github/fetch-ci-logs.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson } from "@dev-loops/core/github/gh";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -105,15 +106,6 @@ export function parseFetchCiLogsCliArgs(argv) {
   return options;
 }
 
-async function ghJson(run, ghCommand, args, env, label) {
-  const result = await run(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`${label} failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout, { label });
-}
-
 function tailLines(text, n) {
   const lines = String(text).replace(/\r?\n$/u, "").split(/\r?\n/u);
   return lines.slice(Math.max(0, lines.length - n)).join("\n");
@@ -123,11 +115,8 @@ export async function fetchCiLogs(options, { env = process.env, ghCommand = "gh"
   // 1. Resolve the PR's current head SHA — logs must be scoped to the head being
   //    evaluated, not a stale push.
   const pr = await ghJson(
-    run,
-    ghCommand,
     ["pr", "view", String(options.pr), "--repo", options.repo, "--json", "headRefOid"],
-    env,
-    "gh pr view",
+    { env, ghCommand, runChild: run, label: "gh pr view" },
   );
   const headSha = typeof pr.headRefOid === "string" ? pr.headRefOid.trim() : "";
   if (headSha.length === 0) {
@@ -136,11 +125,8 @@ export async function fetchCiLogs(options, { env = process.env, ghCommand = "gh"
 
   // 2. List Actions runs for that exact commit.
   const runs = await ghJson(
-    run,
-    ghCommand,
     ["run", "list", "--repo", options.repo, "--commit", headSha, "--json", "databaseId,name,conclusion,status"],
-    env,
-    "gh run list",
+    { env, ghCommand, runChild: run, label: "gh run list" },
   );
   if (!Array.isArray(runs)) {
     throw new Error("gh run list did not return a JSON array");

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
-import { formatCliError, isDirectCliRun, parseJsonText, sanitizeCopilotSummonTokens } from "../_core-helpers.mjs";
+import { formatCliError, isDirectCliRun, sanitizeCopilotSummonTokens } from "../_core-helpers.mjs";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { loadDevLoopConfig, resolveGatePostFindingsComments } from "@dev-loops/core/config";
 // Severity vocabulary and its most-urgent-first ordering are owned by gate-fanin.
 import { SEVERITY_ORDER, VALID_SEVERITIES, deriveDisposition, hasLocatableShape, isDefaultDeferrableSeverity, normalizeSeverity } from "@dev-loops/core/loop/gate-fanin";
@@ -752,19 +753,10 @@ export function flattenPaginatedSlurp(payload) {
   return Array.isArray(payload) ? payload : [];
 }
 
-// Shared `gh` invoke-and-parse helper: run a `gh` subcommand, fail loudly on a
-// non-zero exit (naming the command so a failure is traceable back to the
-// call site), and parse its stdout as JSON. Exported so sibling GitHub
-// scripts that only ever need a stdin-less `gh` call (no `--input -` payload)
-// can reuse this instead of re-implementing the same exit-code check.
-export async function runGhJson(args, { env, ghCommand, runChild: run = runChild }) {
-  const result = await run(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 3).join(" ")}` });
-}
+// Re-exported so sibling GitHub scripts (close-gate-findings.mjs,
+// _gate-finding-surface.mjs) can keep importing `runGhJson` from here without
+// changing their imports.
+export { runGhJson };
 
 export async function listIssueComments({ repo, pr }, { env, ghCommand, runChild: run }) {
   const payload = await runGhJson(

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun, sanitizeCopilotSummonTokens } from "../_core-helpers.mjs";
 import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { loadDevLoopConfig, resolveGatePostFindingsComments } from "@dev-loops/core/config";

--- a/scripts/github/probe-ci-status.mjs
+++ b/scripts/github/probe-ci-status.mjs
@@ -4,6 +4,7 @@ import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helper
 import { parseArgs } from "node:util";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson } from "@dev-loops/core/github/gh";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import {
   summarizeHeadScopedCheckRunsSignal,
@@ -151,19 +152,6 @@ function parsePositiveMs(raw, flag) {
   return value;
 }
 
-async function ghJson(ghCommand, args, env) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  try {
-    return JSON.parse(result.stdout);
-  } catch {
-    throw new Error(`Invalid JSON from gh: ${result.stdout.trim() || "<empty>"}`);
-  }
-}
-
 function extractPrVisibleCheckNames(statusCheckRollup) {
   if (!Array.isArray(statusCheckRollup)) return [];
   return statusCheckRollup
@@ -188,9 +176,8 @@ function extractFailedStatusContexts(statuses) {
 
 async function fetchPrHeadSha({ repo, pr }, { env, ghCommand }) {
   const payload = await ghJson(
-    ghCommand,
     ["pr", "view", String(pr), "--repo", repo, "--json", "headRefOid,statusCheckRollup"],
-    env,
+    { env, ghCommand },
   );
   const headSha = typeof payload.headRefOid === "string" ? payload.headRefOid.trim() : "";
   if (headSha.length === 0) {

--- a/scripts/github/ready-for-review.mjs
+++ b/scripts/github/ready-for-review.mjs
@@ -4,6 +4,7 @@ import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { fetchDraftGateEvidence } from "./_gate-finding-surface.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { loadDevLoopConfig, resolveGateConfig } from "@dev-loops/core/config";
 import { findBlockingTitleMarkers } from "@dev-loops/core/loop/pr-title-markers";
 import { syncBoardStatus as realSyncBoardStatus, loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
@@ -63,12 +64,6 @@ export function parseReadyForReviewCliArgs(argv) {
   parseRepoSlug(opts.repo);
   if (opts.waiveSizeBudget && !opts.reason) throw parseError("--waive-size-budget requires --reason <text>");
   return opts;
-}
-
-async function runGhJson(args, { env, ghCommand }) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) throw new Error(`gh command failed: ${result.stderr.trim() || `exit code ${result.code}`}`);
-  return parseJsonText(result.stdout);
 }
 
 async function fetchPrState({ repo, pr }, { env, ghCommand }) {

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -8,6 +8,7 @@ import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { parseAllowedRefsCsv, parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { loadPrGateCoordinationContext } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { buildFanoutEnforcement, evaluateInlineFanoutMode } from "./detect-checkpoint-evidence.mjs";
 import { evaluatePrGateCoordination, PR_CHECKPOINT_ACTION } from "@dev-loops/core/loop/pr-gate-coordination";
@@ -1294,14 +1295,6 @@ function detectStaleGateCommentWarning({ strict, headSha, gate }) {
     return null;
   }
   return `A gate comment for \`${gate}\` already exists on a different head SHA \`${strict.headSha}\` (comment ${strict.commentId}). The old comment is stale for the current head.`;
-}
-async function runGhJson(args, { env, ghCommand, runChild = defaultRunChild }) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout, { label: `gh ${args.slice(0, 3).join(" ")}` });
 }
 function parseCommentMutationResponse(payload) {
   const commentId = Number.isInteger(payload?.id) ? payload.id : null;

--- a/scripts/github/withdraw-copilot-review-request.mjs
+++ b/scripts/github/withdraw-copilot-review-request.mjs
@@ -57,6 +57,7 @@ import { isCopilotLogin, SUBMITTED_REVIEW_STATES } from "@dev-loops/core/github/
 import { parseReviewThreads } from "@dev-loops/core/github/review-threads";
 import { REVIEW_THREADS_QUERY } from "./capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson } from "@dev-loops/core/github/gh";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { classifyDeltaSinceLastReview, getLastCopilotReviewHeadSha } from "./request-copilot-review.mjs";
@@ -183,20 +184,8 @@ function parseCliArgs(argv) {
   return args;
 }
 
-async function ghJson(runChild, env, ghArgs) {
-  const result = await runChild("gh", ghArgs, env);
-  if (result.code !== 0) {
-    throw new Error(`gh command failed: ${result.stderr.trim() || `exit code ${result.code}`}`);
-  }
-  try {
-    return JSON.parse(result.stdout);
-  } catch {
-    throw new Error(`Invalid JSON from gh: ${result.stdout.trim() || "<empty>"}`);
-  }
-}
-
 async function fetchCopilotRequested(args, { env, runChild }) {
-  const requested = await ghJson(runChild, env, ["api", `repos/${args.repo}/pulls/${args.pr}/requested_reviewers`]);
+  const requested = await ghJson(["api", `repos/${args.repo}/pulls/${args.pr}/requested_reviewers`], { env, runChild });
   const users = Array.isArray(requested?.users) ? requested.users : [];
   return users.some((user) => isCopilotLogin(user?.login));
 }
@@ -204,9 +193,9 @@ async function fetchCopilotRequested(args, { env, runChild }) {
 async function collectState(args, { env, runChild }) {
   const copilotRequested = await fetchCopilotRequested(args, { env, runChild });
 
-  const pr = await ghJson(runChild, env, [
+  const pr = await ghJson([
     "pr", "view", String(args.pr), "--repo", args.repo, "--json", "headRefOid,reviews",
-  ]);
+  ], { env, runChild });
   const reviews = Array.isArray(pr?.reviews) ? pr.reviews : [];
   const submittedCopilotReviews = reviews.filter(
     (review) => isCopilotLogin(review?.author?.login)
@@ -230,13 +219,13 @@ async function collectState(args, { env, runChild }) {
   // missing isResolved as unresolved, so an unfamiliar payload refuses rather
   // than reading as clean.
   const { owner, name } = parseRepoSlug(args.repo);
-  const threadsPayload = await ghJson(runChild, env, [
+  const threadsPayload = await ghJson([
     "api", "graphql",
     "-f", `query=${REVIEW_THREADS_QUERY}`,
     "-F", `owner=${owner}`,
     "-F", `name=${name}`,
     "-F", `pr=${args.pr}`,
-  ]);
+  ], { env, runChild });
   const unresolvedThreadCount = parseReviewThreads(threadsPayload).summary.unresolvedThreads;
 
   return {

--- a/scripts/loop/_inspect-run-viewer-adapter.mjs
+++ b/scripts/loop/_inspect-run-viewer-adapter.mjs
@@ -1,6 +1,6 @@
 import { parseRepoSlugParts } from "@dev-loops/core/github/repo-slug";
 import { inspectRun } from "./inspect-run.mjs";
-import { runChild } from "../_cli-primitives.mjs";
+import { ghJson } from "@dev-loops/core/github/gh";
 const ASSIGNED_PR_LIST_CACHE_TTL_MS = 15_000;
 const DEFAULT_UPDATED_WITHIN_DAYS = 7;
 const DEFAULT_RESULT_LIMIT = 25;
@@ -196,17 +196,8 @@ export function normalizeInspectionTarget(target) {
     pr: parsePositivePr(target.pr),
   };
 }
-export function createInspectionViewerAdapter({ inspectRunImpl = inspectRun, runGhJsonImpl = null, nowImpl = () => Date.now() } = {}) {
-  const runGhJson = async (args, { env = process.env, ghCommand = "gh" } = {}) => {
-    if (typeof runGhJsonImpl === "function") {
-      return runGhJsonImpl(args, { env, ghCommand });
-    }
-    const result = await runChild(ghCommand, args, env);
-    if (result.code !== 0) {
-      throw new Error(`Command failed: ${ghCommand} ${args.join(" ")}\n${result.stderr.trim() || "(no stderr output)"}`);
-    }
-    return parseGhJsonOutput(result.stdout);
-  };
+export function createInspectionViewerAdapter({ inspectRunImpl = inspectRun, runGhJsonImpl = ghJson, nowImpl = () => Date.now() } = {}) {
+  const runGhJson = (args, { env = process.env, ghCommand = "gh" } = {}) => runGhJsonImpl(args, { env, ghCommand });
   const toRepoSlug = (repository) => {
     if (repository === null || typeof repository !== "object") {
       return null;

--- a/scripts/loop/detect-reviewer-loop-state.mjs
+++ b/scripts/loop/detect-reviewer-loop-state.mjs
@@ -5,6 +5,7 @@ import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.m
 import { formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { SUBMITTED_REVIEW_STATES } from "@dev-loops/core/github/copilot-helpers";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import {
   interpretReviewerLoopState,
   normalizeReviewerSnapshot,
@@ -115,18 +116,6 @@ export function parseDetectReviewerCliArgs(argv) {
     throw new Error("Provide either --input <path> or --repo <owner/name> --pr <number>");
   }
   return options;
-}
-async function runGhJson(args, { env, ghCommand }) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  try {
-    return JSON.parse(result.stdout);
-  } catch {
-    throw new Error(`Invalid JSON from gh: ${result.stdout.trim() || "<empty>"}`);
-  }
 }
 async function fetchPrView({ repo, pr }, deps) {
   const result = await runChild(

--- a/scripts/loop/inspect-run.mjs
+++ b/scripts/loop/inspect-run.mjs
@@ -2,10 +2,11 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, parseJsonText, parseReviewThreads } from "../_core-helpers.mjs";
 import { fetchGithubReviewThreadsPayload } from "../github/capture-review-threads.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { readExistingCheckpoint } from "./_checkpoint-io.mjs";
 import { loadCopilotEvidence, loadReviewerEvidence } from "./_loop-evidence.mjs";
 import { interpretOuterLoopState } from "@dev-loops/core/loop/conductor-routing";
@@ -146,18 +147,6 @@ export function parseInspectRunCliArgs(argv) {
     }
   }
   return options;
-}
-async function runGhJson(args, { env, ghCommand }) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  try {
-    return JSON.parse(result.stdout);
-  } catch {
-    throw new Error(`Invalid JSON from gh: ${result.stdout.trim() || "<empty>"}`);
-  }
 }
 function normalizeTimelineReviewRequestEvents(payload) {
   const events = Array.isArray(payload) ? payload : [];

--- a/scripts/loop/pre-pr-ready-gate.mjs
+++ b/scripts/loop/pre-pr-ready-gate.mjs
@@ -3,11 +3,11 @@ import {
   buildParseError,
   formatCliError,
   isDirectCliRun,
-  parseJsonText,
 } from "../_core-helpers.mjs";
-import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { fetchDraftGateEvidence } from "../github/_gate-finding-surface.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson as runGhJson } from "@dev-loops/core/github/gh";
 import { parseArgs } from "node:util";
 import { evaluatePrSizeBudget as realEvaluatePrSizeBudget } from "./check-size-budget.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
@@ -79,15 +79,6 @@ export function parsePrePrReadyGateCliArgs(argv) {
     throw parseError(error instanceof Error ? error.message : String(error));
   }
   return options;
-}
-
-async function runGhJson(args, { env, ghCommand }) {
-  const result = await runChild(ghCommand, args, env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh command failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout);
 }
 
 async function fetchPrState({ repo, pr }, { env, ghCommand }) {

--- a/scripts/refine/_refine-helpers.mjs
+++ b/scripts/refine/_refine-helpers.mjs
@@ -3,8 +3,9 @@ import { readFile } from "node:fs/promises";
 
 import { buildParseError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parseArgs } from "node:util";
-import { parsePositiveInteger, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, requireTokenValue } from "../_cli-primitives.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
+import { ghJson } from "@dev-loops/core/github/gh";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
 export const FORBIDDEN_PROSE_PATTERNS = [
@@ -130,15 +131,6 @@ export async function loadTreeFromInput(inputPath) {
   return normalizeTreePayload(parseJsonText(raw));
 }
 
-async function ghApiJson(args, { ghCommand = "gh", env = process.env } = {}) {
-  const result = await runChild(ghCommand, ["api", ...args], env);
-  if (result.code !== 0) {
-    const detail = result.stderr.trim() || `exit code ${result.code}`;
-    throw new Error(`gh api command failed: ${detail}`);
-  }
-  return parseJsonText(result.stdout);
-}
-
 export async function loadTreeOnline({ issue, repo, cwd = process.cwd(), ghCommand = "gh", env = process.env }) {
   const resolvedRepo = typeof repo === "string" && repo.trim().length > 0
     ? repo.trim()
@@ -160,9 +152,9 @@ export async function loadTreeOnline({ issue, repo, cwd = process.cwd(), ghComma
       continue;
     }
 
-    const issuePayload = await ghApiJson([
-      `repos/${owner}/${name}/issues/${current.number}`,
-    ], { ghCommand, env });
+    const issuePayload = await ghJson([
+      "api", `repos/${owner}/${name}/issues/${current.number}`,
+    ], { ghCommand, env, label: "gh api command" });
 
     const number = issuePayload?.number;
     if (!Number.isInteger(number) || number <= 0) {
@@ -183,9 +175,9 @@ export async function loadTreeOnline({ issue, repo, cwd = process.cwd(), ghComma
       existing.parentNumber = current.parentNumber;
     }
 
-    const subIssuesPayload = await ghApiJson([
-      `repos/${owner}/${name}/issues/${number}/sub_issues`,
-    ], { ghCommand, env });
+    const subIssuesPayload = await ghJson([
+      "api", `repos/${owner}/${name}/issues/${number}/sub_issues`,
+    ], { ghCommand, env, label: "gh api command" });
 
     const currentIssue = byNumber.get(number);
     const children = [];


### PR DESCRIPTION
## Objective

Child 8 of the simplification epic #1689 (sibling of #1696): migrate the remaining `ghJson`/`runGhJson`/`ghApiJson` copies in scripts/github, scripts/loop, and scripts/refine onto the shared helper from #1695, deleting the duplicated local bodies. Net **-112 lines** (12 files: 39 insertions, 151 deletions).

Closes #1697.

## In scope (done)

Deleted the local body and routed every call site through `ghJson` from `@dev-loops/core/github/gh` in 12 files:

- `scripts/github/probe-ci-status.mjs`, `fetch-ci-logs.mjs`, `upsert-checkpoint-verdict.mjs`, `withdraw-copilot-review-request.mjs`, `ready-for-review.mjs`
- `scripts/loop/pre-pr-ready-gate.mjs`, `inspect-run.mjs`, `detect-reviewer-loop-state.mjs`
- `scripts/refine/_refine-helpers.mjs` (`ghApiJson` → `ghJson(["api", ...], { label: "gh api command" })`)
- plus the three files carrying a sanctioned residual (below)

`scripts/projects/reconcile-queue.mjs` was already migrated by #1696 (now on main); re-verified at pickup and left untouched.

## Three sanctioned residuals

1. `scripts/github/detect-checkpoint-evidence.mjs` — keeps an ~8-line `runGhJson` wrapper that routes `isGhBinaryMissing(error)` → `restFallback` around the shared `ghJson`. ENOENT-only: any other `gh` failure still throws (the #1358 contract), never silently retried through REST.
2. `scripts/github/post-gate-findings.mjs` — the local body becomes a one-line re-export (`import { ghJson as runGhJson }` + `export { runGhJson }`), so `close-gate-findings.mjs` and `_gate-finding-surface.mjs` keep importing `runGhJson` from here with zero import changes.
3. `scripts/loop/_inspect-run-viewer-adapter.mjs` — keeps the ~3-line `runGhJsonImpl` injection shim whose default delegates to the shared helper; `parseGhJsonOutput` stays exported.

## Preserved invariants

- Exit-failure prefix `gh command failed: <stderr|exit code N>` byte-identical; `fetch-ci-logs` per-call `${label} failed:` and `_refine-helpers` `gh api command failed:` reproduced via the shared helper's `label` option.
- The anchored `detect-reviewer-loop-state` pin `/^gh command failed: unexpected extra gh call #2: /` still holds; `parseGhJsonOutput`'s `Invalid JSON from gh:` pin passes.
- Bespoke paths untouched: `detect-reviewer-loop-state` `fetchPrView` null-on-missing-PR runChild, `withdraw-copilot-review-request`'s inline `gh pr edit --remove-reviewer` block, and the ENOENT-only `restFallback` contract.
- `runChild` injection preserved at every migrated call site; no test file changed.

## Verification

- `node --test` over all pinned suites (detect-checkpoint-evidence, _gh-rest-fallback, withdraw-copilot-review-request, post-gate-findings, detect-reviewer-loop-state, inspect-run-viewer-client, probe-ci-status, fetch-ci-logs, ready-for-review, upsert-checkpoint-verdict, pre-pr-ready-gate, inspect-run-unit/cli) → all green.
- `npm test` (full verify) → exit 0, 0 failures (core 2789, scripts 4167, assets 285, extension 126, dev-loop 38, pack 1, docs + workflows clean).
- grep confirms no remaining local `ghJson`/`runGhJson`/`ghApiJson` body in the 12 migrated files beyond the three sanctioned residuals. (Out of scope, deliberately untouched: the sync `ghJson(args, cwd)` helpers in `scripts/loop/info.mjs` and `scripts/loop/resolve-dev-loop-startup.mjs`, and the distinct-prefix `head-sha.mjs`/`view-pr.mjs` readers — epic follow-up candidates.)

## Acceptance criteria

- [x] Every local `ghJson`/`runGhJson`/`ghApiJson` body in the scoped files is deleted; all call sites route through the shared helper.
- [x] Only the three sanctioned residuals remain (ENOENT restFallback wrapper, re-export, injection shim).
- [x] `close-gate-findings.mjs` and `_gate-finding-surface.mjs` compile with zero import changes.
- [x] Exit-failure and per-call error prefixes byte-identical (via the `label` option).
- [x] `detect-reviewer-loop-state` anchored pin unchanged; `parseGhJsonOutput` pins pass.
- [x] Bespoke paths untouched; `detect-checkpoint-evidence` never routes non-ENOENT failures through `restFallback`.
- [x] Net diff is a deletion (~-112 lines); no new abstraction introduced.
- [x] Re-verified file:line refs at pickup (reconcile-queue already migrated by #1696 → skipped).

## AC / DoD matrix

| Acceptance criterion | Verified by (definition of done) |
|---|---|
| All local gh-JSON bodies deleted, routed through shared helper | pinned test suites green; grep shows only 3 residuals |
| Only 3 sanctioned residuals remain | grep sweep |
| close-gate-findings / _gate-finding-surface compile, zero import changes | post-gate-findings suite green; full `npm test` |
| error prefixes byte-identical (label option) | detect-reviewer-loop-state, fetch-ci-logs, _refine suites |
| detect-reviewer-loop-state anchored pin + parseGhJsonOutput pins | detect-reviewer-loop-state + inspect-run-viewer-client suites |
| bespoke paths untouched; ENOENT-only restFallback | withdraw + detect-checkpoint-evidence suites |
| net deletion, no new abstraction | full `npm test` green |

## Non-goals

- The shared helper itself (#1695) and the scripts/projects ghGraphql migration (#1696) — both landed.
- Gate-tooling vocabulary/normalizer dedup (#1698), core/loop helper dedup (#1699), test-fixture consolidation (#1700).
- `head-sha.mjs` / `view-pr.mjs` (deliberately distinct `gh pr view failed:` prefixes) — epic follow-up candidate.
