### PR TITLE
feat(gate): fan-in catch for a clean round with an unproven resolved angle

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -958,7 +958,27 @@ mechanical refusal catching it; the only trace is the ledger's own
 carried-angle provenance. The direction stays fail-safe for budget/spend
 either way — it can under-dispatch, never over-spend or fabricate findings
 for an angle that DID run — it just does not mechanically catch every
-under-dispatch.
+under-dispatch by itself. A fan-in-side, angle-agnostic backstop for exactly
+this gap is `checkResolvedAngleEvidence` (`@dev-loops/core/loop/gate-fanin`):
+given the round's full RESOLVED angle set (not just its configured mandatory
+subset), it fails closed on any resolved angle with neither a real per-angle
+artifact nor a proven carry. `consolidate-fanin.mjs` wires it through its own
+`--resolved-angles <json>` flag — when supplied, and only when the round's
+computed verdict is `clean`, a missing resolved angle refuses the pass, naming
+the angle(s) and the artifact/proof expected. This closes the mandatory-only
+gap above whenever a caller supplies `--resolved-angles`; today no caller does
+(preventative — no live regression this catch fires against yet), so this
+does not change the mandatory-only enforcement any existing caller relies on.
+
+<!-- rule: GATE-EXEC-RESOLVED-ANGLE-EVIDENCE -->
+`GATE-EXEC-RESOLVED-ANGLE-EVIDENCE`: when `consolidate-fanin.mjs` is invoked
+with `--resolved-angles <json>` (the round's full resolved angle-name list,
+e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`/`angles`
+field) and the round's computed overall verdict is `clean`, every named
+resolved angle MUST have either a real per-angle artifact in `--findings-dir`
+or a proven carry (a name also present in `--carried-angles`, itself only
+ever populated after its own `--carry-forward-plan` proof check). A resolved
+angle with neither FAILS CLOSED (exit 1), naming the missing angle(s).
 
 <!-- rule: GATE-EXEC-PRIMER-EVIDENCE -->
 `GATE-EXEC-PRIMER-EVIDENCE`: when the round recorded primer-dispatch ordering

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -973,7 +973,7 @@ does not change the mandatory-only enforcement any existing caller relies on.
 <!-- rule: GATE-EXEC-RESOLVED-ANGLE-EVIDENCE -->
 `GATE-EXEC-RESOLVED-ANGLE-EVIDENCE`: when `consolidate-fanin.mjs` is invoked
 with `--resolved-angles <json>` (the round's full resolved angle-name list,
-e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`/`angles`
+e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`
 field) and the round's computed overall verdict is `clean`, every named
 resolved angle MUST have either a real per-angle artifact in `--findings-dir`
 or a proven carry (a name also present in `--carried-angles`, itself only

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -744,6 +744,56 @@ export function checkFanoutAngleCoverage(recordedAngles, { mandatoryAngles = [],
 export const FANIN_SYNTHETIC_ANGLES = Object.freeze(["pr-checklist-matrix"]);
 
 /**
+ * Validate a round's RESOLVED angle set — the full angle list the round
+ * targeted, independent of any single gate's configured MANDATORY subset —
+ * against the evidence actually recorded for it: every resolved angle must
+ * have either a per-angle artifact in `recordedAngles` (matched by
+ * {@link baseAngleName}, same rule as {@link checkFanoutAngleCoverage}) or be
+ * named in `carriedAngles` (angle names a caller has already PROVEN carried
+ * forward from a prior clean head — never a bare, unverified name; the
+ * consolidate-fanin CLI's own `--carried-angles` is only ever populated after
+ * its `--carry-forward-plan` proof check, so passing it straight through here
+ * keeps that same guarantee).
+ *
+ * This closes a gap {@link checkFanoutAngleCoverage} leaves open: that check
+ * only protects a CALLER-SUPPLIED mandatory subset, so a wrong carry-forward
+ * declaration naming only NON-mandatory angles under-dispatches with no
+ * mechanical refusal — visible only in the ledger's own carried-angle
+ * provenance (see the Gate Review Sub-Loop Contract's Phase 3 backstop
+ * paragraph). This function protects every resolved angle, not just the
+ * mandatory ones. Pure.
+ *
+ * @param {unknown} resolvedAngles — the round's full resolved angle-name list
+ * @param {object} [evidence]
+ * @param {unknown} [evidence.recordedAngles] — array of `{ angle: string, ... }` entries (per-angle artifacts this round consolidated)
+ * @param {Iterable<string>} [evidence.carriedAngles] — angle names already proven carried forward
+ * @returns {{ missingAngles: string[] }}
+ */
+export function checkResolvedAngleEvidence(resolvedAngles, { recordedAngles, carriedAngles } = {}) {
+  const resolved = Array.isArray(resolvedAngles)
+    ? [...new Set(
+        resolvedAngles
+          .map((a) => (typeof a === "string" ? a.trim() : ""))
+          .filter((a) => a.length > 0),
+      )]
+    : [];
+  const recorded = Array.isArray(recordedAngles)
+    ? recordedAngles
+      .map((e) => (e && typeof e === "object" && typeof e.angle === "string" ? e.angle.trim() : ""))
+      .filter((a) => a.length > 0)
+    : [];
+  const recordedBases = new Set(recorded.map(baseAngleName));
+  const carriedBases = new Set(
+    [...(carriedAngles ?? [])].map((a) => baseAngleName(String(a).trim())),
+  );
+  const missingAngles = resolved.filter((a) => {
+    const base = baseAngleName(a);
+    return !recordedBases.has(base) && !carriedBases.has(base);
+  });
+  return { missingAngles };
+}
+
+/**
  * Default cap on parallel fan-out reviewers when a caller does not supply one.
  * Mirrors the config default (gates.maxFanoutReviewers).
  */

--- a/packages/core/src/loop/gate-fanin.mjs
+++ b/packages/core/src/loop/gate-fanin.mjs
@@ -748,7 +748,8 @@ export const FANIN_SYNTHETIC_ANGLES = Object.freeze(["pr-checklist-matrix"]);
  * targeted, independent of any single gate's configured MANDATORY subset —
  * against the evidence actually recorded for it: every resolved angle must
  * have either a per-angle artifact in `recordedAngles` (matched by
- * {@link baseAngleName}, same rule as {@link checkFanoutAngleCoverage}) or be
+ * {@link baseAngleName} plus a case-insensitive compare — same base+lowercase
+ * rule consolidate-fanin.mjs applies to its own angle keys) or be
  * named in `carriedAngles` (angle names a caller has already PROVEN carried
  * forward from a prior clean head — never a bare, unverified name; the
  * consolidate-fanin CLI's own `--carried-angles` is only ever populated after
@@ -782,12 +783,18 @@ export function checkResolvedAngleEvidence(resolvedAngles, { recordedAngles, car
       .map((e) => (e && typeof e === "object" && typeof e.angle === "string" ? e.angle.trim() : ""))
       .filter((a) => a.length > 0)
     : [];
-  const recordedBases = new Set(recorded.map(baseAngleName));
+  // Matched base+lowercase, same as checkFanoutAngleCoverage's callers
+  // (consolidate-fanin's realAngleKeys/exemptCarriedKeys) and
+  // reviewerBudgetPreflight's normalizeAngleKey: per-angle artifacts are
+  // independently authored, so a case difference between a resolved angle
+  // name and its recorded/carried evidence must not read as missing.
+  const normalizeAngleBase = (a) => baseAngleName(a).toLowerCase();
+  const recordedBases = new Set(recorded.map(normalizeAngleBase));
   const carriedBases = new Set(
-    [...(carriedAngles ?? [])].map((a) => baseAngleName(String(a).trim())),
+    [...(carriedAngles ?? [])].map((a) => normalizeAngleBase(String(a).trim())),
   );
   const missingAngles = resolved.filter((a) => {
-    const base = baseAngleName(a);
+    const base = normalizeAngleBase(a);
     return !recordedBases.has(base) && !carriedBases.has(base);
   });
   return { missingAngles };

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -810,6 +810,17 @@ describe("checkResolvedAngleEvidence (#1783 — fan-in catch for a resolved angl
     assert.deepEqual(result.missingAngles, []);
   });
 
+  test("matches case-insensitively — a resolved angle differing only in case from its artifact/carry is not falsely missing", () => {
+    // Per-angle artifacts are independently authored, so a resolved "Dry" must still match a
+    // recorded/carried "dry" — same base+lowercase rule consolidate-fanin.mjs applies to its own
+    // angle keys (realAngleKeys/exemptCarriedKeys).
+    const result = checkResolvedAngleEvidence(
+      ["correctness", "Dry", "KISS"],
+      { recordedAngles: [{ angle: "correctness" }, { angle: "dry" }], carriedAngles: ["kiss"] },
+    );
+    assert.deepEqual(result.missingAngles, []);
+  });
+
   test("tolerates malformed/missing input (non-array resolvedAngles/recordedAngles, entries without a usable .angle)", () => {
     assert.deepEqual(checkResolvedAngleEvidence(undefined, {}).missingAngles, []);
     assert.deepEqual(

--- a/packages/core/test/gate-fanin.test.mjs
+++ b/packages/core/test/gate-fanin.test.mjs
@@ -11,6 +11,7 @@ import {
   countDistinctReviewers,
   provenanceConsistencyError,
   checkFanoutAngleCoverage,
+  checkResolvedAngleEvidence,
   countFreshDispatchUnits,
   fanoutReviewerPairingError,
   freshAngleNames,
@@ -761,6 +762,60 @@ describe("checkFanoutAngleCoverage (#1196 — mandatory angles + angle-pool memb
       { mandatoryAngles: [], pool: ["dry", "kiss"] },
     );
     assert.deepEqual(result.foreignAngles, []);
+  });
+});
+
+describe("checkResolvedAngleEvidence (#1783 — fan-in catch for a resolved angle with neither an artifact nor a proven carry)", () => {
+  test("refuses when a wrongly-carried NON-mandatory angle has neither an artifact nor a proven carry", () => {
+    // "correctness" and "yagni" were both freshly reviewed (real artifacts); "dry" was the
+    // round's resolved set too, but no artifact was written for it and it was never carried —
+    // the exact under-dispatch shape checkFanoutAngleCoverage's own mandatory-only check misses
+    // when "dry" is not a configured mandatory angle.
+    const result = checkResolvedAngleEvidence(
+      ["correctness", "yagni", "dry"],
+      {
+        recordedAngles: [{ angle: "correctness" }, { angle: "yagni" }],
+        carriedAngles: [],
+      },
+    );
+    assert.deepEqual(result.missingAngles, ["dry"]);
+  });
+
+  test("passes when every resolved angle has either a real artifact or a proven carry", () => {
+    const result = checkResolvedAngleEvidence(
+      ["correctness", "yagni", "dry"],
+      {
+        recordedAngles: [{ angle: "correctness" }, { angle: "yagni" }],
+        carriedAngles: ["dry"],
+      },
+    );
+    assert.deepEqual(result.missingAngles, []);
+  });
+
+  test("a grouped-but-ran angle (its own per-angle artifact, written by a shared-group reviewer) counts as covered", () => {
+    // Grouped dispatch still writes one per-angle artifact per angle it covers (never one
+    // merged artifact for the group) — so a grouped angle needs no special-casing here.
+    const result = checkResolvedAngleEvidence(
+      ["correctness", "dry", "kiss"],
+      { recordedAngles: [{ angle: "correctness" }, { angle: "dry" }, { angle: "kiss" }], carriedAngles: [] },
+    );
+    assert.deepEqual(result.missingAngles, []);
+  });
+
+  test("delta-suffixed artifacts and carries count toward their base angle", () => {
+    const result = checkResolvedAngleEvidence(
+      ["correctness", "dry"],
+      { recordedAngles: [{ angle: "correctness-delta-at-abc123" }], carriedAngles: ["dry"] },
+    );
+    assert.deepEqual(result.missingAngles, []);
+  });
+
+  test("tolerates malformed/missing input (non-array resolvedAngles/recordedAngles, entries without a usable .angle)", () => {
+    assert.deepEqual(checkResolvedAngleEvidence(undefined, {}).missingAngles, []);
+    assert.deepEqual(
+      checkResolvedAngleEvidence(["dry"], { recordedAngles: [null, { angle: "" }, "nope"] }).missingAngles,
+      ["dry"],
+    );
   });
 });
 

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -161,8 +161,8 @@ Optional:
                                  normalized trim+lowercase). Required together with --carried-angles (given
                                  without it, or vice versa, fails closed at parse time).
   --resolved-angles <json>       JSON array of angle-name strings naming the round's FULL resolved angle
-                                 set (e.g. write-gate-context.mjs's own context artifact "resolvedAngles"/
-                                 "angles" field) — independent of any single gate's configured MANDATORY
+                                 set (e.g. write-gate-context.mjs's own context artifact "resolvedAngles"
+                                 field) — independent of any single gate's configured MANDATORY
                                  subset. When given AND the round's computed overall verdict is "clean",
                                  every named angle must have EITHER a real per-angle artifact in
                                  --findings-dir OR a proven carry (a name also present in --carried-angles,

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -58,12 +58,12 @@ import { requireTokenValue } from "../_cli-primitives.mjs";
 import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { GATE_NAMES } from "../github/_gate-names.mjs";
-import { parseCarriedAnglesJsonArray } from "../github/_carried-angles.mjs";
+import { normalizeCarriedAngleElements, parseCarriedAnglesJsonArray } from "../github/_carried-angles.mjs";
 import { isPostedCommentLimitError, normalizeStructuredFindings, renderStructuredFindings } from "../github/upsert-checkpoint-verdict.mjs";
 import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixes.mjs";
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
-import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, consolidateFanin, normalizeSeverity, severityRank, tallySeverities, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
+import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, checkResolvedAngleEvidence, consolidateFanin, normalizeSeverity, severityRank, tallySeverities, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
 import { enforceCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { enforcePrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 
@@ -160,6 +160,20 @@ Optional:
                                  be a 7-64 char hex SHA (write-gate-findings-log.mjs's own provenance bound;
                                  normalized trim+lowercase). Required together with --carried-angles (given
                                  without it, or vice versa, fails closed at parse time).
+  --resolved-angles <json>       JSON array of angle-name strings naming the round's FULL resolved angle
+                                 set (e.g. write-gate-context.mjs's own context artifact "resolvedAngles"/
+                                 "angles" field) — independent of any single gate's configured MANDATORY
+                                 subset. When given AND the round's computed overall verdict is "clean",
+                                 every named angle must have EITHER a real per-angle artifact in
+                                 --findings-dir OR a proven carry (a name also present in --carried-angles,
+                                 which is only ever populated after its own --carry-forward-plan proof
+                                 check above) — otherwise this FAILS CLOSED (exit 1), naming the missing
+                                 angle(s) and the artifact/proof expected for each. This is the mechanical
+                                 fan-in-side catch for a resolved angle left with no evidence at all — see
+                                 checkResolvedAngleEvidence (@dev-loops/core/loop/gate-fanin) and the Gate
+                                 Review Sub-Loop Contract's Phase 3 backstop paragraph. Optional; omitted
+                                 by default (no caller supplies it yet) — the hash/mandatory-angle checks
+                                 elsewhere in this pass still run either way.
   --repo-root <path>             Root used to resolve this worktree's config (loadDevLoopConfig) when
                                  --gate is given (default: process.cwd()) — makes the overall verdict
                                  deterministic regardless of the CLI's invocation directory
@@ -272,7 +286,9 @@ Exit codes:
      render budget at minimum summary length with --ledger-out not given, or a
      GATE-EXEC-BRIEFING-PREFIX verification failure when --head-sha is given
      (a sentinel records a divergent/missing prefix hash, or the sentinel count
-     is short of --expected-dispatch-units) — #1618
+     is short of --expected-dispatch-units) — #1618, or (with --resolved-angles
+     and a "clean" verdict) a resolved angle with neither a per-angle artifact
+     nor a proven carried-forward entry
   2  Invalid --jq filter`.trim();
 
 const parseError = buildParseError(USAGE);
@@ -583,6 +599,7 @@ export function parseConsolidateFaninCliArgs(argv) {
     prChecklistMatrix: undefined,
     carriedAngles: undefined,
     carryForwardPlan: undefined,
+    resolvedAngles: undefined,
     repoRoot: undefined,
     expectedDispatchUnits: undefined,
     primerEvidence: undefined,
@@ -602,6 +619,7 @@ export function parseConsolidateFaninCliArgs(argv) {
       "pr-checklist-matrix": { type: "string" },
       "carried-angles": { type: "string" },
       "carry-forward-plan": { type: "string" },
+      "resolved-angles": { type: "string" },
       "repo-root": { type: "string" },
       "expected-dispatch-units": { type: "string" },
       "primer-evidence": { type: "string" },
@@ -684,6 +702,23 @@ export function parseConsolidateFaninCliArgs(argv) {
       } catch (err) {
         throw parseError(err instanceof Error ? err.message : String(err));
       }
+      continue;
+    }
+    if (token.name === "resolved-angles") {
+      const raw = requireTokenValue(token, parseError);
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw parseError("--resolved-angles must be a JSON array of angle-name strings");
+      }
+      if (!Array.isArray(parsed)) {
+        throw parseError("--resolved-angles must be a JSON array of non-empty angle-name strings");
+      }
+      options.resolvedAngles = normalizeCarriedAngleElements(
+        parsed,
+        () => parseError("--resolved-angles must be a JSON array of non-empty angle-name strings"),
+      );
       continue;
     }
     if (token.name === "repo-root") {
@@ -1295,6 +1330,30 @@ export async function consolidateGateFanin(options) {
           .join("; ")
       : "one or more per-angle artifacts report a blocked verdict";
     throw new Error(`fan-in is blocked — refusing to emit a consolidated findings shape (${detail})`);
+  }
+
+  // GATE-EXEC-RESOLVED-ANGLE-EVIDENCE: when the caller names the round's full
+  // resolved angle set (--resolved-angles) and this round computed a "clean"
+  // verdict, every resolved angle must have either a real per-angle artifact
+  // or a proven carry — checkFanoutAngleCoverage's own mandatory-angle check
+  // (elsewhere in the write/read paths that consume this ledger) protects
+  // only a caller-supplied MANDATORY subset, so a wrong carry-forward
+  // declaration naming only non-mandatory angles could otherwise close clean
+  // with no mechanical refusal (see the Gate Review Sub-Loop Contract's Phase
+  // 3 backstop paragraph). `rawArtifacts` already includes both real
+  // artifacts and any --carried-angles upserts at this point, so passing
+  // `options.carriedAngles` alongside it is redundant-but-harmless for those
+  // — it only makes a difference for a resolved angle with NEITHER.
+  if (options.resolvedAngles !== undefined && consolidated.verdict === "clean") {
+    const { missingAngles } = checkResolvedAngleEvidence(options.resolvedAngles, {
+      recordedAngles: rawArtifacts,
+      carriedAngles: options.carriedAngles ?? [],
+    });
+    if (missingAngles.length > 0) {
+      throw new Error(
+        `GATE-EXEC-RESOLVED-ANGLE-EVIDENCE: fan-in computed a "clean" verdict but --resolved-angles names angle(s) with no evidence at all: ${missingAngles.join(", ")} — each expected either a per-angle findings artifact in --findings-dir or a proven carried-forward entry in --carried-angles/--carry-forward-plan; neither was found`,
+      );
+    }
   }
 
   // --ledger-out is the durable, always-complete audit trail and must land on

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -958,7 +958,27 @@ mechanical refusal catching it; the only trace is the ledger's own
 carried-angle provenance. The direction stays fail-safe for budget/spend
 either way — it can under-dispatch, never over-spend or fabricate findings
 for an angle that DID run — it just does not mechanically catch every
-under-dispatch.
+under-dispatch by itself. A fan-in-side, angle-agnostic backstop for exactly
+this gap is `checkResolvedAngleEvidence` (`@dev-loops/core/loop/gate-fanin`):
+given the round's full RESOLVED angle set (not just its configured mandatory
+subset), it fails closed on any resolved angle with neither a real per-angle
+artifact nor a proven carry. `consolidate-fanin.mjs` wires it through its own
+`--resolved-angles <json>` flag — when supplied, and only when the round's
+computed verdict is `clean`, a missing resolved angle refuses the pass, naming
+the angle(s) and the artifact/proof expected. This closes the mandatory-only
+gap above whenever a caller supplies `--resolved-angles`; today no caller does
+(preventative — no live regression this catch fires against yet), so this
+does not change the mandatory-only enforcement any existing caller relies on.
+
+<!-- rule: GATE-EXEC-RESOLVED-ANGLE-EVIDENCE -->
+`GATE-EXEC-RESOLVED-ANGLE-EVIDENCE`: when `consolidate-fanin.mjs` is invoked
+with `--resolved-angles <json>` (the round's full resolved angle-name list,
+e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`/`angles`
+field) and the round's computed overall verdict is `clean`, every named
+resolved angle MUST have either a real per-angle artifact in `--findings-dir`
+or a proven carry (a name also present in `--carried-angles`, itself only
+ever populated after its own `--carry-forward-plan` proof check). A resolved
+angle with neither FAILS CLOSED (exit 1), naming the missing angle(s).
 
 <!-- rule: GATE-EXEC-PRIMER-EVIDENCE -->
 `GATE-EXEC-PRIMER-EVIDENCE`: when the round recorded primer-dispatch ordering

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -973,7 +973,7 @@ does not change the mandatory-only enforcement any existing caller relies on.
 <!-- rule: GATE-EXEC-RESOLVED-ANGLE-EVIDENCE -->
 `GATE-EXEC-RESOLVED-ANGLE-EVIDENCE`: when `consolidate-fanin.mjs` is invoked
 with `--resolved-angles <json>` (the round's full resolved angle-name list,
-e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`/`angles`
+e.g. `write-gate-context.mjs`'s own context artifact `resolvedAngles`
 field) and the round's computed overall verdict is `clean`, every named
 resolved angle MUST have either a real per-angle artifact in `--findings-dir`
 or a proven carry (a name also present in `--carried-angles`, itself only

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -299,6 +299,11 @@
       "id": "GATE-EXEC-REGATE-MANDATORY"
     },
     {
+      "id": "GATE-EXEC-RESOLVED-ANGLE-EVIDENCE",
+      "enforcement": "runtime",
+      "enforcementNote": "consolidate-fanin.mjs's --resolved-angles refuses a clean verdict via gate-fanin.mjs checkResolvedAngleEvidence when a resolved angle has neither an artifact nor a proven carry"
+    },
+    {
       "id": "GATE-EXEC-REVIEWER-BUDGET-PREFLIGHT"
     },
     {

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -959,6 +959,69 @@ test("parseConsolidateFaninCliArgs rejects unparseable/non-array/empty-string --
   );
 });
 
