### PR TITLE
fix(gate): shared carried-angles element validation at the programmatic seam (#1778)

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -450,10 +450,15 @@ export function parseWriteGateContextCliArgs(argv) {
       } catch {
         throw parseError("--carried-angles must be a JSON array of angle-name strings");
       }
-      if (!Array.isArray(parsed) || parsed.some((a) => typeof a !== "string" || a.trim().length === 0)) {
+      if (!Array.isArray(parsed)) {
         throw parseError("--carried-angles must be a JSON array of non-empty angle-name strings");
       }
-      options.carriedAngles = parsed.map((a) => a.trim());
+      // Element validation shared with resolveFanoutDispatch (issue 1778); the
+      // JSON-array shape is CLI-specific so it stays here, wording unchanged.
+      options.carriedAngles = normalizeCarriedAngleElements(
+        parsed,
+        () => parseError("--carried-angles must be a JSON array of non-empty angle-name strings"),
+      );
       continue;
     }
     if (token.name === "tmp-root") {
@@ -1669,6 +1674,38 @@ export function hasRenameEntry(nameStatusOutput) {
  * @param {object} options — parsed CLI options shape
  * @returns {object}
  */
+
+// Shared carried-angles element contract (issue 1778). One definition of a valid
+// carried angle — a non-empty-after-trim string — used by BOTH the CLI parse
+// (parseWriteGateContextCliArgs) and the programmatic seam (resolveFanoutDispatch)
+// so the two cannot drift. Each caller supplies its own error via makeError; the
+// element predicate and the trim live only here. Assumes an array (each caller
+// establishes iterability first).
+function normalizeCarriedAngleElements(elements, makeError) {
+  if (elements.some((a) => typeof a !== "string" || a.trim().length === 0)) {
+    throw makeError();
+  }
+  return elements.map((a) => a.trim());
+}
+
+// Programmatic entry contract for resolveFanoutDispatch's carriedAngles: an array
+// or any iterable of angle names. Reject the two silent-corruption inputs the CLI
+// parse already blocks but this seam did not (issue 1778): a bare string (would
+// spread into per-character angles) and a non-iterable (would throw a raw
+// TypeError on spread) — both with a named error. Returns a trimmed string[]
+// (empty for null/undefined).
+function normalizeCarriedAnglesArg(carriedAngles) {
+  if (carriedAngles == null) return [];
+  if (typeof carriedAngles === "string") {
+    throw new Error("carriedAngles must be an array (or iterable) of angle-name strings, not a bare string — a string spreads into per-character angles");
+  }
+  if (!Array.isArray(carriedAngles) && typeof carriedAngles[Symbol.iterator] !== "function") {
+    throw new Error("carriedAngles must be an array (or iterable) of angle-name strings");
+  }
+  const list = Array.isArray(carriedAngles) ? carriedAngles : [...carriedAngles];
+  return normalizeCarriedAngleElements(list, () => new Error("carriedAngles must contain only non-empty angle-name strings"));
+}
+
 /**
  * Resolve the fan-out dispatch plan for a gate round (issue #1601): the
  * dispatch units (`resolveFanoutGroups`), the bounded-concurrency wave plan
@@ -1711,8 +1748,7 @@ export function resolveFanoutDispatch(config, configGate, resolvedAngles, { full
   // name is NOT rejected here (this seam has no plan-proof cross-check to
   // validate an unrecognized name against, and resolveFanoutGroups already
   // treats an unresolved angle as ungrouped rather than erroring).
-  const carriedAnglesList =
-    carriedAngles == null ? [] : Array.isArray(carriedAngles) ? carriedAngles : [...carriedAngles];
+  const carriedAnglesList = normalizeCarriedAnglesArg(carriedAngles);
   if (carriedAnglesList.length > 0) {
     const mandatoryAngles = resolveGateAngleContract(config, configGate).mandatoryAngles;
     for (const angle of carriedAnglesList) {

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -1696,7 +1696,9 @@ function normalizeCarriedAngleElements(elements, makeError) {
 // (empty for null/undefined).
 function normalizeCarriedAnglesArg(carriedAngles) {
   if (carriedAngles == null) return [];
-  if (typeof carriedAngles === "string") {
+  // A primitive string and a boxed String wrapper are both iterable and would
+  // spread into per-character angles; reject both as a bare string.
+  if (typeof carriedAngles === "string" || carriedAngles instanceof String) {
     throw new Error("carriedAngles must be an array (or iterable) of angle-name strings, not a bare string — a string spreads into per-character angles");
   }
   if (!Array.isArray(carriedAngles) && typeof carriedAngles[Symbol.iterator] !== "function") {

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -4652,6 +4652,45 @@ test("#1635 resolveFanoutDispatch: absent carriedAngles is unchanged from today'
   assert.deepEqual(withoutCarried.preflight.carriedAngles, []);
 });
 
+test("issue 1778 resolveFanoutDispatch rejects a non-string carried-angle element with a named error (no silent String() coercion)", () => {
+  assert.throws(
+    () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: ["a", 1] }),
+    /carriedAngles must contain only non-empty angle-name strings/,
+  );
+});
+
+test("issue 1778 resolveFanoutDispatch rejects a blank (whitespace-only) carried-angle element with a named error", () => {
+  assert.throws(
+    () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: ["a", "   "] }),
+    /carriedAngles must contain only non-empty angle-name strings/,
+  );
+});
+
+test("issue 1778 resolveFanoutDispatch rejects a bare-string carriedAngles rather than spreading it into per-character angles", () => {
+  assert.throws(
+    () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: "abc" }),
+    /not a bare string/,
+  );
+});
+
+test("issue 1778 resolveFanoutDispatch rejects a non-iterable carriedAngles with a named error (not a raw TypeError)", () => {
+  assert.throws(
+    () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: 123 }),
+    /carriedAngles must be an array \(or iterable\) of angle-name strings/,
+  );
+});
+
+test("issue 1778 resolveFanoutDispatch accepts and trims a valid non-array iterable carriedAngles", () => {
+  // A Set is a legitimate iterable; the contract normalizes it like an array.
+  const plan = resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c", "d", "e"], {
+    fullLabel: false,
+    availableReviewers: 1,
+    carriedAngles: new Set([" d ", "e"]),
+  });
+  assert.deepEqual(plan.preflight.carriedAngles, ["d", "e"]);
+  assert.equal(plan.preflight.requiredReviewers, 1);
+});
+
 test("#1507 buildGateContextArtifact carries the preflight in fanout.preflight", () => {
   const plan = resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b"], { fullLabel: false, availableReviewers: 0 });
   const artifact = buildGateContextArtifact({

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -4673,6 +4673,14 @@ test("issue 1778 resolveFanoutDispatch rejects a bare-string carriedAngles rathe
   );
 });
 
+test("issue 1778 resolveFanoutDispatch rejects a boxed String wrapper as a bare string (not spread per-character)", () => {
+  assert.throws(
+    // eslint-disable-next-line no-new-wrappers
+    () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: new String("abc") }),
+    /not a bare string/,
+  );
+});
+
 test("issue 1778 resolveFanoutDispatch rejects a non-iterable carriedAngles with a named error (not a raw TypeError)", () => {
   assert.throws(
     () => resolveFanoutDispatch({ version: 1 }, "draft", ["a", "b", "c"], { carriedAngles: 123 }),


### PR DESCRIPTION
## Objective

Share the carried-angles element validation between the CLI parse and the programmatic `resolveFanoutDispatch` seam so a malformed `carriedAngles` input cannot silently corrupt the dispatch plan. Two deferred draft-gate findings from the carried-angles preflight work. Internal-tooling, test + script only.

Closes #1778.

## Root cause

`parseWriteGateContextCliArgs` rejected non-string, empty, and whitespace-only `--carried-angles` elements, but a programmatic caller of `resolveFanoutDispatch` bypassed that check:

- a non-string element was silently `String(a)`-coerced in `reviewerBudgetPreflight`'s key normalization,
- a bare string was spread into per-character angles (`[..."abc"]` → `["a","b","c"]`),
- a number threw a raw `TypeError` on the spread instead of a named contract error.

## Change

- Extract the element predicate (string, non-empty after trim) + the trim into one `normalizeCarriedAngleElements`, used by BOTH `parseWriteGateContextCliArgs` and `resolveFanoutDispatch` so the two paths cannot drift (AC1).
- Add `normalizeCarriedAnglesArg`, the programmatic entry contract: it rejects a bare string — primitive or boxed `String` wrapper (AC2) — and a non-iterable (AC3) with named errors before any spread, accepts any real iterable, and returns a trimmed `string[]`.
- The CLI keeps its JSON-array shape check and exact error wording; existing parse tests stay green (AC4).

Non-goal respected: `reviewerBudgetPreflight`'s exclusion semantics, the mandatory-angle refusal, and `completedAngles`' contract are all untouched — the fix rejects a bad `carriedAngles` upstream at the `resolveFanoutDispatch` seam.

## Verification (DoD)

- `node --test test/github/write-gate-context.test.mjs packages/core/test/gate-fanin.test.mjs` → 360/360 (six new pins: non-string element, blank element, bare string, boxed String wrapper, non-iterable, valid non-array iterable).
- `npm run verify` → all suites green (0 failures).

## Acceptance criteria

- [x] `resolveFanoutDispatch` validates carried-angle elements (string, non-empty after trim) with a named error, shared with the CLI parse so the two paths cannot drift.
- [x] A bare-string `carriedAngles` input is rejected with a named error rather than spread into per-character angles.
- [x] Tests pin the programmatic malformed-input contract: non-string element, blank element, bare string, non-iterable.
- [x] The CLI path's behavior and error wording stay unchanged (existing parse tests stay green).

## Definition of done

- [x] `node --test test/github/write-gate-context.test.mjs packages/core/test/gate-fanin.test.mjs` green.
- [x] `npm run verify` green.

## Non-goals

- No change to the preflight's exclusion semantics or the mandatory-angle refusal.
- No new validation on unrelated preflight inputs (`completedAngles` keeps its current contract).
