### PR TITLE
test(config): single-source severity-vocab parity + strengthen refusal pins (closes #1762)

### DIFF
--- a/packages/core/test/config.test.mjs
+++ b/packages/core/test/config.test.mjs
@@ -11,7 +11,9 @@ import {
   DevLoopConfigSchema,
   FileConfigSchema,
   BUILT_IN_DEFAULTS,
+  BLOCKING_SEVERITY_SPELLINGS,
 } from "../src/config/config.mjs";
+import { LEGACY_SEVERITY_ALIASES } from "../src/loop/gate-fanin.mjs";
 import {
   resolveConductorModel,
   resolveAutonomyStopAt,
@@ -2824,34 +2826,45 @@ describe("role resolution", () => {
     // The schema requires min 1; an empty list reaches this resolver only
     // through a config that failed validation, and passing it through would
     // make the gate block on nothing (and severity consumers diverge on it).
-    test("resolveGateConfig throws on an explicitly-empty blockCleanOnFindingSeverities array", () => {
+    test("resolveGateConfig throws on an explicitly-empty blockCleanOnFindingSeverities array, naming the gate key", () => {
       const config = {
         version: 1,
         gates: { draft: { blockCleanOnFindingSeverities: [] } },
       };
-      assert.throws(() => resolveGateConfig(config, "draft"), /is empty/);
+      assert.throws(
+        () => resolveGateConfig(config, "draft"),
+        (err) => err instanceof Error && err.message.includes("gates.draft.blockCleanOnFindingSeverities") && /is empty/.test(err.message),
+      );
     });
 
     // The schema requires an array; a scalar or mapping here is the same
     // failed-validation channel and previously fell back to the high default
     // silently, under-blocking relative to the author's intent.
-    test("resolveGateConfig throws on a present-but-non-array blockCleanOnFindingSeverities value", () => {
+    test("resolveGateConfig throws on a present-but-non-array blockCleanOnFindingSeverities value, naming the gate key", () => {
       for (const value of ["medium", { medium: true }, 3, null]) {
         assert.throws(
           () => resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: value } } }, "draft"),
-          /must be an array/,
+          (err) => err instanceof Error && err.message.includes("gates.draft.blockCleanOnFindingSeverities") && /must be an array/.test(err.message),
           String(value),
         );
       }
     });
 
     // Parity pin for the derived vocabulary: every spelling the schema enum
-    // accepts must resolve without refusal, so the guard can never drift
-    // ahead of the schema.
-    test("resolveGateConfig accepts every schema-enum blockCleanOnFindingSeverities spelling", () => {
-      for (const spelling of ["high", "medium", "low", "must-fix", "worth-fixing-now", "nice-to-have", "defer"]) {
+    // accepts must resolve to its canonical value without refusal, so the
+    // guard can never drift ahead of the schema. Derives the expected
+    // spelling set from BLOCKING_SEVERITY_SPELLINGS (config.mjs's single
+    // source for the vocabulary) instead of a hand-typed literal copy, so
+    // widening the vocabulary can't silently strand this pin behind the real
+    // list, and asserts the actual canonical resolved value (not just a
+    // length) so a resolver that returns the WRONG canonical spelling still
+    // fails this test.
+    test("resolveGateConfig accepts every schema-enum blockCleanOnFindingSeverities spelling and resolves it to its canonical value", () => {
+      for (const spelling of BLOCKING_SEVERITY_SPELLINGS) {
         const result = resolveGateConfig({ version: 1, gates: { draft: { blockCleanOnFindingSeverities: [spelling] } } }, "draft");
-        assert.equal(result.blockCleanOnFindingSeverities.length, 1, spelling);
+        const canonical = Object.hasOwn(LEGACY_SEVERITY_ALIASES, spelling) ? LEGACY_SEVERITY_ALIASES[spelling] : spelling;
+        assert.deepEqual(result.blockCleanOnFindingSeverities, [canonical], spelling);
+        assert.ok(BLOCKING_SEVERITY_SPELLINGS.includes(canonical), `canonical value "${canonical}" for "${spelling}" must itself be schema-enum vocabulary`);
       }
     });
 


### PR DESCRIPTION
## Objective

Single-source the gate severity refusal-message vocabulary against `BLOCKING_SEVERITY_SPELLINGS` and strengthen the refusal/parity pins so widening the vocabulary can't silently strand them. Sibling of #1761. Test-only, net +13.

Closes #1762.

## State at pickup (against main, post-#1761)

- AC1 production side was already satisfied: `BLOCKING_SEVERITY_SPELLINGS` is exported and the out-of-vocabulary refusal message already interpolates `BLOCKING_SEVERITY_SPELLINGS.join(", ")`. The gap was the parity **test** pinning its own literal 7-spelling copy.
- AC4 was already satisfied and pinned: `resolveBlockingSeverities` checks raw (untrimmed) values against `BLOCKING_SEVERITY_SPELLING_SET` before `normalizeSeverity` runs, so a whitespace-padded canonical spelling (`" high "`) is **rejected**, not trimmed into acceptance — already covered by an existing test with a rationale comment.

## Change (test-only)

- **AC1/AC2**: the schema-enum parity test now imports `BLOCKING_SEVERITY_SPELLINGS` (and `LEGACY_SEVERITY_ALIASES`) and iterates the shared constant instead of a hand-typed literal; for each spelling it `deepEqual`s the actual resolved `blockCleanOnFindingSeverities` against its expected canonical value and asserts that canonical value is a member of the shared spellings — asserting the canonical resolved value, not just list length.
- **AC3**: the empty-array and non-array refusal-message pins now use a predicate `assert.throws` that asserts the interpolated `gates.draft.blockCleanOnFindingSeverities` gate key (plus the original message regex), not just a generic substring.
- **AC4**: no change — rejection of whitespace-padded spellings is the correct fail-closed posture and was already pinned as deliberate.

No production code changed (config.mjs already met the vocabulary/export requirement).

## Verification (DoD)

- `node --test packages/core/test/config.test.mjs` → 455/455.
- `npm run test:core` → 2800/2800.
- `npm run verify` → all suites green (0 failures).

## Acceptance criteria

- [x] The refusal message's allowed list and the parity test's spelling set derive from the shared source (`BLOCKING_SEVERITY_SPELLINGS`).
- [x] The parity test asserts the canonical resolved value, not only list length.
- [x] The empty-array and non-array refusal message pins assert the interpolated gate key.
- [x] The trim-based (non-)acceptance of whitespace-padded canonical spellings is pinned as deliberate (rejection; already pinned).

## Definition of done

- [x] Config suite green; `npm run verify` green.

## Non-goals

- No change to severity validation behavior (the whitespace rejection stays; AC4 kept, not removed).
- No production code change (config.mjs already single-sources the vocabulary).
- The eager cross-gate validation itself (#1761, landed).