+test("parseConsolidateFaninCliArgs parses --resolved-angles", () => {
+  const result = parseConsolidateFaninCliArgs([
+    "--findings-dir", "/tmp/x",
+    "--resolved-angles", '["correctness","dry"]',
+  ]);
+  assert.deepEqual(result.resolvedAngles, ["correctness", "dry"]);
+});
+
+test("parseConsolidateFaninCliArgs rejects unparseable/non-array/empty-string --resolved-angles", () => {
+  assert.throws(
+    () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--resolved-angles", "not json"]),
+    /--resolved-angles must be a JSON array/,
+  );
+  assert.throws(
+    () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--resolved-angles", '{"angle":"dry"}']),
+    /--resolved-angles must be a JSON array of non-empty angle-name strings/,
+  );
+  assert.throws(
+    () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--resolved-angles", '["dry",""]']),
+    /--resolved-angles must be a JSON array of non-empty angle-name strings/,
+  );
+});
+
+// #1783: checkFanoutAngleCoverage's own mandatory-angle check misses a wrong
+// carry-forward declaration naming only a NON-mandatory angle — it never
+// looks past the caller-supplied mandatory subset. --resolved-angles is the
+// fan-in-side backstop that protects every resolved angle, not just the
+// mandatory ones.
+test("consolidateGateFanin refuses a clean verdict when --resolved-angles names a wrongly-carried NON-mandatory angle with no artifact and no proven carry", async () => {
+  await withFindingsDir(
+    { "correctness.json": { angle: "correctness", verdict: "clean", findings: [] } },
+    async (dir) => {
+      // "dry" is part of this round's resolved set but was neither reviewed
+      // (no artifact) nor declared carried — exactly the gap a wrong
+      // write-gate-context.mjs --carried-angles list leaves behind.
+      await assert.rejects(
+        () => consolidateGateFanin({ findingsDir: dir, resolvedAngles: ["correctness", "dry"] }),
+        /GATE-EXEC-RESOLVED-ANGLE-EVIDENCE.*"clean".*dry/s,
+      );
+    },
+  );
+});
+
+test("consolidateGateFanin passes when every --resolved-angles angle has a real artifact or a proven carry", async () => {
+  await withMinimalConfigRepoRoot(async (repoRoot) => {
+    await withFindingsDir(
+      { "correctness.json": { angle: "correctness", verdict: "clean", findings: [] } },
+      async (dir) => {
+        const result = await consolidateGateFanin({
+          findingsDir: dir,
+          gate: "draft_gate",
+          repoRoot,
+          carriedAngles: ["dry"],
+          carryForwardPlan: JSON.parse(carryForwardPlanJson(["dry"])).carried,
+          resolvedAngles: ["correctness", "dry"],
+        });
+        assert.equal(result.overallVerdict, "clean");
+        assert.deepEqual(result.angles.map((a) => a.angle).sort(), ["correctness", "dry"]);
+      },
+    );
+  });
+});
+
 test("parseConsolidateFaninCliArgs rejects a malformed --carry-forward-plan", () => {
   assert.throws(
     () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--carry-forward-plan", "not json"]),

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -1022,6 +1022,35 @@ test("consolidateGateFanin passes when every --resolved-angles angle has a real 
   });
 });
 
