### PR TITLE
refactor(gate): dedup gate vocabulary/normalizers/path-builders + shared resolveBodyOrFile (closes #1698)

### DIFF
--- a/packages/core/src/cli/primitives.mjs
+++ b/packages/core/src/cli/primitives.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
 /**
@@ -165,6 +167,33 @@ export function runChild(command, args, env = process.env, stdinText = undefined
     child.on("error", reject);
     child.on("close", (code) => { resolve({ code, stdout, stderr }); });
   });
+}
+
+/**
+ * Resolve a `--body <text>` / `--body-file <path>` pair to the actual body
+ * string, the one file-reading step every `--body-file` CLI flag in this repo
+ * needs: read the file (or stdin, when `allowStdin` and `bodyFile === "-"`)
+ * and FAIL CLOSED (throw) on an empty/whitespace-only result, so a blank or
+ * unreadable `--body-file` can never silently clear a PR/comment body. When
+ * `bodyFile` is absent, `body` is returned unchanged (no emptiness check —
+ * callers that must reject an empty inline `--body` do that themselves,
+ * since not every caller enforces it).
+ *
+ * @param {object} input
+ * @param {string} [input.body] — inline body value, returned as-is when no bodyFile
+ * @param {string} [input.bodyFile] — path to read the body from ("-" = stdin, when allowStdin)
+ * @param {boolean} [input.allowStdin] — honor `bodyFile === "-"` as stdin (fd 0); default false
+ * @returns {Promise<string | undefined>}
+ */
+export async function resolveBodyOrFile({ body, bodyFile, allowStdin = false } = {}) {
+  if (bodyFile === undefined || bodyFile === null) return body;
+  // fs/promises readFile does not accept an integer fd, so stdin (fd 0) is
+  // read synchronously via the callback-style API, which does.
+  const content = allowStdin && bodyFile === "-" ? readFileSync(0, "utf8") : await readFile(bodyFile, "utf8");
+  if (content.trim().length === 0) {
+    throw new Error(`--body-file ${bodyFile} is empty`);
+  }
+  return content;
 }
 
 export function runCommand(command, args, { cwd = process.cwd(), env = process.env } = {}) {

--- a/packages/core/src/cli/primitives.mjs
+++ b/packages/core/src/cli/primitives.mjs
@@ -188,7 +188,7 @@ export function runChild(command, args, env = process.env, stdinText = undefined
 export async function resolveBodyOrFile({ body, bodyFile, allowStdin = false } = {}) {
   if (bodyFile === undefined || bodyFile === null) return body;
   // fs/promises readFile does not accept an integer fd, so stdin (fd 0) is
-  // read synchronously via the callback-style API, which does.
+  // read synchronously via readFileSync, which does accept one.
   const content = allowStdin && bodyFile === "-" ? readFileSync(0, "utf8") : await readFile(bodyFile, "utf8");
   if (content.trim().length === 0) {
     throw new Error(`--body-file ${bodyFile} is empty`);

--- a/scripts/_cli-primitives.mjs
+++ b/scripts/_cli-primitives.mjs
@@ -8,6 +8,7 @@ export {
   parseAllowedRefsCsv,
   parsePrNumber,
   parseIssueNumber,
+  resolveBodyOrFile,
   runChild,
   runCommand,
 } from "@dev-loops/core/cli/primitives";

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -28,6 +28,7 @@ import { buildLogPath } from "./write-gate-findings-log.mjs";
 import { BODY_EXCERPT_MAX_CHARS, fetchAllReviewThreads } from "./list-review-threads.mjs";
 import { captureParsedReviewThreads } from "./_review-thread-mutations.mjs";
 import { guardCommentBodyNoIssuePrIds } from "@dev-loops/core/github/comment-id-guard";
+import { GATE_NAMES, GATE_VERDICTS } from "./_gate-names.mjs";
 
 // Canonical filter/map for a paginated GET pulls/{pr}/reviews payload into the
 // comment-stream shape the gate summarizers consume. Validity comes from the
@@ -58,8 +59,8 @@ export function normalizePrReviewsPayload(payload) {
     }));
 }
 
-const VALID_LEDGER_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
-const VALID_GATES = new Set(["draft_gate", "pre_approval_gate"]);
+const VALID_LEDGER_VERDICTS = new Set(GATE_VERDICTS);
+const VALID_GATES = new Set(GATE_NAMES);
 
 // Findings at round <= this stay in the standard fix loop; from the next round
 // on, an open medium finding is deferred instead of re-fixed in-gate.

--- a/scripts/github/_gate-names.mjs
+++ b/scripts/github/_gate-names.mjs
@@ -4,6 +4,36 @@
 // the two can never drift.
 export const GATE_NAMES = ["draft_gate", "pre_approval_gate"];
 
+// Canonical gate-verdict vocabulary — the single source of truth shared by
+// every gate-review script that parses/validates a --verdict or ledger
+// overallVerdict value (upsert-checkpoint-verdict.mjs, _gate-finding-surface.mjs,
+// write-gate-findings-log.mjs), so the three can never drift.
+export const GATE_VERDICTS = ["clean", "findings_present", "blocked"];
+
+const GATE_NAMES_SET = new Set(GATE_NAMES);
+const GATE_VERDICTS_SET = new Set(GATE_VERDICTS);
+
 // Sentinel scopes spell the gate with dashes (draft-gate-<angle>); this is the
 // one place that derives the dashed scope prefix from a gate name.
 export const gateScopePrefix = (gate) => `${String(gate).replace(/_/g, "-")}-`;
+
+// The one normalizeGate/normalizeVerdict/normalizeHeadSha implementation,
+// shared by every CLI (--gate/--verdict/--head-sha parsing) and ledger reader
+// that previously hand-copied this trim+lowercase+membership-check. Returns
+// null for every non-member input, including any non-string (a typeof guard,
+// never String() coercion, so a non-string can never accidentally stringify
+// into a real member).
+export function normalizeGate(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return GATE_NAMES_SET.has(normalized) ? normalized : null;
+}
+
+export function normalizeVerdict(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return GATE_VERDICTS_SET.has(normalized) ? normalized : null;
+}
+
+export function normalizeHeadSha(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
+}

--- a/scripts/github/create-pr.mjs
+++ b/scripts/github/create-pr.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parseIssueNumber, runChild as _runChild } from "../_cli-primitives.mjs";
+import { parseIssueNumber, resolveBodyOrFile, runChild as _runChild } from "../_cli-primitives.mjs";
 import { resolveSettings, applyDevloopsBoard } from "../projects/_resolve-project.mjs";
 import { main as addQueueItemMain } from "../projects/add-queue-item.mjs";
 import { loadStateColumnMap, LOGICAL_COLUMN } from "@dev-loops/core/loop/queue-board-sync";
@@ -93,6 +92,10 @@ export function extractClosingIssueNumber(body) {
   if (!match) return null;
   return Number(match[1] ?? match[2]);
 }
+// Never reads stdin (`gh pr create` doesn't either — body always comes from an
+// explicit --body/--body-file), so allowStdin stays false. An unreadable or
+// empty --body-file FAILS CLOSED (throws) rather than silently substituting ""
+// (which used to let a broken/blank --body-file open a body-less PR unnoticed).
 async function resolveBody(args) {
   const bodyIdx = args.indexOf("--body");
   if (bodyIdx !== -1 && bodyIdx + 1 < args.length) {
@@ -100,14 +103,9 @@ async function resolveBody(args) {
   }
   const bodyFileIdx = args.indexOf("--body-file");
   if (bodyFileIdx !== -1 && bodyFileIdx + 1 < args.length) {
-    try {
-      const content = await readFile(args[bodyFileIdx + 1], "utf8");
-      return content;
-    } catch {
-      return "";
-    }
+    return resolveBodyOrFile({ bodyFile: args[bodyFileIdx + 1], allowStdin: false });
   }
-  return null; // unreadable → warn
+  return null; // no --body/--body-file given
 }
 // A plain string value for a single-value flag, in both the space form
 // (`--repo owner/name`) and the inline form (`--repo=owner/name`); unlike

--- a/scripts/github/edit-comment.mjs
+++ b/scripts/github/edit-comment.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { guardCommentBodyNoIssuePrIds } from "@dev-loops/core/github/comment-id-guard";
-import { parsePositiveInteger, parseAllowedRefsCsv, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePositiveInteger, parseAllowedRefsCsv, requireTokenValue, resolveBodyOrFile, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
@@ -119,19 +117,11 @@ export function parseEditCommentCliArgs(argv) {
 }
 
 async function resolveBody(options) {
-  if (options.bodyFile === undefined) {
-    if (options.body.trim().length === 0) {
-      throw new Error("--body must not be empty");
-    }
-    return options.body;
+  if (options.bodyFile === undefined && options.body.trim().length === 0) {
+    throw new Error("--body must not be empty");
   }
-  // Read stdin ("-") synchronously via fd 0 — fs/promises.readFile(0) is
-  // unreliable on this Node target (mirrors edit-issue.mjs).
-  const body = options.bodyFile === "-" ? readFileSync(0, "utf8") : await readFile(options.bodyFile, "utf8");
-  if (body.trim().length === 0) {
-    throw new Error(`--body-file ${options.bodyFile} is empty`);
-  }
-  return body;
+  // allowStdin: `--body-file -` reads stdin (fd 0), mirroring edit-issue.mjs.
+  return resolveBodyOrFile({ body: options.body, bodyFile: options.bodyFile, allowStdin: true });
 }
 
 // Update the comment via `gh api -X PATCH .../issues/comments/{id}`. Issue

--- a/scripts/github/edit-pr.mjs
+++ b/scripts/github/edit-pr.mjs
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
+import { parsePrNumber, requireTokenValue, resolveBodyOrFile, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectGrillEmbedHeading } from "@dev-loops/core/loop/issue-refinement-artifact";
 import { parseArgs } from "node:util";
@@ -176,18 +174,10 @@ export function parseEditPrCliArgs(argv) {
 }
 
 async function resolveBody(options) {
-  if (options.bodyFile === undefined) return options.body;
-  // Stdin (fd 0): the fs/promises readFile does NOT accept an integer fd, so read
-  // it synchronously via the callback-style API (which does). A real path stays on
-  // the async promise read.
-  const body =
-    options.bodyFile === "-" ? readFileSync(0, "utf8") : await readFile(options.bodyFile, "utf8");
   // Fail closed on an empty / whitespace-only file so a blank --body-file cannot
   // silently clear the PR body (USAGE promises --body/--title reject empties).
-  if (body.trim().length === 0) {
-    throw new Error(`--body-file ${options.bodyFile} is empty`);
-  }
-  return body;
+  // allowStdin: `--body-file -` reads stdin (fd 0).
+  return resolveBodyOrFile({ body: options.body, bodyFile: options.bodyFile, allowStdin: true });
 }
 
 // Build the `gh pr edit` args and the parallel `edited` list (which fields were

--- a/scripts/github/post-gate-findings.mjs
+++ b/scripts/github/post-gate-findings.mjs
@@ -10,6 +10,7 @@ import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { resolveFindingsInput } from "./_findings-input.mjs";
 import { guardCommentBodyNoIssuePrIds } from "@dev-loops/core/github/comment-id-guard";
+import { GATE_NAMES, normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "./_gate-names.mjs";
 
 const USAGE = `Usage: post-gate-findings.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> (--findings <json> | --findings-file <path>)
 Post (or idempotently update) a visible, marker-tagged PR issue comment that lists the
@@ -59,17 +60,10 @@ function parseError(message) {
 // The one gate vocabulary this module knows about. Shared by normalizeGate
 // (CLI --gate parsing) and validateAndSanitizeRenderInputs's own membership
 // check below, so the two can never name a different set of "real" gates.
-const KNOWN_GATES = new Set(["draft_gate", "pre_approval_gate"]);
+const KNOWN_GATES = new Set(GATE_NAMES);
 
-function normalizeGate(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return KNOWN_GATES.has(normalized) ? normalized : null;
-}
-
-function normalizeHeadSha(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
-}
+const normalizeGate = normalizeGateShared;
+const normalizeHeadSha = normalizeHeadShaShared;
 
 // Validate via the centralized repo-slug validator shared by sibling GitHub
 // scripts (parseRepoSlug). It enforces owner/name structure and rejects unsafe

--- a/scripts/github/resolve-angle-carry-forward.mjs
+++ b/scripts/github/resolve-angle-carry-forward.mjs
@@ -38,6 +38,7 @@ import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { normalizeFullHeadSha } from "../lib/head-sha.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "./_gate-names.mjs";
 import { buildLogPath } from "./write-gate-findings-log.mjs";
 import {
   assertWorktreeAtHead,
@@ -46,8 +47,6 @@ import {
   mapGateToConfigKey,
   parseChangedFiles,
 } from "./write-gate-context.mjs";
-
-const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
 
 const USAGE = `Usage: resolve-angle-carry-forward.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --prev-head <sha> --head-sha <sha> [--tmp-root <path>]
 Decide, per angle, whether a prior CLEAN gate verdict (recorded at --prev-head) may
@@ -69,15 +68,8 @@ function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
 }
 
-function normalizeGate(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return GATE_NAMES.has(normalized) ? normalized : null;
-}
-
-function normalizeHeadSha(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
-}
+const normalizeGate = normalizeGateShared;
+const normalizeHeadSha = normalizeHeadShaShared;
 
 export function parseResolveAngleCarryForwardCliArgs(argv) {
   const { tokens } = parseArgs({

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -37,8 +37,7 @@ import {
   updateGateReview,
 } from "./_gate-finding-surface.mjs";
 import { fetchAllReviewThreads } from "./list-review-threads.mjs";
-const GATE_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
-const GATE_VERDICTS = new Set(["clean", "findings_present", "blocked"]);
+import { normalizeGate as normalizeGateShared, normalizeVerdict as normalizeVerdictShared } from "./_gate-names.mjs";
 const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
 // Mirrors check-size-budget.mjs's computeSizeBudget outcome enum exactly —
 // this file never recomputes the outcome, only validates/renders it.
@@ -258,14 +257,8 @@ function rejectRemovedFlag(token) {
     `${token} has been removed. Force bypass requires separate operator authorization. Omit the flag.`,
   );
 }
-function normalizeGateName(value) {
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-  return GATE_NAMES.has(normalized) ? normalized : null;
-}
-function normalizeVerdict(value) {
-  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-  return GATE_VERDICTS.has(normalized) ? normalized : null;
-}
+const normalizeGateName = normalizeGateShared;
+const normalizeVerdict = normalizeVerdictShared;
 function normalizeExecutionMode(value) {
   const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
   return GATE_EXECUTION_MODES.has(normalized) ? normalized : null;

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -48,7 +48,7 @@ import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { viewPr } from "./view-pr.mjs";
 import { viewIssue } from "./view-issue.mjs";
 import { buildAdjacentBundle, DEFAULT_MAX_FILE_BYTES } from "./build-adjacent-bundle.mjs";
-import { GATE_NAMES, gateScopePrefix } from "./_gate-names.mjs";
+import { GATE_NAMES, gateScopePrefix, normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "./_gate-names.mjs";
 import { resolveLinkedIssuesFromPr } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -162,16 +162,8 @@ function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
 }
 
-function normalizeGate(value) {
-  const gates = new Set(GATE_NAMES);
-  const normalized = String(value).trim().toLowerCase();
-  return gates.has(normalized) ? normalized : null;
-}
-
-function normalizeHeadSha(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
-}
+const normalizeGate = normalizeGateShared;
+const normalizeHeadSha = normalizeHeadShaShared;
 
 // ponytail: a DENYLIST, not an allowlist — the `git diff` call runs via
 // execFileSync's argv array (no shell), so `base` cannot inject shell syntax
@@ -480,9 +472,14 @@ export function parseWriteGateContextCliArgs(argv) {
 }
 
 /**
- * Build the deterministic artifact path for a gate-review context handoff.
- * Mirrors write-gate-findings-log.mjs buildLogPath. Exported for reuse by the
- * fork fan-out reviewers so producer and consumer agree on the path.
+ * Internal deterministic-path builder shared by every gate-artifact path
+ * function below (buildGateContextPath, buildGateReviewsDir, buildGateDiffPath,
+ * buildGateBriefingPrefixPath, buildGateBriefingScopePath,
+ * buildValidationResultsPath): validates/sanitizes the repo/pr/gate/headSha
+ * segments once and joins `<tmpRoot>/<dir>/<repo-slug>/pr-<N>/<gate>-<headSha><suffix>`.
+ * `dir` distinguishes the "gate-context" artifact family from the
+ * "gate-reviews" per-angle findings directory; `suffix` (empty for the
+ * directory case) distinguishes the file extension within a family.
  *
  * @param {object} input
  * @param {string} input.repo — owner/name
@@ -490,32 +487,30 @@ export function parseWriteGateContextCliArgs(argv) {
  * @param {string} input.gate — draft_gate | pre_approval_gate
  * @param {string} input.headSha
  * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative artifact path
+ * @param {string} [input.dir] — top-level artifact-family directory, default "gate-context"
+ * @param {string} [input.suffix] — filename suffix (extension), default ""
+ * @returns {string} relative path
  */
-export function buildGateContextPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
+function buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot = "tmp", dir = "gate-context", suffix = "" }) {
   const repoSlug = repoSlugFor(repo);
   const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.json`);
+  return path.join(tmpRoot, dir, repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}${suffix}`);
 }
 
-/**
- * Build the deterministic per-angle findings-artifact directory a gate-review
- * fan-out writes to (one `<angle>.json` per angle). Mirrors the path
- * `consolidate-fanin.mjs` reads from, so producer and consumer agree.
- * Exported for reuse by the same-head skip-completed resume scan.
- *
- * @param {object} input
- * @param {string} input.repo — owner/name
- * @param {number|string} input.pr
- * @param {string} input.gate — draft_gate | pre_approval_gate
- * @param {string} input.headSha
- * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative directory path
- */
+// Deterministic artifact path for a gate-review context handoff. Mirrors
+// write-gate-findings-log.mjs buildLogPath. Exported for reuse by the fork
+// fan-out reviewers so producer and consumer agree on the path. Param shapes:
+// see buildGateArtifactPath above.
+export function buildGateContextPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, suffix: ".json" });
+}
+
+// Deterministic per-angle findings-artifact directory a gate-review fan-out
+// writes to (one `<angle>.json` per angle). Mirrors the path
+// `consolidate-fanin.mjs` reads from. Exported for reuse by the same-head
+// skip-completed resume scan.
 export function buildGateReviewsDir({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
-  const repoSlug = repoSlugFor(repo);
-  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-reviews", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}`);
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, dir: "gate-reviews" });
 }
 
 /**
@@ -632,96 +627,43 @@ function repoSlugFor(repo) {
   return parts.join("-");
 }
 
-/**
- * Build the deterministic path for the FULL diff captured alongside the gate
- * context artifact. Mirrors buildGateContextPath but with a `.diff` extension so
- * scoped reviewers can read the entire change set (not just hunks) from a stable
- * location. Exported for reuse by the fork fan-out reviewers.
- *
- * @param {object} input
- * @param {string} input.repo — owner/name
- * @param {number|string} input.pr
- * @param {string} input.gate — draft_gate | pre_approval_gate
- * @param {string} input.headSha
- * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative diff path
- */
+// Deterministic path for the FULL diff captured alongside the gate context
+// artifact. Mirrors buildGateContextPath but with a `.diff` extension so
+// scoped reviewers can read the entire change set (not just hunks). Exported
+// for reuse by the fork fan-out reviewers.
 export function buildGateDiffPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
