### PR TITLE
fix(gate): make run-gate-validation resolveDepState worktree-aware

### DIFF
--- a/scripts/loop/run-gate-validation.mjs
+++ b/scripts/loop/run-gate-validation.mjs
@@ -308,6 +308,18 @@ export async function buildValidationArtifact({ repo, pr, gate, headSha, suites,
  * are excluded from the comparison to avoid false "stale" stamps on a synced
  * tree.
  *
+ * A loop worktree (tmp/worktrees/<repo>/<kind>-<n>) is a linked checkout:
+ * ensure-worktree.mjs symlinks only `node_modules/@dev-loops/core` into it
+ * and never runs `npm install` there, so the worktree has no local
+ * `node_modules/.package-lock.json` of its own — the suites it runs still
+ * resolve every other dependency by Node's normal ancestor-directory module
+ * resolution, reaching the main checkout's `node_modules` above it. Reading
+ * only `<repoRoot>/node_modules/.package-lock.json` therefore stamps every
+ * worktree round "stale" unconditionally, regardless of whether the deps the
+ * suites actually ran against are fresh. The installed-lock lookup below
+ * walks up from `repoRoot` to the nearest ancestor directory that has one,
+ * so it reads the dependency root the suites actually ran against.
+ *
  * @param {string} repoRoot - Absolute path to the repo (main checkout or worktree).
  * @returns {Promise<{status: string, detail: string}>}
  */
@@ -317,15 +329,35 @@ function isInstallableOnHost(pkg) {
   return true;
 }
 
+/**
+ * Walk up from `startDir` to the nearest ancestor (inclusive) with a
+ * `node_modules/.package-lock.json`, returning its raw contents and the
+ * directory it was found in. Returns `{ raw: null, root: null }` when no
+ * ancestor up to the filesystem root has one.
+ * @param {string} startDir
+ * @returns {Promise<{raw: string | null, root: string | null}>}
+ */
+async function findAncestorInstalledLock(startDir) {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    const raw = await readFile(path.join(dir, "node_modules", ".package-lock.json"), "utf8").catch(() => null);
+    if (raw !== null) return { raw, root: dir };
+    const parent = path.dirname(dir);
+    if (parent === dir) return { raw: null, root: null };
+    dir = parent;
+  }
+}
+
 async function resolveDepState(repoRoot) {
   const lockRaw = await readFile(path.join(repoRoot, "package-lock.json"), "utf8").catch(() => null);
-  const installedRaw = await readFile(path.join(repoRoot, "node_modules", ".package-lock.json"), "utf8").catch(() => null);
   if (lockRaw === null) {
     return { status: "n-a", detail: "no package-lock.json at repo root" };
   }
+  const { raw: installedRaw, root: depRoot } = await findAncestorInstalledLock(repoRoot);
   if (installedRaw === null) {
-    return { status: "stale", detail: "node_modules/.package-lock.json absent — installed deps not materialized (npm ci/install not run)" };
+    return { status: "stale", detail: "node_modules/.package-lock.json absent in repoRoot or any ancestor — installed deps not materialized (npm ci/install not run)" };
   }
+  const depRootNote = depRoot === repoRoot ? "" : ` (resolved from ancestor ${depRoot})`;
   let lock;
   let installed;
   try {
@@ -336,7 +368,7 @@ async function resolveDepState(repoRoot) {
   try {
     installed = JSON.parse(installedRaw);
   } catch {
-    return { status: "stale", detail: "node_modules/.package-lock.json unparseable — cannot verify installed deps" };
+    return { status: "stale", detail: `node_modules/.package-lock.json unparseable${depRootNote} — cannot verify installed deps` };
   }
   const expected = lock.packages ?? {};
   const have = installed.packages ?? {};
@@ -355,12 +387,12 @@ async function resolveDepState(repoRoot) {
   }
   if (missing.length === 0 && mismatched.length === 0) {
     const installedCount = Object.keys(have).filter((k) => k !== "").length;
-    return { status: "synced", detail: `installed deps match package-lock.json (${installedCount} packages)` };
+    return { status: "synced", detail: `installed deps match package-lock.json (${installedCount} packages)${depRootNote}` };
   }
   const parts = [];
   if (missing.length) parts.push(`${missing.length} missing package(s)`);
   if (mismatched.length) parts.push(`${mismatched.length} version-mismatched package(s)`);
-  return { status: "stale", detail: `installed deps diverge from package-lock.json: ${parts.join(", ")}` };
+  return { status: "stale", detail: `installed deps diverge from package-lock.json${depRootNote}: ${parts.join(", ")}` };
 }
 
 /**

--- a/scripts/loop/run-gate-validation.mjs
+++ b/scripts/loop/run-gate-validation.mjs
@@ -292,6 +292,37 @@ export async function buildValidationArtifact({ repo, pr, gate, headSha, suites,
 }
 
 /**
+ * Whether a package-lock.json `packages[]` entry is installable on the
+ * current host, given its optional `os`/`cpu` platform gates.
+ * @param {{os?: string[], cpu?: string[]}} pkg
+ * @returns {boolean}
+ */
+function isInstallableOnHost(pkg) {
+  if (pkg.os && !pkg.os.includes(process.platform)) return false;
+  if (pkg.cpu && !pkg.cpu.includes(process.arch)) return false;
+  return true;
+}
+
+/**
+ * Walk up from `startDir` to the nearest ancestor (inclusive) with a
+ * `node_modules/.package-lock.json`, returning its raw contents and the
+ * directory it was found in. Returns `{ raw: null, root: null }` when no
+ * ancestor up to the filesystem root has one.
+ * @param {string} startDir
+ * @returns {Promise<{raw: string | null, root: string | null}>}
+ */
+async function findAncestorInstalledLock(startDir) {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    const raw = await readFile(path.join(dir, "node_modules", ".package-lock.json"), "utf8").catch(() => null);
+    if (raw !== null) return { raw, root: dir };
+    const parent = path.dirname(dir);
+    if (parent === dir) return { raw: null, root: null };
+    dir = parent;
+  }
+}
+
+/**
  * Compare the repo's package-lock.json against the installed lock snapshot
  * (node_modules/.package-lock.json) (#1627). A mismatch means the validation
  * suites ran against stale deps — stamped, not blocking, so gate consumers can
@@ -323,31 +354,6 @@ export async function buildValidationArtifact({ repo, pr, gate, headSha, suites,
  * @param {string} repoRoot - Absolute path to the repo (main checkout or worktree).
  * @returns {Promise<{status: string, detail: string}>}
  */
-function isInstallableOnHost(pkg) {
-  if (pkg.os && !pkg.os.includes(process.platform)) return false;
-  if (pkg.cpu && !pkg.cpu.includes(process.arch)) return false;
-  return true;
-}
-
-/**
- * Walk up from `startDir` to the nearest ancestor (inclusive) with a
- * `node_modules/.package-lock.json`, returning its raw contents and the
- * directory it was found in. Returns `{ raw: null, root: null }` when no
- * ancestor up to the filesystem root has one.
- * @param {string} startDir
- * @returns {Promise<{raw: string | null, root: string | null}>}
- */
-async function findAncestorInstalledLock(startDir) {
-  let dir = path.resolve(startDir);
-  for (;;) {
-    const raw = await readFile(path.join(dir, "node_modules", ".package-lock.json"), "utf8").catch(() => null);
-    if (raw !== null) return { raw, root: dir };
-    const parent = path.dirname(dir);
-    if (parent === dir) return { raw: null, root: null };
-    dir = parent;
-  }
-}
-
 async function resolveDepState(repoRoot) {
   const lockRaw = await readFile(path.join(repoRoot, "package-lock.json"), "utf8").catch(() => null);
   if (lockRaw === null) {

--- a/test/loop/run-gate-validation.test.mjs
+++ b/test/loop/run-gate-validation.test.mjs
@@ -421,12 +421,15 @@ test("buildValidationArtifact: stamps depState stale when installed lockfile is 
       JSON.stringify({ lockfileVersion: 3, packages: {} }),
       "utf8",
     );
-    // No node_modules/.package-lock.json → deps not materialized → stale.
+    // No node_modules/.package-lock.json anywhere up the ancestor chain →
+    // deps not materialized → stale. Passing at all also confirms the
+    // ancestor walk-up terminates (does not hang) when it finds nothing.
     const artifact = await buildValidationArtifact(
       { repo: "o/r", pr: 1, gate: "draft_gate", headSha: "abc1234", suites: [], tmpRoot: "tmp" },
       { repoRoot },
     );
     assert.equal(artifact.depState.status, "stale");
+    assert.match(artifact.depState.detail, /absent in repoRoot or any ancestor/);
   } finally {
     await rm(repoRoot, { recursive: true, force: true });
   }
@@ -455,6 +458,7 @@ test("buildValidationArtifact: stamps depState synced for a linked worktree with
       { repoRoot },
     );
     assert.equal(artifact.depState.status, "synced");
+    assert.match(artifact.depState.detail, new RegExp(`resolved from ancestor ${outerRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   } finally {
     await rm(outerRoot, { recursive: true, force: true });
   }
@@ -476,6 +480,14 @@ test("buildValidationArtifact: stamps depState stale for a linked worktree when 
       { repoRoot },
     );
     assert.equal(artifact.depState.status, "stale");
+    // Pin the walk-up specifically: the pre-walk-up code only ever reads
+    // repoRoot's own node_modules (which does not exist here), so it would
+    // stamp "stale" via the absent-lockfile branch instead — same status,
+    // different detail. Asserting the ancestor is named in the detail means
+    // this only passes when resolveDepState actually found and compared the
+    // outer checkout's installed lock.
+    assert.match(artifact.depState.detail, /diverge/);
+    assert.match(artifact.depState.detail, new RegExp(`resolved from ancestor ${outerRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   } finally {
     await rm(outerRoot, { recursive: true, force: true });
   }

--- a/test/loop/run-gate-validation.test.mjs
+++ b/test/loop/run-gate-validation.test.mjs
@@ -432,6 +432,55 @@ test("buildValidationArtifact: stamps depState stale when installed lockfile is 
   }
 });
 
+test("buildValidationArtifact: stamps depState synced for a linked worktree with no local node_modules (ancestor installed lock matches)", async () => {
+  // Mirrors ensure-worktree.mjs's linked layout: the worktree has its own
+  // package-lock.json (checked out via git) but no local node_modules — only
+  // the ancestor (main checkout) has the installed lock the suites actually
+  // ran against.
+  const outerRoot = await mkdtemp(path.join(os.tmpdir(), "run-gate-validation-worktree-"));
+  try {
+    const repoRoot = path.join(outerRoot, "worktree");
+    await mkdir(repoRoot, { recursive: true });
+    await mkdir(path.join(outerRoot, "node_modules"), { recursive: true });
+    const lock = JSON.stringify({
+      lockfileVersion: 3,
+      packages: { "": { name: "fixture" }, "node_modules/a": { version: "1.0.0" } },
+    });
+    const installed = JSON.stringify({ lockfileVersion: 3, packages: { "node_modules/a": { version: "1.0.0" } } });
+    await writeFile(path.join(repoRoot, "package-lock.json"), lock, "utf8");
+    await writeFile(path.join(outerRoot, "node_modules", ".package-lock.json"), installed, "utf8");
+
+    const artifact = await buildValidationArtifact(
+      { repo: "o/r", pr: 1, gate: "draft_gate", headSha: "abc1234", suites: [], tmpRoot: "tmp" },
+      { repoRoot },
+    );
+    assert.equal(artifact.depState.status, "synced");
+  } finally {
+    await rm(outerRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildValidationArtifact: stamps depState stale for a linked worktree when the ancestor's installed deps genuinely diverge", async () => {
+  const outerRoot = await mkdtemp(path.join(os.tmpdir(), "run-gate-validation-worktree-"));
+  try {
+    const repoRoot = path.join(outerRoot, "worktree");
+    await mkdir(repoRoot, { recursive: true });
+    await mkdir(path.join(outerRoot, "node_modules"), { recursive: true });
+    const lock = JSON.stringify({ lockfileVersion: 3, packages: { "node_modules/a": { version: "2.0.0" } } });
+    const installed = JSON.stringify({ lockfileVersion: 3, packages: { "node_modules/a": { version: "1.0.0" } } });
+    await writeFile(path.join(repoRoot, "package-lock.json"), lock, "utf8");
+    await writeFile(path.join(outerRoot, "node_modules", ".package-lock.json"), installed, "utf8");
+
+    const artifact = await buildValidationArtifact(
+      { repo: "o/r", pr: 1, gate: "draft_gate", headSha: "abc1234", suites: [], tmpRoot: "tmp" },
+      { repoRoot },
+    );
+    assert.equal(artifact.depState.status, "stale");
+  } finally {
+    await rm(outerRoot, { recursive: true, force: true });
+  }
+});
+
 test("buildValidationArtifact: stamps depState n-a when there is no package-lock.json", async () => {
   const { repoRoot } = await makeFixtureRepo();
   try {


### PR DESCRIPTION
## Objective

Stop `run-gate-validation.mjs` from stamping `depState: stale` unconditionally on every linked-worktree gate round, so the signal actually discriminates a drifted dependency tree from the normal linked layout. Internal-tooling, script + test only.

Closes #1800.

## Root cause

`resolveDepState` read only `<repoRoot>/node_modules/.package-lock.json` with no walk-up. Loop worktrees are linked (ensure-worktree only symlinks `node_modules/@dev-loops/core`; it never runs `npm install`), so a worktree has no local installed lock and `resolveDepState` stamped `stale` every round — noise reviewers dismissed each pass.

## Change

- New `findAncestorInstalledLock(repoRoot)` walks up from `repoRoot` (inclusive) to the nearest ancestor with `node_modules/.package-lock.json`, matching how Node's own module resolution reaches the main checkout's `node_modules` from a linked worktree. `resolveDepState` reads the installed lock from there; `depState.detail` notes the resolved ancestor when it differs from `repoRoot`.
- The staleness decision itself is unchanged: once the installed lock (wherever found) is parsed, a real mismatch (missing or version-differing package) still returns `stale`. Only WHERE the installed lock is read changed.
- `allPassed` is untouched (`suiteResults.every(s => s.exitCode === 0)`); `depState` stays a separate advisory field.

## Verification (DoD)

- `node --test test/loop/run-gate-validation.test.mjs` → 25/25 (new: a linked worktree with no local `node_modules` whose ancestor lock matches stamps `synced`; a linked worktree whose ancestor deps genuinely diverge stamps `stale`).
- `npm run verify` → all suites green.
- Verified live: from this issue's worktree (no local installed lock), `resolveDepState` now walks up to the main checkout and stamps `synced`, previously `stale`.

## Acceptance criteria

- [x] `resolveDepState` is worktree-aware: it resolves the dependency root the suites run against (walk-up to the ancestor `node_modules`) before stamping.
- [x] A genuinely stale dependency tree still stamps `stale`; the normal linked-worktree layout stamps synced.
- [x] A test pins both cases.

## Definition of done

- [x] `node --test` on the run-gate-validation suite and `npm run verify` green.

## Non-goals

- No change to `allPassed` semantics (the stamp stays advisory).