+// #1783: the resolved-angle-evidence backstop only guards a "clean" round — a
+// round that already computed findings_present must NOT be refused for a
+// missing resolved angle (that would mask the real findings behind a
+// RESOLVED-ANGLE error). Pins the `consolidated.verdict === "clean"` skip.
+test("consolidateGateFanin does NOT apply --resolved-angles refusal on a findings_present round", async () => {
+  await withMinimalConfigRepoRoot(async (repoRoot) => {
+    await withFindingsDir(
+      {
+        "correctness.json": {
+          angle: "correctness",
+          verdict: "findings_present",
+          findings: [{ severity: "must-fix", summary: "real defect", file: "src/a.mjs", line: 1 }],
+        },
+      },
+      async (dir) => {
+        // "dry" has neither an artifact nor a proven carry — on a clean round
+        // this refuses, but here the round is already findings_present.
+        const result = await consolidateGateFanin({
+          findingsDir: dir,
+          gate: "draft_gate",
+          repoRoot,
+          resolvedAngles: ["correctness", "dry"],
+        });
+        assert.equal(result.overallVerdict, "findings_present");
+      },
+    );
+  });
+});
+
 test("parseConsolidateFaninCliArgs rejects a malformed --carry-forward-plan", () => {
   assert.throws(
     () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--carry-forward-plan", "not json"]),


### PR DESCRIPTION
## Objective

Land a fan-in-side mechanical catch (AC4 residual from the carried-angles preflight work) so a wrong `--carried-angles` list naming only NON-mandatory angles cannot under-dispatch and still close a round clean. Preventative: no caller supplies the new flag yet.

Closes #1783.

## Root cause

`checkFanoutAngleCoverage` protects only configured-mandatory angles, and the merge check verifies the clean current-head marker, never per-angle completeness. A clean round verdict could therefore close with a resolved angle that never ran, visible only in the ledger's provenance.

## Change

- New pure `checkResolvedAngleEvidence` in `packages/core/src/loop/gate-fanin.mjs` (beside `checkFanoutAngleCoverage`): compares the round's full RESOLVED angle set against (per-angle artifacts, base-name matched) ∪ (proven-carried angles), and refuses a clean verdict when any resolved angle has neither — not just mandatory ones.
- `consolidate-fanin.mjs` wires it via a new optional `--resolved-angles <json>` flag: when supplied and the computed verdict is `clean`, it runs the check against the recorded artifacts and the already-proof-checked carried angles, and throws before any ledger write on a miss.
- Refusal message names the missing angle(s) and the evidence it expected (`GATE-EXEC-RESOLVED-ANGLE-EVIDENCE`).
- Contract doc backstop paragraph updated to cite the new catch; new rule registered in `required-rules.json` (runtime enforcement); `.claude` mirror regenerated.

Grouped dispatch needs no special-casing: a grouped reviewer still writes one per-angle artifact per angle it covers, so a grouped-but-ran angle is already covered by the recorded-artifacts side (pinned by a test).

## Verification (DoD)

- `npm run verify` → exit 0 (test:core 2807/2807, test:scripts pass with pre-existing skips, all other suites green).
- `npm run test:docs` → green (validate-links, validate-rule-ownership 206 rules, validate-decision-records).

## Acceptance criteria

- [x] Fan-in check compares the resolved angle set against per-angle artifacts + proven-carried angles and refuses a clean verdict when any resolved angle has neither (not just mandatory).
- [x] The refusal names the missing angle(s) and the artifact/proof it expected.
- [x] The contract doc backstop paragraph cites the new mechanical catch.
- [x] Tests pin the refusal for a wrongly-carried non-mandatory angle and the pass for a fully-proven round.

## Definition of done

- [x] Affected suites + `npm run verify` green.
- [x] `npm run test:docs` green.

## Non-goals

- No change to the preflight or the entry refusal (they stay as shipped by the carried-angles work).