-  const repoSlug = repoSlugFor(repo);
-  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.diff`);
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, suffix: ".diff" });
 }
 
-/**
- * Build the deterministic path for the rendered invariant briefing prefix
- * (GATE-EXEC-BRIEFING-PREFIX): the byte-identical block every per-angle
- * reviewer of this gate pass is seeded with, before their angle-specific
- * suffix. Mirrors buildGateContextPath/buildGateDiffPath. Exported so the
- * fan-out reviewers and `verify-fresh-review-context.mjs --prefix-file` agree
- * on the path with the context-builder.
- *
- * @param {object} input
- * @param {string} input.repo — owner/name
- * @param {number|string} input.pr
- * @param {string} input.gate — draft_gate | pre_approval_gate
- * @param {string} input.headSha
- * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative briefing-prefix path
- */
+// Deterministic path for the rendered invariant briefing prefix
+// (GATE-EXEC-BRIEFING-PREFIX): the byte-identical block every per-angle
+// reviewer of this gate pass is seeded with, before their angle-specific
+// suffix. Exported so the fan-out reviewers and
+// `verify-fresh-review-context.mjs --prefix-file` agree on the path.
 export function buildGateBriefingPrefixPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
-  const repoSlug = repoSlugFor(repo);
-  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.briefing-prefix.txt`);
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, suffix: ".briefing-prefix.txt" });
 }
 
