### PR TITLE
fix(config): eager all-gate severity-vocabulary validation in resolveGateConfig (closes #1761)

### DIFF
--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -1944,22 +1944,6 @@ export function resolveRefinement(config) {
 }
 
 /**
- * Resolve one gate configuration object from the merged dev-loop config.
- *
- * Returns the configured gate angles when present, or null for angles when the
- * config omits them (caller falls back to skill-defined defaults). Boolean gate
- * flags always resolve to stable defaults.
- *
- * The returned shape is the STABLE, resolved view every other angle resolver
- * and consumer builds on — `mandatoryAngles`/`excludeAngles`/`dynamicAngles`/
- * `additiveAngles` are derived here from the unified `gates.<gate>.angles`
- * array (`mandatory: true` / `enabled: false` per-entry, D3) and the
- * `gates.<gate>.dynamic` sub-object, so downstream consumers keep reading the
- * same field names the pre-1.0 flat config keys used. (`extraAngles` no
- * longer exists as a concept: D3's merge-by-name lets a later config layer add
- * a plain, non-mandatory angle to `angles` directly, without restating the
- * list — the exact ergonomic `extraAngles` used to provide.)
- *
  * Resolve and validate ONE gate's raw `blockCleanOnFindingSeverities` value
  * against the schema's severity vocabulary, returning the normalized/deduped
  * list (or the ["high"] default when the key is absent). Shared by
@@ -2005,6 +1989,22 @@ function resolveBlockingSeverities(config, gate) {
 }
 
 /**
+ * Resolve one gate configuration object from the merged dev-loop config.
+ *
+ * Returns the configured gate angles when present, or null for angles when the
+ * config omits them (caller falls back to skill-defined defaults). Boolean gate
+ * flags always resolve to stable defaults.
+ *
+ * The returned shape is the STABLE, resolved view every other angle resolver
+ * and consumer builds on — `mandatoryAngles`/`excludeAngles`/`dynamicAngles`/
+ * `additiveAngles` are derived here from the unified `gates.<gate>.angles`
+ * array (`mandatory: true` / `enabled: false` per-entry, D3) and the
+ * `gates.<gate>.dynamic` sub-object, so downstream consumers keep reading the
+ * same field names the pre-1.0 flat config keys used. (`extraAngles` no
+ * longer exists as a concept: D3's merge-by-name lets a later config layer add
+ * a plain, non-mandatory angle to `angles` directly, without restating the
+ * list — the exact ergonomic `extraAngles` used to provide.)
+ *
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
  * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean, mediumFixWindow: number, tiers: Array<{name: string, match: object, angles: string[]}> }}

--- a/packages/core/src/config/config.mjs
+++ b/packages/core/src/config/config.mjs
@@ -255,6 +255,12 @@ function formatConfigValue(value) {
   }
 }
 
+// The three GatesConfig keys whose value is a GateConfig (i.e. carries its
+// own blockCleanOnFindingSeverities) — kept in sync with the `gates:
+// { draft, preApproval, spike }` keys below by construction (both list the
+// same three names; a fourth GateConfig-typed gate would need both updated).
+const GATE_KEYS_WITH_BLOCKING_SEVERITIES = /** @type {const} */ (["draft", "preApproval", "spike"]);
+
 const GateConfig = z.strictObject({
   angles: z.array(GateAngleEntry).optional().describe("Review lenses this gate fans out to. A bare string is sugar for { name }; an object may set mandatory/enabled/persona/prompt/model/tier."),
   dynamic: GateDynamicConfig.optional().describe("Diff-driven dynamic angle selection policy for this gate."),
@@ -1954,59 +1960,89 @@ export function resolveRefinement(config) {
  * a plain, non-mandatory angle to `angles` directly, without restating the
  * list — the exact ergonomic `extraAngles` used to provide.)
  *
+ * Resolve and validate ONE gate's raw `blockCleanOnFindingSeverities` value
+ * against the schema's severity vocabulary, returning the normalized/deduped
+ * list (or the ["high"] default when the key is absent). Shared by
+ * resolveGateConfig, which calls this for every GateConfig-typed gate on
+ * every invocation (see that function's @throws doc) so an invalid list on
+ * any gate refuses eagerly, not only when that specific gate is requested.
+ *
+ * @param {DevLoopConfig} config
+ * @param {"draft"|"preApproval"|"spike"} gate
+ * @returns {string[]}
+ * @throws {Error} when `gate`'s PRESENT `blockCleanOnFindingSeverities` key
+ *   is schema-invalid (non-array, empty, or containing an out-of-vocabulary
+ *   entry).
+ */
+function resolveBlockingSeverities(config, gate) {
+  const rawBlocking = config?.gates?.[gate]?.blockCleanOnFindingSeverities;
+  if (rawBlocking === undefined) return ["high"];
+  if (!Array.isArray(rawBlocking)) {
+    throw new Error(
+      `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities must be an array ` +
+      `of defect severities, got ${formatConfigValue(rawBlocking)}. ` +
+      `Fix the config before gate operations can proceed.`
+    );
+  }
+  if (rawBlocking.length === 0) {
+    throw new Error(
+      `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities is empty; ` +
+      `the schema requires at least one blocking severity, and an empty list would make the gate block on nothing. ` +
+      `Fix the config before gate operations can proceed.`
+    );
+  }
+  const invalid = rawBlocking.filter((s) => typeof s !== "string" || !BLOCKING_SEVERITY_SPELLING_SET.has(s));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities contains ` +
+      `value(s) outside the schema's severity vocabulary: ${invalid.map((s) => formatConfigValue(s)).join(", ")}. ` +
+      `Allowed (exact spellings): ${BLOCKING_SEVERITY_SPELLINGS.join(", ")} ` +
+      `(the legacy spellings normalize to high/medium/low). ` +
+      `Fix the config before gate operations can proceed.`
+    );
+  }
+  return [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
+}
+
+/**
  * @param {DevLoopConfig} config
  * @param {"draft"|"preApproval"|"spike"} gate
  * @returns {{ angles: string[]|null, excludeAngles: string[], mandatoryAngles: string[], required: boolean, requireCi: boolean, blockCleanOnFindingSeverities: string[], dynamicAngles: boolean, additiveAngles: boolean, mediumFixWindow: number, tiers: Array<{name: string, match: object, angles: string[]}> }}
- * @throws {Error} when THIS gate's PRESENT `blockCleanOnFindingSeverities`
- *   key is any schema-invalid shape: a non-array value, an empty array, or an
- *   entry that is not one of the schema enum's exact spellings. Every such
- *   shape can only arrive through a config that failed schema validation (the
+ * @throws {Error} when ANY gate's (draft, preApproval, or spike — not only
+ *   the requested `gate`'s) PRESENT `blockCleanOnFindingSeverities` key is
+ *   any schema-invalid shape: a non-array value, an empty array, or an entry
+ *   that is not one of the schema enum's exact spellings. Every such shape
+ *   can only arrive through a config that failed schema validation (the
  *   schema requires a min-1 array of the enum spellings; the guard
  *   exact-matches raw entries against the same spelling list, so its accept
  *   set is byte-identical to the schema's), and passing it through would make
- *   the gate block on the wrong severities or on nothing at all. The refusal
- *   reaches every caller that resolves the affected gate — including ones
- *   reading unrelated fields from it (resolveRefinement's preApproval
- *   requireCi read, angle and tier resolution, state detection) — because no
- *   gate operation should proceed on a config whose verdict-semantics key
- *   failed validation; a caller resolving a DIFFERENT gate of the same config
- *   is untouched. This is the stated boundary with the module's
- *   degrade-quietly convention for dispatch-ergonomics keys
- *   (resolveMaxAnglesPerGroup substitutes its default, resolveFanoutGroups
- *   drops malformed entries): those keys only shape dispatch, so they degrade;
- *   the key that decides what blocks a clean verdict refuses. An ABSENT key
- *   still falls back to the default unchanged.
+ *   the affected gate block on the wrong severities or on nothing at all.
+ *   Validated EAGERLY across all three gates on every call — not lazily,
+ *   only for the requested `gate` — so that a single-gate consumer (e.g. a
+ *   draft-only fan-in consolidation) can never proceed and produce a
+ *   side-effect (write a ledger artifact, flip ready-for-review) while a
+ *   DIFFERENT gate's severity list is invalid; that invalid gate would only
+ *   have surfaced later, lazily, at a dual-gate call site (e.g. verdict
+ *   posting), after the single-gate side effect already happened. This is
+ *   the stated boundary with the module's degrade-quietly convention for
+ *   dispatch-ergonomics keys (resolveMaxAnglesPerGroup substitutes its
+ *   default, resolveFanoutGroups drops malformed entries): those keys only
+ *   shape dispatch, so they degrade; the key that decides what blocks a
+ *   clean verdict refuses, fail-closed, before any gate proceeds. An ABSENT
+ *   key still falls back to the default unchanged.
  */
 export function resolveGateConfig(config, gate) {
   const gateConfig = config?.gates?.[gate];
-  const rawBlocking = gateConfig?.blockCleanOnFindingSeverities;
+  // Eagerly validate every gate's blockCleanOnFindingSeverities together
+  // (not just the requested `gate`'s) so an invalid list on ANY gate refuses
+  // up front, before this call's single-gate result can be used for a
+  // side effect that a later, different-gate call would otherwise still be
+  // able to reach lazily. See the @throws doc above for the reachability
+  // this closes.
   let blockCleanOnFindingSeverities = ["high"];
-  if (rawBlocking !== undefined) {
-    if (!Array.isArray(rawBlocking)) {
-      throw new Error(
-        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities must be an array ` +
-        `of defect severities, got ${formatConfigValue(rawBlocking)}. ` +
-        `Fix the config before gate operations can proceed.`
-      );
-    }
-    if (rawBlocking.length === 0) {
-      throw new Error(
-        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities is empty; ` +
-        `the schema requires at least one blocking severity, and an empty list would make the gate block on nothing. ` +
-        `Fix the config before gate operations can proceed.`
-      );
-    }
-    const invalid = rawBlocking.filter((s) => typeof s !== "string" || !BLOCKING_SEVERITY_SPELLING_SET.has(s));
-    if (invalid.length > 0) {
-      throw new Error(
-        `Config validation failed: gates.${gate}.blockCleanOnFindingSeverities contains ` +
-        `value(s) outside the schema's severity vocabulary: ${invalid.map((s) => formatConfigValue(s)).join(", ")}. ` +
-        `Allowed (exact spellings): ${BLOCKING_SEVERITY_SPELLINGS.join(", ")} ` +
-        `(the legacy spellings normalize to high/medium/low). ` +
-        `Fix the config before gate operations can proceed.`
-      );
-    }
-    blockCleanOnFindingSeverities = [...new Set(rawBlocking.map((s) => normalizeSeverity(s)))];
+  for (const g of GATE_KEYS_WITH_BLOCKING_SEVERITIES) {
+    const resolved = resolveBlockingSeverities(config, g);
+    if (g === gate) blockCleanOnFindingSeverities = resolved;
   }
   const entries = normalizeAngleEntries(gateConfig?.angles);
   // An explicitly-empty (or all-garbage/malformed) array is a real configured

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2865,6 +2865,34 @@ describe("role resolution", () => {
       assert.throws(() => resolveGateConfig(config, "draft"), /outside the schema's severity vocabulary/);
     });
 
+    // Fail-closed posture (issue #1761): resolveGateConfig validates every
+    // GateConfig-typed gate's blockCleanOnFindingSeverities together, eagerly,
+    // on every call — not only the requested gate's. Without this, a
+    // single-gate consumer (e.g. a draft-only fan-in consolidation) could
+    // resolve draft's (valid) config, consolidate a round, and flip
+    // ready-for-review before a later dual-gate call site (e.g. verdict
+    // posting) ever resolved preApproval and threw on ITS invalid list —
+    // leaving a written ledger artifact and no verdict. Requesting "draft"
+    // here must throw on preApproval's invalid list even though draft's own
+    // list is valid and draft is the only gate being resolved.
+    test("resolveGateConfig throws on an out-of-vocabulary blockCleanOnFindingSeverities value on a DIFFERENT gate than the one requested (eager cross-gate validation)", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: { blockCleanOnFindingSeverities: ["high"] },
+          preApproval: { blockCleanOnFindingSeverities: ["critical"] },
+        },
+      };
+      assert.throws(
+        () => resolveGateConfig(config, "draft"),
+        (err) =>
+          err instanceof Error &&
+          err.message.includes("Config validation failed") &&
+          err.message.includes("gates.preApproval.blockCleanOnFindingSeverities") &&
+          err.message.includes('"critical"'),
+      );
+    });
+
     test("resolveGateConfig honors the deprecated worthFixingNowFixWindow alias when mediumFixWindow is absent", () => {
       const config = {
         version: 1,

--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -2893,6 +2893,28 @@ describe("role resolution", () => {
       );
     });
 
+    // Same eager cross-gate guarantee for the third GateConfig-typed gate,
+    // spike. Without a spike pin, dropping "spike" from the eager loop (or
+    // regressing spike to lazy validation) would escape the suite and silently
+    // reintroduce the side-effect race for the spike gate.
+    test("resolveGateConfig throws on an out-of-vocabulary blockCleanOnFindingSeverities value on the spike gate when a DIFFERENT gate is requested (eager cross-gate validation)", () => {
+      const config = {
+        version: 1,
+        gates: {
+          draft: { blockCleanOnFindingSeverities: ["high"] },
+          spike: { blockCleanOnFindingSeverities: ["critical"] },
+        },
+      };
+      assert.throws(
+        () => resolveGateConfig(config, "draft"),
+        (err) =>
+          err instanceof Error &&
+          err.message.includes("Config validation failed") &&
+          err.message.includes("gates.spike.blockCleanOnFindingSeverities") &&
+          err.message.includes('"critical"'),
+      );
+    });
+
     test("resolveGateConfig honors the deprecated worthFixingNowFixWindow alias when mediumFixWindow is absent", () => {
       const config = {
         version: 1,


### PR DESCRIPTION
## Objective

Fix the per-gate refusal-timing race in `resolveGateConfig`: an invalid `blockCleanOnFindingSeverities` list on one gate could let a single-gate consumer consolidate a round and flip ready-for-review before a dual-gate consumer threw at verdict time.

Closes #1761.

## Decision recorded (AC1)

Chosen posture: **validate all gates eagerly at the shared entry point** (fail-closed before side effects), rather than documenting the split per-gate timing as intended.

Rationale: `resolveGateConfig(config, gate)` is the single choke point every consumer funnels through to read `blockCleanOnFindingSeverities` — both the single-gate consumer (`scripts/loop/consolidate-fanin.mjs`, draft only) and the dual-gate consumer (`scripts/github/upsert-checkpoint-verdict.mjs`, draft + preApproval). No shared seam exists above it (`loadDevLoopConfig`/`applyLayer` drops schema-invalid layers before merge, so an invalid list only reaches here via a programmatic config object). Validating all gates at this one function is the smallest correct place.

## Change (AC2)

- Extracted the existing per-gate validation into `resolveBlockingSeverities(config, gate)` (messages unchanged).
- `resolveGateConfig` now loops over the three `GateConfig`-typed gates (`draft`, `preApproval`, `spike`) and validates each on every call, regardless of which gate was requested. Any gate's invalid severity list throws immediately, using the exact same error message shape (naming the offending gate) as before.
- Valid config is unaffected — no new refusals for valid severity lists.

## Pin (AC2)

`packages/core/test/config.test.mjs`: two cross-gate pins — `resolveGateConfig(config, "draft")` with a valid `draft` but an out-of-vocabulary severity on `preApproval` (and, in a sibling pin, on `spike`) now throws, naming `gates.preApproval.` / `gates.spike.blockCleanOnFindingSeverities` and `"critical"`. This proves eager cross-gate refusal before any single-gate consumer can consolidate/flip-ready, and covers all three GateConfig-typed gates against a drop-from-loop or regress-to-lazy mutation.

## Verification (DoD)

- `node --test packages/core/test/config.test.mjs` → 455/455 (with the added spike pin).
- `npm run test:core` → 2799/2799.
- `npm run verify` → all suites green (0 failures).
- No existing test changed (all pre-existing severity tests set only one gate's severities, so none trip the new cross-gate check).

## Acceptance criteria

- [x] A decision is recorded: validate both gates eagerly at one shared entry point (chosen), vs documenting per-gate timing.
- [x] The chosen posture is implemented with a pin.

## Definition of done

- [x] Config suite green; `npm run verify` green.

## Non-goals

- No behavior change for valid configs (no new refusals for valid severity lists).
- No new gate keys or vocabulary; the eager loop covers exactly the three existing GateConfig-typed gates (draft, preApproval, spike).
- No documentation of the per-gate split timing as intended — the split was the bug; eager validation replaces it.
