### PR TITLE
test(github): pin reply-resolve thread counters in message-map --resolve mode

### DIFF
--- a/test/github/reply-resolve-review-threads.test.mjs
+++ b/test/github/reply-resolve-review-threads.test.mjs
@@ -1008,6 +1008,90 @@ test("reply-resolve-review-threads posts a distinct mapped reply body per thread
   }
 });
 
+test("reply-resolve-review-threads --message-map --resolve pins true matched/replied/resolved counts across a multi-thread run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-map-resolve-counts-"));
+
+  try {
+    const gh = await writeGhStub(tempDir, [
+      {
+        stdout: createReviewThreadsPayload([
+          {
+            id: "THREAD_1",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_101", databaseId: 101, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+          {
+            id: "THREAD_2",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_202", databaseId: 202, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+          {
+            id: "THREAD_3",
+            isResolved: false,
+            comments: { nodes: [{ id: "PRRC_node_303", databaseId: 303, body: "note", author: { login: "Copilot", __typename: "Bot" } }] },
+          },
+        ]),
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/101/replies"],
+        stdout: '{"id":3001,"html_url":"https://github.com/owner/repo/pull/17#discussion_r3001"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_1"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_1","isResolved":true}}}}\n',
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/202/replies"],
+        stdout: '{"id":3002,"html_url":"https://github.com/owner/repo/pull/17#discussion_r3002"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_2"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_2","isResolved":true}}}}\n',
+      },
+      {
+        assertArgs: ["repos/owner/repo/pulls/17/comments/303/replies"],
+        stdout: '{"id":3003,"html_url":"https://github.com/owner/repo/pull/17#discussion_r3003"}\n',
+      },
+      {
+        assertArgs: ["api", "graphql", "--field", "threadId=THREAD_3"],
+        stdout: '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD_3","isResolved":true}}}}\n',
+      },
+      {
+        stdout: createReviewThreadsPayload([
+          { id: "THREAD_1", isResolved: true, comments: { nodes: [] } },
+          { id: "THREAD_2", isResolved: true, comments: { nodes: [] } },
+          { id: "THREAD_3", isResolved: true, comments: { nodes: [] } },
+        ]),
+      },
+    ]);
+    const mapPath = path.join(tempDir, "message-map.json");
+    await writeJsonHelper(mapPath, {
+      THREAD_1: "Fixed the null check in file-a.mjs in 93cd7f8.",
+      THREAD_2: "Fixed the off-by-one in file-b.mjs in 93cd7f8.",
+      THREAD_3: "Fixed the missing await in file-c.mjs in 93cd7f8.",
+    });
+
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--message-map", mapPath, "--resolve"],
+      { env: gh.env },
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.matchedThreadCount, 3);
+    assert.equal(parsed.repliedThreadCount, 3);
+    assert.equal(parsed.resolvedThreadCount, 3);
+    assert.equal(parsed.results.length, 3);
+    assert.equal(parsed.matchedThreadCount, parsed.results.length);
+    assert.equal(parsed.repliedThreadCount, parsed.results.length);
+    assert.equal(parsed.resolvedThreadCount, parsed.results.length);
+    assert.ok(parsed.results.every((entry) => entry.resolved === true));
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("reply-resolve-review-threads sanitizes Copilot summon tokens in --message-map bodies exactly like --message", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-threads-map-sanitize-"));
 


### PR DESCRIPTION
## Objective

Pin the `reply-resolve-review-threads.mjs` thread counters in `--message-map --resolve` mode. Internal-tooling, test only.

Closes #1788.

## Finding: no code defect on current source

The reported symptom (a `--message-map --resolve` run printing `resolvedThreadCount: 0` while actually resolving every thread) does not reproduce on the current source. `runCli` derives all three counters once, after the reply/resolve loop, with no mode-specific branch:

- `matchedThreadCount` from the matched set,
- `repliedThreadCount = results.length`,
- `resolvedThreadCount = results.filter(r => r.resolved).length`,

so `--message` and `--message-map` share identical counting, and the USAGE field names match the emitted payload. An integration-style repro (a 2-thread `--message-map --resolve` run read back through `--jq '.resolvedThreadCount'`) prints the true count. The original 2026-08-20 observation was evidently fixed by an intervening change.

## Change

- No production code change (none is justified by the evidence).
- Added the missing regression test: prior `--message-map` tests either omitted `--resolve` or covered failure paths, so nothing pinned the counters on a successful multi-thread `--message-map --resolve` run (unlike `--message` mode, which already had one). The new test asserts `matched`/`replied`/`resolvedThreadCount` all equal the resolved-thread count and match `results.length`.

## Verification (DoD)

- `node --test test/github/reply-resolve-review-threads.test.mjs` → 22/22.
- `npm run verify` → exit 0, all suites green.

## Acceptance criteria

- [x] `resolvedThreadCount` / `repliedThreadCount` / `matchedThreadCount` reflect true counts in `--message-map` mode (verified already correct; now pinned).
- [x] A test pins the counters for a multi-thread `--message-map` run with `--resolve`.

## Definition of done

- [x] `node --test` on the script's suite and `npm run verify` green.

## Non-goals

- No change to the reply/resolve mutation behavior (untouched; only regression coverage added).