-/**
- * Build the deterministic path for a per-scope briefing companion file (AC3,
- * #1572): a narrower slice of the same bundle for angles whose configured
- * `scope` is not "full" (see GATE_ANGLE_SCOPES). Mirrors
- * buildGateBriefingPrefixPath, one file per distinct non-full scope actually
- * declared by this round's resolved angles.
- *
- * @param {object} input
- * @param {string} input.repo — owner/name
- * @param {number|string} input.pr
- * @param {string} input.gate — draft_gate | pre_approval_gate
- * @param {string} input.headSha
- * @param {"changed-files"|"docs-only"} input.scope — a non-"full" GATE_ANGLE_SCOPES value
- * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative scoped-briefing path
- */
+// Deterministic path for a per-scope briefing companion file (AC3, #1572): a
+// narrower slice of the same bundle for angles whose configured `scope` is
+// not "full" (see GATE_ANGLE_SCOPES). `scope` must be a non-"full"
+// GATE_ANGLE_SCOPES value (e.g. "changed-files" | "docs-only") — validated
+// here since the shared internal builder has no scope-vocabulary awareness.
 export function buildGateBriefingScopePath({ repo, pr, gate, headSha, scope, tmpRoot = "tmp" }) {
   if (scope === "full" || !GATE_ANGLE_SCOPES.includes(scope)) {
     throw new Error(`buildGateBriefingScopePath: scope must be a non-"full" GATE_ANGLE_SCOPES value, got ${JSON.stringify(scope)}`);
   }
-  const repoSlug = repoSlugFor(repo);
-  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.briefing-${scope}.txt`);
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, suffix: `.briefing-${scope}.txt` });
 }
 
-/**
- * Build the deterministic path for the shared validation-results artifact
- * (GATE-EXEC-VALIDATION-ARTIFACT, `run-gate-validation.mjs`): the record of
- * this round's validation suites, run once and read (not re-run) by every
- * per-angle reviewer via the briefing-prefix section {@link renderBriefingPrefix}
- * appends when `validationResultsPath` is threaded. Mirrors
- * buildGateContextPath/buildGateDiffPath/buildGateBriefingPrefixPath. Exported
- * so `run-gate-validation.mjs` (the producer) and this module's CLI/context
- * artifact (the consumer that records the path) agree on the location without
- * re-implementing the slug/segment-safety logic.
- *
- * @param {object} input
- * @param {string} input.repo — owner/name
- * @param {number|string} input.pr
- * @param {string} input.gate — draft_gate | pre_approval_gate
- * @param {string} input.headSha
- * @param {string} [input.tmpRoot] — default "tmp"
- * @returns {string} relative validation-results path
- */
+// Deterministic path for the shared validation-results artifact
+// (GATE-EXEC-VALIDATION-ARTIFACT, `run-gate-validation.mjs`): the record of
+// this round's validation suites, run once and read (not re-run) by every
+// per-angle reviewer via the briefing-prefix section. Exported so
+// `run-gate-validation.mjs` (the producer) and this module's CLI/context
+// artifact (the consumer that records the path) agree on the location.
 export function buildValidationResultsPath({ repo, pr, gate, headSha, tmpRoot = "tmp" }) {
-  const repoSlug = repoSlugFor(repo);
-  const { pr: safePr, gate: safeGate, headSha: safeSha } = validatePathSegments({ pr, gate, headSha });
-  return path.join(tmpRoot, "gate-context", repoSlug, `pr-${safePr}`, `${safeGate}-${safeSha}.validation.json`);
+  return buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, suffix: ".validation.json" });
 }
 
 /**

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -13,6 +13,7 @@ import { GATE_CONFIG_KEY, SEVERITY_ORDER, VALID_SEVERITIES, applyJudgeDispositio
 import { JUDGE_DISPOSITIONS as _JUDGE_DISPOSITIONS_ARRAY } from "@dev-loops/core/loop/gate-fanin";
 const JUDGE_DISPOSITIONS = new Set(_JUDGE_DISPOSITIONS_ARRAY);
 import { loadDevLoopConfig, resolveFanoutGroups, resolveGateAngleContract, resolveRejectForeignAngles } from "@dev-loops/core/config";
+import { normalizeGate as normalizeGateShared, normalizeVerdict as normalizeVerdictShared } from "./_gate-names.mjs";
 const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings <json> | --findings-file <path>) [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
 Required:
@@ -45,16 +46,8 @@ ${JQ_OUTPUT_USAGE}
 function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
 }
-function normalizeGate(value) {
-  const gates = new Set(["draft_gate", "pre_approval_gate"]);
-  const normalized = String(value).trim().toLowerCase();
-  return gates.has(normalized) ? normalized : null;
-}
-function normalizeVerdict(value) {
-  const verdicts = new Set(["clean", "findings_present", "blocked"]);
-  const normalized = String(value).trim().toLowerCase();
-  return verdicts.has(normalized) ? normalized : null;
-}
+const normalizeGate = normalizeGateShared;
+const normalizeVerdict = normalizeVerdictShared;
 // Exported so other tools (e.g. upsert-checkpoint-verdict.mjs's
 // RESOLVED_DISPOSITIONS) derive their own subset from this single copy of the
 // disposition vocabulary instead of hand-copying it out of sync.
@@ -491,9 +484,10 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // comparison: a bare-array input never persists a null/undefined/
   // non-string/out-of-domain verdict un-normalized, and a wrapper input
   // compares against an already-normalized caller verdict so a domain failure
-  // is never misattributed as a contradiction. typeof is checked before
-  // normalizeVerdict, which coerces via String() and would otherwise let a
-  // non-string (e.g. an array) silently pass as its stringified form.
+  // is never misattributed as a contradiction. The shared normalizeVerdict
+  // (scripts/github/_gate-names.mjs) already guards non-strings internally
+  // (typeof check, never String() coercion), so this outer typeof check is
+  // redundant defense-in-depth, not load-bearing.
   const callerVerdict = typeof options.verdict === "string" ? normalizeVerdict(options.verdict) : null;
   if (!callerVerdict) {
     throw parseError("--verdict must be clean, findings_present, or blocked");
@@ -506,11 +500,9 @@ export async function writeGateFindingsLog(options, { repoRoot = process.cwd() }
   // across calls.
   let persistedVerdict = callerVerdict;
   if (overallVerdict !== undefined) {
-    // The wrapper's overallVerdict must itself be a string BEFORE
-    // normalization runs — normalizeVerdict coerces via String(), which would
-    // otherwise let an array-wrapped wrapper verdict (e.g. ["clean"], whose
-    // String() form is the bare string "clean") silently pass as a valid
-    // wrapper instead of being rejected as malformed.
+    // The wrapper's overallVerdict must itself be a string; the shared
+    // normalizeVerdict already rejects any non-string internally, so this
+    // outer typeof check is redundant defense-in-depth, not load-bearing.
     const verdict = typeof overallVerdict === "string" ? normalizeVerdict(overallVerdict) : null;
     if (!verdict) {
       throw parseError(

--- a/scripts/loop/judge-pass.mjs
+++ b/scripts/loop/judge-pass.mjs
@@ -8,6 +8,7 @@ import {
   validateJudgeVerdict,
 } from "@dev-loops/core/loop/gate-fanin";
 import { ensureFollowUpIssue, fingerprintFinding } from "../github/_gate-finding-surface.mjs";
+import { GATE_NAMES } from "../github/_gate-names.mjs";
 import { resolveFindingsInput } from "../github/_findings-input.mjs";
 import {
   JQ_OUTPUT_PARSE_OPTIONS,
@@ -64,7 +65,7 @@ Exit codes:
   2   Invalid --jq filter
 `.trim();
 
-const GATES = Object.freeze(["draft_gate", "pre_approval_gate"]);
+const GATES = GATE_NAMES;
 
 function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });

