### PR TITLE
fix(gate): base-collapse carried names before the always-rerun refusal

### DIFF
--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -36,7 +36,7 @@ import { parseArgs } from "node:util";
 
 import { GATE_ANGLE_SCOPES, GATE_FULL_LABEL, loadDevLoopConfig, resolveFanoutGroups, resolveFanoutMaxConcurrent, resolveFanoutSequential, resolveFanoutEffectiveConcurrency, resolveGateAngleContract, resolveGateAngleScope, resolveGateAnglesDynamic, resolveMaxAnglesPerGroup, resolveRoleModel } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
-import { reviewerBudgetPreflight, scheduleFanoutWaves } from "@dev-loops/core/loop/gate-fanin";
+import { baseAngleName, reviewerBudgetPreflight, scheduleFanoutWaves } from "@dev-loops/core/loop/gate-fanin";
 import { buildAngleRequestGroups, buildReviewDispatchPlan, normalizeHarnessCapabilities } from "@dev-loops/core/loop/review-dispatch-plan";
 import { classifyFile } from "@dev-loops/core/analysis/diff-analyzer";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
@@ -1726,12 +1726,17 @@ export function resolveFanoutDispatch(config, configGate, resolvedAngles, { full
   // the preflight. Unlike consolidate-fanin.mjs, an unmapped/unknown angle
   // name is NOT rejected here (this seam has no plan-proof cross-check to
   // validate an unrecognized name against, and resolveFanoutGroups already
-  // treats an unresolved angle as ungrouped rather than erroring).
+  // treats an unresolved angle as ungrouped rather than erroring). Like
+  // consolidate-fanin.mjs, the name is baseAngleName-collapsed (+lowercase)
+  // BEFORE the check: a delta-suffixed always-include spelling (e.g.
+  // `renderer-security-delta-at-<sha>`) must still resolve to its base and be
+  // refused, not fall through as an unmapped/unknown angle.
   const carriedAnglesList = normalizeCarriedAnglesArg(carriedAngles);
   if (carriedAnglesList.length > 0) {
     const mandatoryAngles = resolveGateAngleContract(config, configGate).mandatoryAngles;
     for (const angle of carriedAnglesList) {
-      const surface = angleReviewSurface(angle, { alwaysRerun: mandatoryAngles });
+      const key = baseAngleName(angle).toLowerCase();
+      const surface = angleReviewSurface(key, { alwaysRerun: mandatoryAngles });
       if (surface.kind === "always") {
         throw new Error(`--carried-angles names "${angle}", which can never legitimately carry forward: it always re-runs (a configured mandatory angle, or a hardcoded ALWAYS_INCLUDE evidence/security/description angle) — resolve-angle-carry-forward.mjs can never mark it carried, so refusing to exclude its dispatch unit here (fail-closed)`);
       }

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -4816,6 +4816,22 @@ test("#1635 resolveFanoutDispatch refuses a --carried-angles name that can never
   assert.deepEqual(unmapped.preflight.skippedGroups, []);
 });
 
+test("issue 1784 resolveFanoutDispatch refuses a delta-suffixed always-include spelling (baseAngleName-collapsed before the check, mirroring consolidate-fanin.mjs)", () => {
+  const config = draftConfig({ dynamicAngles: false, mandatoryAngles: ["gate-evidence"] });
+  // `<angle>-delta-at-<sha>` must collapse to its base BEFORE the always-rerun
+  // check, same as consolidate-fanin.mjs's own baseAngleName+lowercase key —
+  // otherwise the name resolves as "unknown", is wrongly accepted, and the
+  // preflight's trim+lowercase match then silently drops the dispatch unit.
+  assert.throws(
+    () => resolveFanoutDispatch(config, "draft", ["scope", "gate-evidence"], { carriedAngles: ["gate-evidence-delta-at-abc1234"] }),
+    /can never legitimately carry forward/,
+  );
+  assert.throws(
+    () => resolveFanoutDispatch(config, "draft", ["scope", "pr-description"], { carriedAngles: ["pr-description-delta-at-abc1234"] }),
+    /can never legitimately carry forward/,
+  );
+});
+
 test("#1635 resolveFanoutDispatch excludes a carried group and round-trips carriedAngles provenance for a one-shot iterable (generator / Set.values()), not just an array", () => {
   // Regression pin: resolveFanoutDispatch used to materialize carriedAngles
   // into carriedAnglesList for the refusal guard, then pass the ORIGINAL


### PR DESCRIPTION
## Objective

Close the second, undocumented divergence between `write-gate-context.mjs`'s always-rerun refusal and `consolidate-fanin.mjs`'s mandatory-angle refusal: the sibling collapses `baseAngleName` before its check, this one did not. Internal-tooling, script + test only.

Closes #1784.

## Root cause

The refusal called `angleReviewSurface(name)` on the raw carried-angle name. A delta-suffixed always-include spelling (`<angle>-delta-at-<sha>`) resolved `unknown`, was wrongly accepted, and the preflight's trim+lowercase match then silently dropped that dispatch unit. Low reachability today (the sanctioned producer fail-closes an unknown surface and never emits such names), but the divergence was real and unowned.

## Change

- In `resolveFanoutDispatch`'s carried-angle refusal loop, collapse each name via `baseAngleName(angle).toLowerCase()` before `angleReviewSurface(...)`, matching `consolidate-fanin.mjs`'s exact key derivation. `baseAngleName` is imported from the existing `@dev-loops/core/loop/gate-fanin` import (helper reused, not re-implemented).
- Corrected the comment above the refusal loop: the `baseAngleName` gap is now closed; the one remaining, still-accurate divergence (no plan-proof cross-check) stays documented. The CLI `--carried-angles` flag-help never claimed `baseAngleName` parity, so it needed no correction.

## Verification (DoD)

- `node --test test/github/write-gate-context.test.mjs` → 242/242 (new pin refuses both a configured-mandatory and a hardcoded ALWAYS_INCLUDE delta-suffixed spelling).
- `npm run verify` → all suites green (test:core 2808/2808, test:scripts 4215/4215, test:docs green).

## Acceptance criteria

- [x] The refusal applies the same `baseAngleName` collapse as `consolidate-fanin.mjs` before the always-rerun check.
- [x] A test pins refusal of a delta-suffixed always-include spelling.
- [x] The mirror claim in the flag help/doc names either zero remaining divergences or exactly the ones that exist (the plan-proof divergence remains; the baseAngleName one is closed).

## Definition of done

- [x] `node --test test/github/write-gate-context.test.mjs` and `npm run verify` green.

## Non-goals

- No change to `consolidate-fanin.mjs`'s own refusal.
