### PR TITLE
fix(gate): require followUpDraft on a defer judgeDisposition in validateFindingsArray

### DIFF
--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -192,6 +192,17 @@ function validateFindingsArray(parsed, flagLabel) {
       // silently renormalized.
       entry.followUpDraft = f.followUpDraft;
     }
+    // Mirrors validateJudgeVerdict's own defer rule (packages/core/src/loop/
+    // gate-fanin.mjs): followUpDraft is mandatory on a defer judgeDisposition
+    // (soft-cap contract — a deferred finding always carries a fileable
+    // follow-up draft). validateJudgeVerdict enforces this on the judge's own
+    // artifact before applyJudgeDispositions ever merges it in, but a
+    // hand-authored --findings/--findings-file array bypasses that path
+    // entirely, so this durable-ledger validator needs its own copy of the
+    // same rule rather than trusting an upstream check it never runs through.
+    if (entry.judgeDisposition === "defer" && entry.followUpDraft === undefined) {
+      throw parseError(`${flagLabel}[${i}].followUpDraft is required when judgeDisposition is "defer"`);
+    }
     return entry;
   });
 }

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -161,6 +161,45 @@ test("writeGateFindingsLog accepts a valid 16-hex fingerprint", async () => {
   }
 });
 
+test("writeGateFindingsLog rejects a defer judgeDisposition with no followUpDraft", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{ severity: "low", angle: "scope", summary: "x", judgeDisposition: "defer" }]),
+    });
+  }, /\[0\]\.followUpDraft is required when judgeDisposition is "defer"/);
+});
+
+test("writeGateFindingsLog accepts a defer judgeDisposition carrying a followUpDraft", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "wgfl-defer-draft-"));
+  try {
+    const result = await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{
+        severity: "low",
+        angle: "scope",
+        summary: "x",
+        judgeDisposition: "defer",
+        followUpDraft: { title: "follow up", body: "details" },
+      }]),
+      tmpRoot: dir,
+    });
+    const written = JSON.parse(await readFile(result.path, "utf8"));
+    assert.equal(written.findings[0].judgeDisposition, "defer");
+    assert.deepEqual(written.findings[0].followUpDraft, { title: "follow up", body: "details" });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("parseWriteGateFindingsLogCliArgs rejects missing required args", () => {
   assert.throws(() => {
     parseWriteGateFindingsLogCliArgs([


### PR DESCRIPTION
## Objective

Make the durable-ledger validator enforce the same cross-field rule the judge contract already requires: a `judgeDisposition: "defer"` finding must carry a `followUpDraft`. Internal-tooling, script + test only.

Closes #1795.

## Root cause

`validateFindingsArray` (scripts/github/write-gate-findings-log.mjs) validated a `followUpDraft`'s shape but still accepted a `defer` finding with NO `followUpDraft`, while `validateJudgeVerdict` (the reference rule in packages/core/src/loop/gate-fanin.mjs) makes the draft mandatory on a defer. Adding the cross-field rule exceeded the shape-mirror scope of the parent issue, so it was deferred here.

## Change

- In `validateFindingsArray`, after resolving `followUpDraft`: if `judgeDisposition === "defer"` and `followUpDraft === undefined`, throw `parseError("<label>[i].followUpDraft is required when judgeDisposition is \"defer\"")`, matching the file's path/message convention and mirroring `validateJudgeVerdict`.
- Fires ONLY on `defer`: `act`/`reject` dispositions and findings with no `judgeDisposition` never reach the throw.

## Verification (DoD)

- `node --test test/github/write-gate-findings-log.test.mjs` → 100/100 (new: a `defer` without `followUpDraft` is rejected naming `[i].followUpDraft`; a `defer` WITH a draft passes).
- `npm run verify` → all suites green. No existing fixture needed a draft added (the judge path already supplies one on defer, since `validateJudgeVerdict` requires it upstream).

## Acceptance criteria

- [x] `validateFindingsArray` rejects a `defer` finding without a `followUpDraft`, via a `parseError` naming the `[i].followUpDraft` path.
- [x] Existing enriched-ledger fixtures stay green (none violated the new rule).

## Definition of done

- [x] `node --test test/github/write-gate-findings-log.test.mjs` and `npm run verify` green.

## Non-goals

- No change to `validateJudgeVerdict` (the reference rule).