--- a/scripts/loop/run-gate-validation.mjs
+++ b/scripts/loop/run-gate-validation.mjs
@@ -21,7 +21,7 @@ import { parseArgs } from "node:util";
 
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { GATE_NAMES } from "../github/_gate-names.mjs";
+import { normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "../github/_gate-names.mjs";
 import { assertWorktreeAtHead, buildValidationResultsPath } from "../github/write-gate-context.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -62,16 +62,8 @@ function parseError(message) {
   return Object.assign(new Error(message), { usage: USAGE });
 }
 
-function normalizeGate(value) {
-  const gates = new Set(GATE_NAMES);
-  const normalized = String(value).trim().toLowerCase();
-  return gates.has(normalized) ? normalized : null;
-}
-
-function normalizeHeadSha(value) {
-  const normalized = String(value).trim().toLowerCase();
-  return /^[0-9a-f]{7,64}$/i.test(normalized) ? normalized : null;
-}
+const normalizeGate = normalizeGateShared;
+const normalizeHeadSha = normalizeHeadShaShared;
 
 export function parseRunGateValidationCliArgs(argv) {
   const { tokens } = parseArgs({

--- a/test/github/create-pr.test.mjs
+++ b/test/github/create-pr.test.mjs
@@ -376,13 +376,11 @@ test("create-pr --body-file without closing keyword emits no warning when --issu
   }
 });
 
-test("create-pr --body-file with missing file emits no warning and exits 0 when --issue is absent (#1626)", async () => {
+test("create-pr --body-file with an unreadable file fails closed: nonzero exit, clear error, gh never invoked", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-create-pr-bodyfile-missing-"));
 
   try {
-    const { env, ghLogPath } = await writeGhStub(tempDir, [
-      { stdout: "https://github.com/owner/repo/pull/1\n" },
-    ]);
+    const { env, ghLogPath } = await writeGhStub(tempDir, []);
 
     const result = await runNode([
       "--repo", "owner/repo",
@@ -393,10 +391,10 @@ test("create-pr --body-file with missing file emits no warning and exits 0 when 
       "--body-file", "/nonexistent/path/pr-body.md",
     ], { env });
 
-    assert.equal(result.code, 0);
-    assert.equal(result.stdout, "https://github.com/owner/repo/pull/1\n");
-    assert.equal(result.stderr, "");
-    assert.equal((await readGhCalls(ghLogPath)).length, 1);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /ok":false/);
+    assert.match(result.stderr, /\/nonexistent\/path\/pr-body\.md/);
+    assert.equal((await readGhCalls(ghLogPath)).length, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Objective

Child 9 of the simplification epic #1689: dedup the gate-tooling vocabulary, normalizers, and artifact-path builders across scripts/github (+ one scripts/loop import swap), and extract a shared `resolveBodyOrFile` CLI helper. Net **-57 lines** across 15 files (162 insertions, 219 deletions).

Closes #1698.

> Note on scale: the issue estimated ~-220 lines. That was a rough pre-implementation figure. The real reduction is -57: the two structural wins (collapsing six path builders, unifying the normalizers) are done, but I did not pad the count by stripping explanatory comments — net-negative here comes from removing duplication, not documentation.

## In scope (done)

- **Shared vocabulary**: `scripts/github/_gate-names.mjs` now exports `GATE_VERDICTS = ["clean", "findings_present", "blocked"]` alongside `GATE_NAMES`. The hand-typed gate/verdict `Set`/array literals in `upsert-checkpoint-verdict.mjs`, `_gate-finding-surface.mjs`, `post-gate-findings.mjs`, `resolve-angle-carry-forward.mjs`, `write-gate-findings-log.mjs`, and `scripts/loop/run-gate-validation.mjs` now import them. Also fixed one extra hand-typed `GATES` literal found in `scripts/loop/judge-pass.mjs` (inside the AC's grep scope). The display/parse literals inside `_gate-finding-surface.mjs`'s `REVIEW_HEADER_RE` and error strings are left as-is (not vocabulary sets).
- **Single normalizers**: `normalizeGate`, `normalizeVerdict`, `normalizeHeadSha` each have exactly one implementation, exported from `_gate-names.mjs` (typeof-guard style, returns `null` for every non-member/non-string input). The ~12 per-file copies now delegate. Distinct same-named-but-different functions (`normalizeGateSummary`, `normalizeVerdict(summary)` in audit-gate-evidence, `normalizeHeadShaValue` in consolidate-fanin) are correctly left untouched.
- **Collapsed path builders**: `write-gate-context.mjs`'s six builders (`buildGateContextPath`, `buildGateReviewsDir`, `buildGateDiffPath`, `buildGateBriefingPrefixPath`, `buildGateBriefingScopePath`, `buildValidationResultsPath`) now route through one internal `buildGateArtifactPath({ repo, pr, gate, headSha, tmpRoot, dir, suffix })` plus one-line named wrappers. Every export name, signature, and returned path is byte-identical (a `dir` param was added beyond the illustrative signature because `buildGateReviewsDir` roots under `gate-reviews/`). `buildGateBriefingScopePath` keeps its scope-validation throw in the wrapper.
- **Shared resolveBodyOrFile**: added to `@dev-loops/core/cli/primitives`, re-exported through `scripts/_cli-primitives.mjs`. `edit-pr` and `edit-comment` route through it (keeping `--body-file -` stdin and the empty-file throw); their id-guard / `--enforce-grill` checks still run on the resolved body. `create-pr` now **fails closed** on an unreadable/empty `--body-file` (nonzero exit + clear error, before `gh` is invoked) — the previous silent empty-string fallback is gone.

## Behavior change (the one sanctioned one)

`create-pr --body-file <unreadable-or-empty>` used to swallow the read error and proceed with an empty body; it now exits nonzero with `{"ok":false,"error":...}` naming the path, before any `gh` call. This is the only behavior change and the only modified test assertion.

## Verification

- Gate-vocabulary suites (write-gate-context [235], upsert-checkpoint-verdict, post-gate-findings, resolve-angle-carry-forward, write-gate-findings-log, gate-finding-surface) → all green; the write-gate-context path-shape pins pass unmodified, proving byte-identical builder output.
- Body-resolution suites (edit-pr, edit-comment, create-pr, create-pr-board) → green.
- run-gate-validation, consolidate-fanin, judge-pass → green.
- `npm test` (full) → 0 failures (core 2789, scripts 4167, assets 285, extension 126, dev-loop 38, pack 1, docs + workflows clean).
- grep: zero hand-typed gate-name/verdict literals in scripts/github + scripts/loop outside `_gate-names.mjs`; the three normalizers defined exactly once.

## Acceptance criteria

- [x] `_gate-names.mjs` exports `GATE_VERDICTS` (clean, findings_present, blocked).
- [x] No scripts/github or scripts/loop file outside `_gate-names.mjs` defines its own gate/verdict literal; the listed files import them.
- [x] `normalizeGate`/`normalizeVerdict`/`normalizeHeadSha` single implementation in `_gate-names.mjs`; per-file copies deleted, call sites delegate.
- [x] Six path builders route through one shared base; each export name/signature/output byte-identical.
- [x] `buildGateBriefingScopePath` still throws on scope "full" or any value outside `GATE_ANGLE_SCOPES`.
- [x] edit-pr/edit-comment/create-pr resolve `--body`/`--body-file` through the shared `resolveBodyOrFile`.
- [x] edit-pr/edit-comment keep stdin support and throw on empty/whitespace-only body file.
- [x] create-pr exits nonzero with a clear error on unreadable/empty `--body-file`; silent fallback gone; a test covers it.
- [x] edit-comment id guard and edit-pr `--enforce-grill` still run on the resolved body.
- [x] Optional export-drop: none taken (not proven safe under drift; conservative skip).

## AC / DoD matrix

| Acceptance criterion | Verified by (definition of done) |
|---|---|
| `_gate-names.mjs` exports GATE_VERDICTS | grep zero hand-typed literals; gate-vocabulary suites |
| no other file defines gate/verdict literal | grep; the six suites |
| normalizers single implementation, copies delegate | write-gate-context / upsert / post-gate-findings / resolve-angle-carry-forward / write-gate-findings-log / run-gate-validation suites |
| six path builders collapsed, byte-identical output | write-gate-context.test.mjs (235 path-pin tests unmodified) |
| buildGateBriefingScopePath still throws on invalid scope | write-gate-context.test.mjs |
| edit-pr/edit-comment/create-pr use shared resolveBodyOrFile | edit-pr / edit-comment / create-pr suites |
| edit-pr/edit-comment stdin + empty-body throw | edit-pr.test.mjs, edit-comment.test.mjs |
| create-pr fails closed on unreadable/empty body-file | create-pr.test.mjs (new assertion — the only changed one) |
| id guard / enforce-grill still run on resolved body | edit-comment.test.mjs, edit-pr.test.mjs |
| optional export-drop only if grep-proven | none dropped (conservative) |

## Non-goals

- ghJson/runGhJson migration in these files (#1697, landed).
- packages/core/src/loop dedup — trimmedOrNull, gate-verdict set there, section helper (#1699).
- Test fixture scaffolding consolidation (#1700).
- Any gate-semantics / artifact-path-shape / guard change beyond the create-pr fail-closed fix.
