### PR TITLE
refactor(contracts): share scanned-surface predicate + strengthen vacuous-pass guard

### DIFF
--- a/test/contracts/referenced-slash-commands-shipped.test.mjs
+++ b/test/contracts/referenced-slash-commands-shipped.test.mjs
@@ -83,25 +83,35 @@ function computeBareSlashFailures(repoRoot, surfaceFile) {
   return computeBareSlashFailuresForContent(path.relative(repoRoot, surfaceFile), content);
 }
 
+// The selection predicate (existing on disk, not allowlisted) — the SINGLE
+// source of which surface files the scan actually inspects. Shared by
+// `collectFailures` and the vacuous-pass guard below so a skip condition
+// added to one can never drift from what the other counts.
+function scannedSurfaceFiles(repoRoot) {
+  return surfaceFiles(repoRoot).filter(
+    (surfaceFile) => fs.existsSync(surfaceFile) && !isAllowlisted(repoRoot, surfaceFile),
+  );
+}
+
 function collectFailures(repoRoot) {
   const failures = [];
-  for (const surfaceFile of surfaceFiles(repoRoot)) {
-    if (!fs.existsSync(surfaceFile)) continue;
-    if (isAllowlisted(repoRoot, surfaceFile)) continue;
+  for (const surfaceFile of scannedSurfaceFiles(repoRoot)) {
     failures.push(...computeBareSlashFailures(repoRoot, surfaceFile));
   }
   return failures;
 }
 
 test("no shipped surface instructs a bare /loop-* slash command without the namespaced alternative", () => {
-  // Vacuous-pass guard (mirrors referenced-scripts-shipped.test.mjs's
-  // references.length check): counts the files the scan actually inspects —
-  // existing and not allowlisted — so neither an empty surface set nor an
-  // all-allowlisted one can pass the contract without scanning anything.
-  const scannedSurfaces = surfaceFiles(REPO_ROOT).filter(
-    (surfaceFile) => fs.existsSync(surfaceFile) && !isAllowlisted(REPO_ROOT, surfaceFile),
-  );
+  // Vacuous-pass guard, two layers deep — mirrors referenced-scripts-shipped's
+  // `references.length` check at the same depth (scan-OUTPUT, not just file
+  // selection):
+  const scannedSurfaces = scannedSurfaceFiles(REPO_ROOT);
   assert.ok(scannedSurfaces.length > 0, "expected the scanned surface set to be non-empty (vacuous-pass guard)");
+  const totalBareTokens = scannedSurfaces.reduce(
+    (count, surfaceFile) => count + [...fs.readFileSync(surfaceFile, "utf8").matchAll(BARE_LOOP_CMD_RE)].length,
+    0,
+  );
+  assert.ok(totalBareTokens > 0, "expected at least one bare /loop-* token across the scanned surfaces (vacuous-pass guard)");
   const failures = collectFailures(REPO_ROOT);
   assert.deepEqual(failures, [], `bare /loop-* slash references without a namespaced alternative:\n${failures.join("\n")}`);
 });


### PR DESCRIPTION
## Objective

Remove the duplicated file-selection predicate between the vacuous-pass guard and `collectFailures` in the slash-command contract test, so they cannot drift, and strengthen the guard to the sibling's depth. Internal-tooling, test only.

Closes #1790.

## Root cause

The vacuous-pass guard copied `collectFailures`'s selection predicate (`existsSync` + not-allowlisted) instead of sharing it. A skip condition later added to `collectFailures` alone would make the guard over-count and weaken the protection it adds. The comment's "mirrors the sibling" claim was also only file-selection-deep (the sibling asserts on extracted scan-output tokens).

## Change

- Extracted a single `scannedSurfaceFiles(repoRoot)` helper (the one selection predicate: `existsSync` + allowlist), consumed by BOTH `collectFailures` and the vacuous-pass guard, so the two share one source of truth. Kept module-local since both consumers live in this one file.
- Strengthened the guard (AC2): it now asserts on scan OUTPUT — the total bare-token matches across the scanned surfaces is `> 0` — so it proves the regex scan actually finds tokens, matching the sibling's `references.length` depth. The comment is updated to describe the two-layer guard, dropping the file-selection-only "mirrors the sibling" overclaim.

## Verification (DoD)

- `node --test test/contracts/referenced-slash-commands-shipped.test.mjs` → 4/4.
- `npm run test:doc-guard` → 283/283.
- `npm run verify` → all suites green.

## Acceptance criteria

- [x] A shared `scannedSurfaceFiles(repoRoot)` helper is consumed by both the vacuous-pass guard and `collectFailures` (single selection predicate).
- [x] The guard is strengthened to assert on scan output (at least one bare token found across surfaces), matching the sibling's depth.
- [x] Existing tests stay green.

## Definition of done

- [x] `node --test test/contracts/referenced-slash-commands-shipped.test.mjs` and `npm run test:doc-guard` green.

## Non-goals

- No change to the surface set itself.
