### PR TITLE
refactor(gate): shared carried-angles JSON-array parser + parseNonNegativeInteger diagnosability

### DIFF
--- a/packages/core/src/cli/primitives.mjs
+++ b/packages/core/src/cli/primitives.mjs
@@ -115,7 +115,7 @@ export function parsePositiveInteger(value, flag, parseError = null) {
 
 export function parseNonNegativeInteger(value, flag, parseError = null) {
   if (!/^\d+$/.test(value)) {
-    throw toCliError(`${flag} must be a non-negative integer`, parseError);
+    throw toCliError(`${flag} must be a non-negative integer, got "${value}"`, parseError);
   }
   return Number(value);
 }

--- a/scripts/github/_carried-angles.mjs
+++ b/scripts/github/_carried-angles.mjs
@@ -1,0 +1,33 @@
+// Shared --carried-angles JSON-array CLI parse (issue 1782), used by both
+// write-gate-context.mjs and consolidate-fanin.mjs's own --carried-angles
+// flag so the two can never drift on accepted shape or error wording. Both
+// CLIs name the flag identically, so its error text is hardcoded here rather
+// than parameterized per caller.
+
+// One definition of a valid carried angle — a non-empty-after-trim string —
+// shared by the CLI parse below and write-gate-context.mjs's own programmatic
+// seam (resolveFanoutDispatch's carriedAngles option). Each caller supplies
+// its own error via makeError; the element predicate and the trim live only
+// here. Assumes an array (each caller establishes iterability first).
+export function normalizeCarriedAngleElements(elements, makeError) {
+  if (elements.some((a) => typeof a !== "string" || a.trim().length === 0)) {
+    throw makeError();
+  }
+  return elements.map((a) => a.trim());
+}
+
+// Parses a raw --carried-angles flag value (a JSON string): JSON.parse, an
+// array-shape check, then non-empty-string element validation. Returns the
+// trimmed angle-name array.
+export function parseCarriedAnglesJsonArray(raw, parseError) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw parseError("--carried-angles must be a JSON array of angle-name strings");
+  }
+  if (!Array.isArray(parsed)) {
+    throw parseError("--carried-angles must be a JSON array of non-empty angle-name strings");
+  }
+  return normalizeCarriedAngleElements(parsed, () => parseError("--carried-angles must be a JSON array of non-empty angle-name strings"));
+}

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -49,6 +49,7 @@ import { viewPr } from "./view-pr.mjs";
 import { viewIssue } from "./view-issue.mjs";
 import { buildAdjacentBundle, DEFAULT_MAX_FILE_BYTES } from "./build-adjacent-bundle.mjs";
 import { GATE_NAMES, gateScopePrefix, normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "./_gate-names.mjs";
+import { normalizeCarriedAngleElements, parseCarriedAnglesJsonArray } from "./_carried-angles.mjs";
 import { resolveLinkedIssuesFromPr } from "../loop/detect-pr-gate-coordination-state.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -444,21 +445,10 @@ export function parseWriteGateContextCliArgs(argv) {
       // with no mechanical catch, traceable only through this artifact's own
       // carried-angle provenance.
       const raw = requireTokenValue(token, parseError);
-      let parsed;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
-        throw parseError("--carried-angles must be a JSON array of angle-name strings");
-      }
-      if (!Array.isArray(parsed)) {
-        throw parseError("--carried-angles must be a JSON array of non-empty angle-name strings");
-      }
-      // Element validation shared with resolveFanoutDispatch (issue 1778); the
-      // JSON-array shape is CLI-specific so it stays here, wording unchanged.
-      options.carriedAngles = normalizeCarriedAngleElements(
-        parsed,
-        () => parseError("--carried-angles must be a JSON array of non-empty angle-name strings"),
-      );
+      // Parse shared with consolidate-fanin.mjs's own --carried-angles flag
+      // (issue 1782), so the two CLIs' accepted shape and wording can never
+      // drift.
+      options.carriedAngles = parseCarriedAnglesJsonArray(raw, parseError);
       continue;
     }
     if (token.name === "tmp-root") {
@@ -1674,19 +1664,6 @@ export function hasRenameEntry(nameStatusOutput) {
  * @param {object} options — parsed CLI options shape
  * @returns {object}
  */
-
-// Shared carried-angles element contract (issue 1778). One definition of a valid
-// carried angle — a non-empty-after-trim string — used by BOTH the CLI parse
-// (parseWriteGateContextCliArgs) and the programmatic seam (resolveFanoutDispatch)
-// so the two cannot drift. Each caller supplies its own error via makeError; the
-// element predicate and the trim live only here. Assumes an array (each caller
-// establishes iterability first).
-function normalizeCarriedAngleElements(elements, makeError) {
-  if (elements.some((a) => typeof a !== "string" || a.trim().length === 0)) {
-    throw makeError();
-  }
-  return elements.map((a) => a.trim());
-}
 
 // Programmatic entry contract for resolveFanoutDispatch's carriedAngles: an array
 // or any iterable of angle names. Reject the two silent-corruption inputs the CLI

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -58,6 +58,7 @@ import { requireTokenValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { GATE_NAMES } from "../github/_gate-names.mjs";
+import { parseCarriedAnglesJsonArray } from "../github/_carried-angles.mjs";
 import { isPostedCommentLimitError, normalizeStructuredFindings, renderStructuredFindings } from "../github/upsert-checkpoint-verdict.mjs";
 import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixes.mjs";
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
@@ -664,17 +665,10 @@ export function parseConsolidateFaninCliArgs(argv) {
       continue;
     }
     if (token.name === "carried-angles") {
-      const raw = requireTokenValue(token, parseError);
-      let parsed;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
-        throw parseError("--carried-angles must be a JSON array of angle-name strings");
-      }
-      if (!Array.isArray(parsed) || parsed.some((a) => typeof a !== "string" || a.trim().length === 0)) {
-        throw parseError("--carried-angles must be a JSON array of non-empty angle-name strings");
-      }
-      options.carriedAngles = parsed.map((a) => a.trim());
+      // Parse shared with write-gate-context.mjs's own --carried-angles flag
+      // (issue 1782), so the two CLIs' accepted shape and wording can never
+      // drift.
+      options.carriedAngles = parseCarriedAnglesJsonArray(requireTokenValue(token, parseError), parseError);
       continue;
     }
     if (token.name === "carry-forward-plan") {

--- a/test/loop/cli-primitives.test.mjs
+++ b/test/loop/cli-primitives.test.mjs
@@ -154,7 +154,7 @@ test("parseNonNegativeInteger accepts zero and rejects invalid values", () => {
   assert.equal(parseNonNegativeInteger("0", "--timeout-ms"), 0);
   assert.throws(
     () => parseNonNegativeInteger("abc", "--timeout-ms", (message) => Object.assign(new Error(message), { usage: "usage" })),
-    (error) => error.message === "--timeout-ms must be a non-negative integer" && error.usage === "usage",
+    (error) => error.message === '--timeout-ms must be a non-negative integer, got "abc"' && error.usage === "usage",
   );
 });
 


### PR DESCRIPTION
## Objective

Close out the parse-layer remainder of the carried-angles preflight work: share the `--carried-angles` JSON-array parse between the two CLIs and restore `parseNonNegativeInteger` diagnosability. Sibling of #1778 (programmatic element validation), which already landed the bare-string rejection.

Closes #1782.

## Change

- AC1 (bare-string rejection at the programmatic seam) was already delivered by #1778: `normalizeCarriedAnglesArg` in `write-gate-context.mjs` rejects a bare primitive string and a boxed `String` with a named error before any spread. Confirmed against the merged code; no further change needed, and now importing the shared element validator.
- AC2: extracted the byte-behavior-identical `--carried-angles` JSON-array parse (`JSON.parse` → array-shape check → non-empty-string element check → trim) into `scripts/github/_carried-angles.mjs` (`parseCarriedAnglesJsonArray` + `normalizeCarriedAngleElements`), following the existing `_gate-names.mjs` shared-helper convention. Both `write-gate-context.mjs` and `consolidate-fanin.mjs` now call it; each CLI's prior error wording is preserved.
- AC3: `parseNonNegativeInteger` (`packages/core/src/cli/primitives.mjs`) now includes the offending value in its rejection message (`… got "<value>"`), restoring pre-migration diagnosability. Fixed at the shared helper source; the one exact-equality test pin updated, all substring/regex pins unchanged.

## Verification (DoD)

- `npm run verify` → exit 0, all suites green (one `capture-review-threads` EPIPE flake on a parallel run, confirmed pre-existing/flaky via a standalone pass and a clean full rerun).

## Acceptance criteria

- [x] A bare string at the programmatic `carriedAngles` seam is rejected with a named error rather than spread into per-character angles (delivered by #1778; verified).
- [x] The `--carried-angles` JSON-array parse block is extracted into a helper shared with the consolidate-fanin copy.
- [x] `parseNonNegativeInteger` rejections include the offending value (helper-wide).

## Definition of done

- [x] Affected suites green; `npm run verify` green.

## Non-goals

- No change to accepted input shapes on either CLI.
