### PR TITLE
fix(test): de-flake reply-resolve hang-guard under parallel verify (#1764)

### DIFF
--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -10,6 +10,19 @@ import { parseReplyResolveThreadsCliArgs } from "../../scripts/github/reply-reso
 
 const scriptPath = path.resolve("scripts/github/reply-resolve-review-threads.mjs");
 
+// Guard budget for the "must terminate, no hang" pins (#1012). The regression is
+// an INFINITE hang, so this only needs to sit safely above the honest worst-case
+// terminating time — it is not a performance assertion. The idle path serially
+// cold-starts ~4 node processes (the tool + one gh GraphQL fetch + two gh reply
+// stubs, each a `#!/usr/bin/env node` script) plus a mandatory 500ms idle-probe
+// floor. Under the full parallel `verify` run (8 suites via run-p, each with
+// CPU-count internal test parallelism, no --test-timeout) the box is heavily
+// oversubscribed and each cold-start balloons, so the old 5000ms budget could
+// elapse on a tool that was terminating fine, not hung (issue 1764, recurrence
+// of the 1639 flake class). A generous finite budget keeps the hang coverage
+// (a true infinite hang still fails) while removing the load sensitivity.
+const HANG_GUARD_MS = 30000;
+
 const runNode = (args = [], options = {}) => runNodeHelper(scriptPath, args, options);
 
 function createReviewThreadsPayload(threads) {
@@ -800,7 +813,7 @@ test("reply-resolve-review-threads terminates on an idle open stdin pipe with no
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
         reject(new Error("reply-resolve-review-threads did not terminate (hang regression #1012)"));
-      }, 5000);
+      }, HANG_GUARD_MS);
       child.on("error", reject);
       child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
       // Intentionally do NOT write or end stdin: an idle, never-EOF pipe.
@@ -840,7 +853,7 @@ test("reply-resolve-review-threads detects a conflicting stdin source promptly o
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
         reject(new Error("reply-resolve-review-threads did not terminate on open-pipe conflict (regression #1012)"));
-      }, 5000);
+      }, HANG_GUARD_MS);
       child.on("error", reject);
       child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
       // Write conflicting body but never end the pipe; the conflict must be
@@ -882,7 +895,7 @@ test("reply-resolve-review-threads detects a conflict when a whitespace-only chu
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
         reject(new Error("reply-resolve-review-threads did not terminate on whitespace-then-data conflict"));
-      }, 5000);
+      }, HANG_GUARD_MS);
       child.on("error", reject);
       child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
       // First a whitespace-only chunk, then real content — never end the pipe.


### PR DESCRIPTION
## Objective

De-flake the reply-resolve "must terminate, no hang" pins under the full parallel `verify` run. Recurrence of the environmental-flake class issue 1639 covered. Test-only.

Closes #1764.

## Root cause (AC2)

The three `#1012` hang-regression pins in `test/github/reply-resolve-review-threads.test.mjs` each guard the spawned child with a fixed `5000ms` `setTimeout` → `SIGKILL`. That guard exists to catch an INFINITE hang, but its budget was tighter than the honest worst-case terminating time under load, so it could fire on a tool that was terminating fine.

The idle path is the worst case. To terminate it serially cold-starts ~4 node processes — the tool itself, one `gh` GraphQL thread fetch, and two `gh` reply calls (the test's `gh` stub is a `#!/usr/bin/env node` script) — plus a mandatory `CONFLICT_STDIN_TIMEOUT_MS` (500ms) idle-probe floor before it can proceed with `--message`. Under `npm run verify` the box is heavily oversubscribed: `run-p` runs 8 test suites concurrently, each `node --test` uses CPU-count internal parallelism, and no `--test-timeout` is set. Every node cold-start balloons under that contention, so ~4 serialized cold-starts + 500ms could exceed 5000ms even though nothing was hung. That is why it failed twice under full parallel `verify` (PR 1752 and PR 1759 drives, 2026-08-19) and passed isolated both times.

## Change (AC1)

- Introduce a shared, documented `HANG_GUARD_MS = 30000` and use it for all three "must terminate" pins (idle-pipe, open-pipe conflict, whitespace-then-data conflict).
- The guard is a hang detector, not a performance assertion: a true (infinite) hang still fails deterministically at 30s (no competing `--test-timeout` exists), while a slow-but-terminating child under CPU saturation now has ample margin over its ~4-cold-start + 500ms floor.
- The hang-regression coverage is preserved verbatim — same spawn model, same assertions, same never-EOF idle pipe. Only the guard budget widened.

No production code changed; the tool's `CONFLICT_STDIN_TIMEOUT_MS` behavior is untouched.

## Verification (DoD)

- Touched leg green isolated: `node --test test/github/reply-resolve-review-threads.test.mjs` → 21/21.
- Ten consecutive full parallel `npm run verify` runs green (reproduces the CPU-oversubscription that triggered the flake). 10/10 green; the run-by-run result is posted in the PR thread.

## Acceptance criteria

- [x] The stdin-idle termination pin is deterministic under full parallel verify, with the hang-regression coverage preserved.
- [x] Root cause of the load sensitivity is stated in the fix PR body.

## Definition of done

- [x] Ten consecutive local full-verify runs green on the touched leg.
- [x] `npm run verify` green.

## Non-goals

- Weakening the pin to a no-op or deleting the hang-regression coverage (unchanged).
- Changing the tool's `CONFLICT_STDIN_TIMEOUT_MS` idle-probe behavior.
