### PR TITLE
fix(gate): reconcile internal-tooling Copilot suppression with the gate-boundary evaluator (#1771)

### DIFF
--- a/packages/core/src/loop/pr-gate-coordination.mjs
+++ b/packages/core/src/loop/pr-gate-coordination.mjs
@@ -1359,7 +1359,14 @@ function evaluatePrGateCoordinationCore(input = {}) {
       ? buildRoundExhaustionGateEvidenceNote({ copilotReviewRoundCount, maxCopilotRounds, ciStatus, preApprovalRequireCi })
       : null;
 
-    if (!sameHeadCleanConverged && !postConvergenceReviewSuppressed && (!roundCapReached || roundCapNewCycleRequired)) {
+    // reviewMode "internal_only" (which also folds in maxCopilotRounds:0 via
+    // copilotReviewDisabled) suppresses Copilot: the handoff routes such a PR
+    // straight to pre_approval_gate, so this branch must not force a re-request
+    // for a missing Copilot convergence point that will never exist. The
+    // sibling PR_READY_NO_FEEDBACK branch already honors internal_only; this
+    // reconciles READY_TO_REREQUEST_REVIEW with it (issue 1771). Non-suppressed
+    // external-review PRs keep reviewMode null and hit the guard unchanged.
+    if (!sameHeadCleanConverged && !postConvergenceReviewSuppressed && reviewMode !== "internal_only" && (!roundCapReached || roundCapNewCycleRequired)) {
       pushUnique(allowedNextActions, [PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW]);
       pushUnique(forbiddenActions, postDraftForbidden);
       return buildResult({
@@ -1377,7 +1384,7 @@ function evaluatePrGateCoordinationCore(input = {}) {
         nextAction: PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW,
         reason: roundCapNewCycleRequired
           ? "The previous Copilot cycle converged at the round cap, but significant post-convergence changes landed on a newer head; start a new Copilot review cycle and re-request review before `pre_approval_gate`."
-          : "The review loop is between passes, but the current head does not yet have a clean settled Copilot convergence point, so `pre_approval_gate` is still forbidden.",
+          : "The review loop is between passes, but the current head does not yet have a clean settled Copilot convergence point, so `pre_approval_gate` is still forbidden. If a Copilot round just landed at this head, it may not be visible to the evaluator yet; re-check after a short propagation wait before treating this as a needed re-request.",
         mergeStateStatus,
         conflictFiles,
           refinementArtifact,

--- a/packages/core/test/pr-gate-coordination.test.mjs
+++ b/packages/core/test/pr-gate-coordination.test.mjs
@@ -345,6 +345,50 @@ test("#1190: maxCopilotRounds: 0 (Copilot review disabled) is exempt from the ou
   assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
 });
 
+test("issue 1771: internal_only READY_TO_REREQUEST_REVIEW with no Copilot convergence point still enters pre-approval directly", () => {
+  // The suppression signal (handoff: run pre_approval_gate directly) and the
+  // gate-boundary evaluator must agree. Before the fix this combination —
+  // internal_only, but sameHeadCleanConverged false and no round cap — forced a
+  // REREQUEST_COPILOT_REVIEW for a convergence point that will never exist,
+  // which the verdict poster then refused as an illegal transition.
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    sameHeadCleanConverged: false,
+    copilotReviewRequestStatus: "requested",
+    reviewMode: "internal_only",
+    ciStatus: "success",
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE);
+  assert(!result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.notEqual(result.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+});
+
+test("issue 1771 non-goal: a non-suppressed external-review PR in the same no-convergence state still re-requests Copilot, and the refusal names the propagation wait", () => {
+  // Same lifecycle state and missing convergence point, but reviewMode is null
+  // (a normal external-review PR). The guard is unchanged for it: it must still
+  // re-request Copilot, never skip to pre-approval. The refusal reason names the
+  // just-landed-round propagation wait (AC3's "names the propagation wait").
+  const result = evaluatePrGateCoordination({
+    pr: 266,
+    currentHeadSha: "fedcba987654",
+    prDraft: false,
+    lifecycleState: STATE.READY_TO_REREQUEST_REVIEW,
+    sameHeadCleanConverged: false,
+    copilotReviewRequestStatus: "requested",
+    ciStatus: "success",
+    preApprovalGate: gate({ visible: false }),
+  });
+
+  assert.equal(result.nextAction, PR_CHECKPOINT_ACTION.REREQUEST_COPILOT_REVIEW);
+  assert(result.forbiddenActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE));
+  assert.match(result.reason, /may not be visible to the evaluator yet|propagation wait/i);
+});
+
 test("draft gate with crediblyGreen CI routes to WAIT_FOR_CI — unconfirmed CI is not a hard block", () => {
   const result = evaluatePrGateCoordination({
     pr: 266,


### PR DESCRIPTION
## Objective

Reconcile the internal-tooling Copilot-suppression signal with the pre-approval gate-boundary evaluator so they agree at the same head. Third recorded occurrence of the disagreement.

Closes #1771.

## Root cause

`evaluatePrGateCoordinationCore` honors `reviewMode: "internal_only"` in the `PR_READY_NO_FEEDBACK` branch but not in the sibling `READY_TO_REREQUEST_REVIEW` branch. In that branch the re-request-Copilot guard checked only `sameHeadCleanConverged`, `postConvergenceReviewSuppressed`, and the round-cap state — never `reviewMode`. So an internal-tooling PR that previously had a Copilot request (interpreter puts it in `READY_TO_REREQUEST_REVIEW`) and has no same-head convergence point was forced back to `REREQUEST_COPILOT_REVIEW` for a convergence point that will never exist. The verdict poster then refused the transition with "could not map this lifecycle state to a legal gate transition", directly contradicting the handoff's "run `pre_approval_gate` directly".

`reviewMode` already reaches the evaluator: `upsert-checkpoint-verdict.mjs` derives `internal_only` from the same `detectInternalOnly` classifier the handoff uses and passes it through. The gap was purely that this one branch did not consult it.

## Change

- Add `reviewMode !== "internal_only"` to the `READY_TO_REREQUEST_REVIEW` re-request guard. When suppressed, control falls to the existing pre-approval logic (RUN_PRE_APPROVAL_GATE / final-approval), exactly the handoff's routing. CI gating is unchanged — the CI blocks/waits run before this guard. `copilotReviewDisabled` (maxCopilotRounds:0) already folds into `internal_only`, so both suppression sources are covered.
- The no-convergence refusal reason now names the propagation wait: if a Copilot round just landed at this head it may not be visible yet, so the caller should re-check before treating it as a needed re-request (AC3, message variant).

No wiring change on the poster side; the suppressed status already arrives as `reviewMode`.

## Verification (DoD)

- `node --test packages/core/test/pr-gate-coordination.test.mjs` → 145/145 (two new pins).
- `npm run verify` → all 8 suites green (0 failures).

## Acceptance criteria

- [x] The internal-tooling suppression signal and the gate-boundary evaluator agree: when the watch layer says pre-approval can run directly, the verdict poster accepts the transition at that head without a same-head Copilot convergence point.
- [x] A test pins the suppressed-Copilot pre-approval entry path.
- [x] The transient variant (a just-landed Copilot round not yet visible) either retries internally or names the propagation wait in its refusal.

## Definition of done

- [x] Affected suites green; `npm run verify` green.

## Non-goals

- Loosening any gate precondition for non-suppressed external-review PRs. The new term fires only when `reviewMode === "internal_only"`; a non-suppressed PR keeps `reviewMode` null and hits the guard unchanged (pinned by a companion test that asserts it still re-requests Copilot).
- Adding an internal re-poll for the transient variant; the message variant of AC3 is used (naming the propagation wait), leaving an internal retry as a possible follow-up.
