### PR TITLE
test(contracts): per-root non-emptiness guards for commands/ and agents/ surfaces

### DIFF
--- a/test/contracts/referenced-scripts-shipped.test.mjs
+++ b/test/contracts/referenced-scripts-shipped.test.mjs
@@ -143,6 +143,21 @@ function computeDanglingReferenceFailures(repoRoot, references, packedFiles) {
   return failures;
 }
 
+// Per-root vacuous-pass guard: `commands/` and `agents/` are scanned via the
+// shared `flatDir` helper, which fails OPEN (returns an empty list) when the
+// dir is missing. The aggregate `references.length > 0` check below is
+// satisfied by OTHER surface roots (skills, packages/core/src, ...), so a
+// vanished/renamed `commands/` or `agents/` dir would otherwise silently
+// shrink the scanned surface with no test failure. Assert each root
+// contributes at least one surface file directly.
+test("the commands/ and agents/ surface roots each contribute at least one surface file", () => {
+  const commandsFiles = flatDir(path.join(REPO_ROOT, "commands"), ".md", []);
+  assert.ok(commandsFiles.length > 0, "expected commands/ to contribute at least one .md surface file — a vanished/renamed commands/ dir would silently shrink the scanned surface");
+
+  const agentsFiles = flatDir(path.join(REPO_ROOT, "agents"), ".md", []);
+  assert.ok(agentsFiles.length > 0, "expected agents/ to contribute at least one .md surface file — a vanished/renamed agents/ dir would silently shrink the scanned surface");
+});
+
 test("every scripts/...mjs reference in the shipped instruction surfaces is in the packed npm file set", () => {
   const packedFiles = expandPackedFileSet(REPO_ROOT);
   assert.ok(packedFiles.size > 100, `packed file set looks too small (${packedFiles.size}) — expansion likely broken`);

--- a/test/contracts/referenced-slash-commands-shipped.test.mjs
+++ b/test/contracts/referenced-slash-commands-shipped.test.mjs
@@ -101,6 +101,21 @@ function collectFailures(repoRoot) {
   return failures;
 }
 
+// Per-root vacuous-pass guard: `commands/` and `agents/` are scanned via the
+// shared `flatDir` helper, which fails OPEN (returns an empty list) when the
+// dir is missing. The aggregate guards below (scannedSurfaces.length,
+// totalBareTokens) are satisfied by OTHER surface roots (skills, .claude,
+// ...), so a vanished/renamed `commands/` or `agents/` dir would otherwise
+// silently shrink the scanned surface with no test failure. Assert each root
+// contributes at least one surface file directly.
+test("the commands/ and agents/ surface roots each contribute at least one surface file", () => {
+  const commandsFiles = flatDir(path.join(REPO_ROOT, "commands"), ".md", []);
+  assert.ok(commandsFiles.length > 0, "expected commands/ to contribute at least one .md surface file — a vanished/renamed commands/ dir would silently shrink the scanned surface");
+
+  const agentsFiles = flatDir(path.join(REPO_ROOT, "agents"), ".md", []);
+  assert.ok(agentsFiles.length > 0, "expected agents/ to contribute at least one .md surface file — a vanished/renamed agents/ dir would silently shrink the scanned surface");
+});
+
 test("no shipped surface instructs a bare /loop-* slash command without the namespaced alternative", () => {
   // Vacuous-pass guard, two layers deep — mirrors referenced-scripts-shipped's
   // `references.length` check at the same depth (scan-OUTPUT, not just file


### PR DESCRIPTION
## Objective

Add per-root non-emptiness guards for the `commands/` and `agents/` surface roots so a vanished or renamed directory fails the contract test loudly instead of silently shrinking the scanned surface. Internal-tooling, test only.

Closes #1792.

## Root cause

After the walk-helper extraction (PR 1791), `commands/` and `agents/` moved from inline `readdirSync` (throws ENOENT on a missing dir) to the shared `flatDir`, which fails open to an empty list. The global vacuous-pass guards are satisfied by other surface roots, so a vanished/renamed `commands/` or `agents/` dir would silently reduce coverage with no failure.

## Change

- `referenced-scripts-shipped.test.mjs`: a new test asserts `flatDir(commands/, '.md')` and `flatDir(agents/, '.md')` each return length `> 0`, with per-root named failure messages.
- `referenced-slash-commands-shipped.test.mjs`: the same per-root guards for its `commands/` and `agents/` roots (both are `flatDir`-scanned there too, same fail-open risk).
- `flatDir` semantics are unchanged (stays fail-open); the non-emptiness assertions live in the tests (non-goal respected).

## Verification (DoD)

- `node --test test/contracts/referenced-scripts-shipped.test.mjs test/contracts/referenced-slash-commands-shipped.test.mjs` → green.
- `npm run test:doc-guard` → 285/285.
- `npm run verify` → all suites green.
- Load-bearing confirmed: temporarily renaming `commands/` made both new guards fail loudly (`expected commands/ to contribute at least one .md surface file`); reverted, all green.

## Acceptance criteria

- [x] `referenced-scripts-shipped.test.mjs` asserts per-root non-emptiness for `commands/` and `agents/`.
- [x] The sibling slash-commands test gets the same per-root guards where its roots are load-bearing.
- [x] Existing tests stay green.

## Definition of done

- [x] `node --test test/contracts/referenced-scripts-shipped.test.mjs test/contracts/referenced-slash-commands-shipped.test.mjs` and `npm run test:doc-guard` green.

## Non-goals

- No change to `flatDir` semantics (shared helper stays fail-open; the guards live in the tests).
