### PR TITLE
feat(review): standalone review entrypoint over draft+pre-approval angles with no gate obligations

### DIFF
--- a/.claude/commands/loop-review.md
+++ b/.claude/commands/loop-review.md
@@ -1,0 +1,16 @@
+---
+description: "Run a single, standalone code-review pass over a PR (no gate obligations)."
+argument-hint: "<pr>"
+---
+<!-- GENERATED from commands/loop-review.command.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+Invoke the `review` skill with `$ARGUMENTS`.
+
+**Usage:** `/dev-loops:loop-review <pr>` (or `/loop-review <pr>` in the dev-loops repo itself)
+
+**Arguments:**
+- `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+
+**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict and stops. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence. See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+
+**Stop conditions:** this command NEVER calls the fixer, never flips a PR to ready-for-review, and never moves a board item — a `review` round is a single, complete, terminal pass with no re-gate path. If the operator wants findings fixed, that is a separate, explicit follow-up instruction.

--- a/.claude/skills/docs/gate-review-comment-contract.md
+++ b/.claude/skills/docs/gate-review-comment-contract.md
@@ -80,11 +80,19 @@ outside this contract's scope: a standalone, on-demand review pass reachable on
 any PR with no lifecycle obligation of its own (see the
 [Review skill](../review/SKILL.md)). It posts through the same single-surface
 poster and required-fields shape this document defines, but is a deliberately
-NON-EVIDENCE gate — `review` is absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header vocabulary
-a `draft_gate`/`pre_approval_gate` comment is parsed against
-(`@dev-loops/core/github/copilot-helpers`), so a `review` comment never
-satisfies `draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
+NON-EVIDENCE gate. The guard is authoritative recognition, not absence:
+`review` IS a recognized gate name in the gate-comment header vocabulary a
+comment is parsed against (`@dev-loops/core/github/copilot-helpers`), and
+recognizing a comment's header as `review` is exactly what makes the parser
+return non-evidence immediately — before it ever falls through to the
+lenient whole-body `draft_gate`/`pre_approval_gate` token scan that a
+genuinely unidentifiable comment relies on. That holds regardless of
+`--findings-ledger`/the gate-findings-review marker. (`review` is also absent
+from `GATE_CONFIG_KEY` in `@dev-loops/core/loop/gate-fanin`, but that is a
+separate, unrelated fact — `review` has no `draft`/`preApproval`-style config
+threshold — not the mechanism that keeps its comments from being misread as
+draft/pre-approval evidence.) So a `review` comment never satisfies
+`draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
 SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
 authorizes nothing this contract's two gates require.
 

--- a/.claude/skills/docs/gate-review-comment-contract.md
+++ b/.claude/skills/docs/gate-review-comment-contract.md
@@ -75,6 +75,19 @@ This contract covers exactly two gates with distinct lifecycle semantics:
   merge readiness on the current head SHA. A new pass is required for each new head
   after post-draft changes.
 
+A THIRD gate, `review` (`GATE_NAMES`, `scripts/github/_gate-names.mjs`), exists
+outside this contract's scope: a standalone, on-demand review pass reachable on
+any PR with no lifecycle obligation of its own (see the
+[Review skill](../review/SKILL.md)). It posts through the same single-surface
+poster and required-fields shape this document defines, but is a deliberately
+NON-EVIDENCE gate — `review` is absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header vocabulary
+a `draft_gate`/`pre_approval_gate` comment is parsed against
+(`@dev-loops/core/github/copilot-helpers`), so a `review` comment never
+satisfies `draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
+SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
+authorizes nothing this contract's two gates require.
+
 ## Separate chains per gate
 
 Each gate runs its own independent review chain (`GATE-EXEC-SEPARATE-CHAINS`, owned by

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -48,10 +48,18 @@ fan-out, Phase 3 fan-in + verdict-post) with `--gate review`, but stops after
 Phase 3 — it never reaches Phase 3.5 (judge), Phase 4 (fix), or Phase 5
 (repeat), and carries no gate obligation of its own (reachable on any PR, no
 auto-resolve, no forbidden-action refusal, no CI wait). It is a deliberately
-NON-EVIDENCE gate: absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header
-vocabulary, so a `review` verdict never satisfies `draft_gate` or
-`pre_approval_gate` evidence. See the [Review skill](../review/SKILL.md).
+NON-EVIDENCE gate: `review` IS a recognized gate name in the gate-comment
+header vocabulary a comment is parsed against
+(`@dev-loops/core/github/copilot-helpers`) — recognized, not absent — and
+that recognition is exactly what makes the parser return non-evidence
+immediately for a `review`-headed comment, before it can ever fall through
+to the lenient whole-body token scan a genuinely unidentifiable comment
+relies on, regardless of whether the comment carries the
+`--findings-ledger` gate-findings-review marker. (It is separately, and
+unrelatedly, absent from `GATE_CONFIG_KEY` in `@dev-loops/core/loop/gate-fanin`
+— it has no `draft`/`preApproval`-style config threshold — but that absence
+is not what keeps a `review` verdict from satisfying `draft_gate` or
+`pre_approval_gate` evidence.) See the [Review skill](../review/SKILL.md).
 
 ## Separate chains per gate
 

--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -42,6 +42,17 @@ This contract owns the **execution shape** of gate-review work. It does not own:
 - the visible gate-review PR comment format (owned by [Gate Review Comment Contract](./gate-review-comment-contract.md), whose evidence is also required for a gate to be satisfied)
 - the broader PR lifecycle sequencing (owned by the workflow skill and [PR Lifecycle Contract](./pr-lifecycle-contract.md))
 
+A THIRD gate, `review` (`GATE_NAMES`, `scripts/github/_gate-names.mjs`), reuses
+this execution shape (Phase 1 context-builder, Phase 1.5 primer, Phase 2
+fan-out, Phase 3 fan-in + verdict-post) with `--gate review`, but stops after
+Phase 3 — it never reaches Phase 3.5 (judge), Phase 4 (fix), or Phase 5
+(repeat), and carries no gate obligation of its own (reachable on any PR, no
+auto-resolve, no forbidden-action refusal, no CI wait). It is a deliberately
+NON-EVIDENCE gate: absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header
+vocabulary, so a `review` verdict never satisfies `draft_gate` or
+`pre_approval_gate` evidence. See the [Review skill](../review/SKILL.md).
+
 ## Separate chains per gate
 
 <!-- rule: GATE-EXEC-SEPARATE-CHAINS -->

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -73,15 +73,26 @@ instruction, not something this skill initiates itself.
 
 ## Non-evidence, by construction
 
-`review` is deliberately absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the core gate-comment header
-vocabulary (`GATE_REVIEW_NAMES`/`GATE_REVIEW_COMMENT_HEADER_RE`,
-`@dev-loops/core/github/copilot-helpers`): a posted `review` verdict comment
-never parses as a `draft_gate` or `pre_approval_gate` comment, so
+`review` is absent from `GATE_CONFIG_KEY` (`@dev-loops/core/loop/gate-fanin`:
+it has no `draft`/`preApproval`-style config threshold), but that absence is
+NOT what keeps a posted `review` verdict comment from being misread as
+draft/pre-approval evidence. The real guard lives in
+`parseGateReviewCommentFields` (`@dev-loops/core/github/copilot-helpers`):
+`review` IS a recognized gate name there — recognized, not absent — and
+recognizing it as `review` is exactly what makes the parser return `null`
+immediately, before its lenient whole-body `draft_gate`/`pre_approval_gate`
+token-scan fallback ever runs. That short circuit holds independent of
+whether the comment carries the `--findings-ledger` gate-findings-review
+marker: a bare `review` post (no ledger, no marker) is caught the same way as
+a marker-bearing one. Without it, a `review` verdict whose findings text
+merely mentions "draft_gate" or "pre_approval_gate" (a plausible thing to say
+when reporting on this very mechanism) could otherwise be misread as real
+evidence by that fallback. Because of this guard,
 `detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs` never
-attribute it to either gate's evidence — `draftGateAlreadySatisfied` stays
-`false` and pre-approval readiness is unaffected, no matter how many `review`
-rounds a PR has carried. Posting `review` is purely informational.
+attribute a `review` comment to either gate's evidence — draft-gate
+satisfaction stays unaffected and pre-approval readiness is unaffected, no
+matter how many `review` rounds a PR has carried. Posting `review` is purely
+informational.
 
 ## Non-goals
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: "review"
+description: "Standalone, on-demand review entrypoint over the shared draft+pre-approval fan-out/fan-in gate procedure. Runs ONE `review`-gate round on any PR — draft or ready, with no dev-loop lifecycle obligation — and posts the single-surface verdict. Never fixes, never flips ready-for-review, never moves a board item, and never satisfies draft_gate/pre_approval_gate evidence."
+allowed-tools: Read Bash
+user-invocable: false
+---
+<!-- GENERATED from skills/review/SKILL.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
+
+
+# Review
+
+`review` is a THIRD gate, alongside `draft_gate` and `pre_approval_gate`
+(`scripts/github/_gate-names.mjs` `GATE_NAMES`), reachable on **any** PR with
+**no gate obligations of its own**: it never blocks a draft→ready transition,
+never blocks merge, never auto-resolves, and never waits on CI. It exists for
+an on-demand "review this PR right now" pass — a code review someone asked for
+outside the normal draft/pre-approval lifecycle — without disturbing that
+lifecycle's own state.
+
+## Interface
+
+```
+/loop-review <pr>
+```
+
+`<pr>` is a pull request number or URL, required. `<owner/repo>` resolves from
+the git remote at invocation, same as the other loop commands.
+
+In a consumer (plugin) install this runs as `/dev-loops:loop-review <pr>`; the
+bare `/loop-review` form is dev-loops-repo-local (repo-local
+`.claude/commands`).
+
+## What it runs
+
+`review` reuses the SAME shared sub-loop
+([Gate-review sub-loop contract](../docs/gate-review-sub-loop-contract.md)) the
+draft/pre-approval gates run, with `--gate review` threaded through every stage,
+but stops after fan-in/verdict-post — it never reaches the judge, fix, or
+repeat phases those gates run:
+
+1. **Phase 1 — context-builder.** `node scripts/github/write-gate-context.mjs
+   --repo <owner/repo> --pr <n> --gate review --head-sha <sha> --base <ref>
+   [...]` — the SAME build-once neutral bundle (diff + adjacent code) draft/
+   pre-approval get. Angle resolution for `review` is NOT dynamic/tiered: it is
+   the deterministic UNION of `draft`'s and `preApproval`'s configured angle
+   sets (`resolveReviewGateAngles` in `write-gate-context.mjs`). The
+   `acceptance-criteria` angle is DROPPED (with a recorded rationale entry,
+   reason `"no spec-of-record"`) only when the PR closes no issue AND its own
+   body carries no AC checklist; it is KEPT when either is true.
+2. **Phase 1.5 — cache primer.** Same `GATE-EXEC-PRIME` contract as any other
+   gate fan-out — prime the shared prefix before releasing the rest of the
+   fan-out.
+3. **Phase 2 — fan-out.** One independent, fresh-context `review` agent per
+   resolved dispatch unit (`resolveFanoutGroups`), each seeded with the
+   identical neutral bundle plus its angle(s) — unchanged from draft/
+   pre-approval fan-out; no new reviewer angles, no bespoke review agent.
+4. **Phase 3 — fan-in + post.** `node scripts/loop/consolidate-fanin.mjs
+   --gate review [...] --ledger-out <path>` synthesizes the per-angle findings
+   into one disposition ledger and computed verdict, then `node
+   scripts/github/upsert-checkpoint-verdict.mjs --repo <owner/repo> --pr <n>
+   --gate review --head-sha <sha> --findings-ledger <path> --next-action "none
+   — informational review, no re-gate required" [...]` posts the SINGLE
+   visible PR review surface (`GATE-COMMENT-SINGLE-SURFACE`) straight from
+   that ledger — no CI wait, no coordination-context read, no auto-resolve, no
+   forbidden-action check (those are draft/pre-approval-only machinery `review`
+   never touches).
+
+**Stop here.** Never proceed to the judge pass, the fix cycle, a re-gate
+round, `pr ready-for-review`, or a board move — a `review` round is a single,
+complete, terminal pass. There is no `review` fixer loop and no re-gate path;
+if the operator wants findings fixed, that is a SEPARATE, explicit
+instruction, not something this skill initiates itself.
+
+## Non-evidence, by construction
+
+`review` is deliberately absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the core gate-comment header
+vocabulary (`GATE_REVIEW_NAMES`/`GATE_REVIEW_COMMENT_HEADER_RE`,
+`@dev-loops/core/github/copilot-helpers`): a posted `review` verdict comment
+never parses as a `draft_gate` or `pre_approval_gate` comment, so
+`detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs` never
+attribute it to either gate's evidence — `draftGateAlreadySatisfied` stays
+`false` and pre-approval readiness is unaffected, no matter how many `review`
+rounds a PR has carried. Posting `review` is purely informational.
+
+## Non-goals
+
+No fixer loop, no re-gate, no merge path, no new reviewer angles, and no
+headless CLI that spawns reviewers itself — fan-out stays agent-orchestrated
+exactly like draft/pre-approval fan-out. It does not change draft_gate or
+pre_approval_gate semantics in any way.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See the canonical shorthand mapping in the [Public Dev Loop Contract](./skills/d
 | enqueue | `/loop-enqueue <issue\|pr\|text>` | — | Queue an issue/PR, or capture an idea as a grilled issue |
 | grill | `/loop-grill <issue\|plan> [--auto]` | — | Socratic Q&A grill of an issue or plan before the loop |
 | queue-status | `/loop-queue-status` | — | Show the queue board grouped by column |
+| review | `/loop-review <pr>` | — | Run a standalone, on-demand review pass over a PR (no gate obligations) |
 | review-ui | `/loop-review-ui <pr>` | — | Review a PR in a running-app UI loop |
 
 Beyond the per-issue loop entrypoints, the Pi `/dev-loops` command and the `dev-loops` CLI also expose standalone utilities: `help`, `status`, `doctor`, `gates` (`status` is the same readiness check as `loop-status` above). `hide` works only inside Pi — the `dev-loops hide` CLI subcommand is recognized but intentionally exits non-zero (session-local Pi UI behavior). Everything above is also available as a skill/agent — inside Pi, hand work to the `dev-loop` skill rather than calling internal routed skills (`local-implementation`, `copilot-pr-followup`, `final-approval`) directly.

--- a/commands/loop-review.command.md
+++ b/commands/loop-review.command.md
@@ -1,0 +1,14 @@
+---
+description: Run a single, standalone code-review pass over a PR (no gate obligations).
+argument-hint: <pr>
+---
+Invoke the `review` skill with `$ARGUMENTS`.
+
+**Usage:** `/dev-loops:loop-review <pr>` (or `/loop-review <pr>` in the dev-loops repo itself)
+
+**Arguments:**
+- `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+
+**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict and stops. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence. See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+
+**Stop conditions:** this command NEVER calls the fixer, never flips a PR to ready-for-review, and never moves a board item — a `review` round is a single, complete, terminal pass with no re-gate path. If the operator wants findings fixed, that is a separate, explicit follow-up instruction.

--- a/packages/core/src/github/copilot-helpers.mjs
+++ b/packages/core/src/github/copilot-helpers.mjs
@@ -15,6 +15,17 @@ import { trimmedOrNull } from "../loop/normalize.mjs";
 // review is.
 export const SUBMITTED_REVIEW_STATES = new Set(["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED"]);
 const GATE_REVIEW_NAMES = new Set(["draft_gate", "pre_approval_gate"]);
+// `review` (the standalone review entrypoint, upsert-checkpoint-verdict.mjs's
+// `--gate review`) is a RECOGNIZED gate header — it is identified, not
+// absent — but carries no draft/pre-approval evidence by design (#1808 AC3).
+// Recognizing it (rather than leaving it unrecognized) is what lets
+// parseGateReviewCommentFields below short-circuit to null the instant a
+// `review` header is seen, instead of falling through to the lenient
+// draft_gate/pre_approval_gate token scan — the fallthrough that previously
+// let a `review` verdict whose findings text merely MENTIONED "draft_gate"
+// get recorded as real draft-gate evidence (a draft-gate bypass).
+const NON_EVIDENCE_GATE_NAMES = new Set(["review"]);
+const RECOGNIZED_GATE_NAMES = new Set([...GATE_REVIEW_NAMES, ...NON_EVIDENCE_GATE_NAMES]);
 const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
 // Size-budget outcome vocabulary — mirrors
 // check-size-budget.mjs's computeSizeBudget outcome enum exactly; this file
@@ -295,9 +306,14 @@ function stripGateCommentMarkdown(rawLine) {
   return line.trim();
 }
 
+// Recognizes BOTH evidence gates (draft_gate/pre_approval_gate) and the
+// non-evidence `review` gate — parseGateReviewCommentFields below relies on
+// `review` coming back as an identified value (not null) so it can
+// short-circuit to non-evidence explicitly, rather than leaving the field
+// null and falling through to the lenient token-scan fallback.
 function normalizeGateReviewName(value) {
   const normalized = stripOptionalCodeTicks(value).toLowerCase();
-  return GATE_REVIEW_NAMES.has(normalized) ? normalized : null;
+  return RECOGNIZED_GATE_NAMES.has(normalized) ? normalized : null;
 }
 
 function normalizeGateReviewVerdict(value) {
@@ -478,6 +494,22 @@ function parseGateReviewCommentFields(body) {
       }
       continue;
     }
+  }
+
+  // An explicit, RECOGNIZED `review` gate field is authoritative and returns
+  // null here — before the lenient token-scan fallback below ever runs. A
+  // `review` verdict comment carries no draft/pre-approval evidence by
+  // design (#1808 AC3); without this short circuit, `fields.gate` would stay
+  // "review" (not one of the two evidence gates) but the lenient fallback
+  // below only fires when `!fields.gate` — so a *recognized* `review` gate
+  // would otherwise skip the fallback yet still return non-null fields keyed
+  // to "review", which is harmless for the two summarizers here (they only
+  // read `.draft_gate`/`.pre_approval_gate`) but leaves the non-evidence
+  // contract implicit rather than explicit. Stated plainly: an identified
+  // non-evidence gate must never be treated as an unidentified body, and an
+  // unidentified body is the ONLY case the token-scan fallback exists for.
+  if (NON_EVIDENCE_GATE_NAMES.has(fields.gate)) {
+    return null;
   }
 
   // Lenient fallback: detect gate name and head SHA anywhere in body

--- a/scripts/github/_gate-names.mjs
+++ b/scripts/github/_gate-names.mjs
@@ -2,7 +2,13 @@
 // across the gate-review tooling. Imported by write-gate-context.mjs (artifact
 // gate validation) and verify-briefing-prefixes.mjs (wrong-gate scope check) so
 // the two can never drift.
-export const GATE_NAMES = ["draft_gate", "pre_approval_gate"];
+//
+// `review` (#1808) is a THIRD, standalone gate: reachable on any PR with NO
+// gate obligations (it never blocks merge/ready, never satisfies draft_gate or
+// pre_approval_gate evidence, and carries no config section of its own — see
+// resolveReviewGateAngles in write-gate-context.mjs and the deliberate absence
+// of a "review" entry in GATE_CONFIG_KEY, @dev-loops/core/loop/gate-fanin).
+export const GATE_NAMES = ["draft_gate", "pre_approval_gate", "review"];
 
 // Canonical gate-verdict vocabulary — the single source of truth shared by
 // every gate-review script that parses/validates a --verdict or ledger

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -49,7 +49,7 @@ const REMOVED_FLAGS = new Set([
   "--force",
   "--force-reason",
 ]);
-const USAGE = `Usage: upsert-checkpoint-verdict.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path> | --findings-json <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate>] [--findings-ledger <path>]
+const USAGE = `Usage: upsert-checkpoint-verdict.mjs --repo <owner/name> --pr <number> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings-summary <text> | --findings-file <path> | --findings-json <path>) --next-action <text> [--gate <draft_gate|pre_approval_gate|review>] [--findings-ledger <path>]
 The --findings-json structured per-angle path is preferred for --execution-mode fanout_fanin.
 Post the gate round's SINGLE visible surface: one PR review of type COMMENT whose
 body carries the checkpoint verdict fields and, with --findings-ledger, the
@@ -62,7 +62,9 @@ A legacy verdict ISSUE comment for the same gate+head is still read and correcte
 in place (back-compat); new rounds always post a review.
 The gate (draft_gate or pre_approval_gate) is auto-resolved from the PR gate
 coordination state when --gate is not provided. Explicit --gate is still accepted
-but must match the coordination state's allowed next actions.
+but must match the coordination state's allowed next actions. --gate review is
+NEVER auto-resolved (must be passed explicitly): it carries no gate obligation,
+skips coordination-state/CI entirely, and always posts fresh.
 Required:
   --repo <owner/name>
   --pr <number>
@@ -167,7 +169,7 @@ Optional:
                                             (gates.<gate>.angles entries with
                                             mandatory: true) REQUIRES this
                                             flag; omitting both is refused.
-  --gate <draft_gate|pre_approval_gate>     Auto-resolved from coordination state
+  --gate <draft_gate|pre_approval_gate|review>     Auto-resolved from coordination state (draft_gate/pre_approval_gate only; review is never auto-resolved)
                                             when omitted. Explicit gate is validated
                                             against allowed coordination actions.
   --lightweight                             This PR is light-dispatched (#1210):
@@ -1612,7 +1614,9 @@ function deriveEffectiveNextAction(verdict, gate) {
   }
   // draft_gate: the PR stays draft and fixes are required before retrying.
   // pre_approval_gate: follow-up fixes are required before final approval —
-  // address the findings and re-run the gate.
+  // address the findings and re-run the gate. review: informational only —
+  // carries no re-gate obligation of its own.
+  if (gate === "review") return "none — informational review, no re-gate required";
   return gate === "draft_gate" ? "stay draft and fix" : "rerun gate";
 }
 
@@ -1718,154 +1722,173 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       // loadPrGateCoordinationContext call will surface the real error.
     }
   }
-  // Thread the light-dispatch signal (#1210) so the context interpreter and the
-  // maxCopilotRounds resolution below both use the composed lightweight cap —
-  // the two must never disagree at the cap boundary (#1126).
-  const coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr, lightweight: options.lightweight === true }, gh);
-  const evidence = coordinationContext.gateEvidence;
-  const canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
-  const draftGateConfig = resolveGateConfig(config, "draft");
-  const preApprovalGateConfig = resolveGateConfig(config, "preApproval");
-  const maxCopilotRounds = options.lightweight === true
-    ? resolveEffectiveCopilotRoundCap(config, { lightweight: true })
-    : resolveRefinementConfig(config, "maxCopilotRounds");
-  // Root cause 2: detect internal-only PRs so the Copilot convergence requirement
-  // is suppressed. Docs-only / tooling-only PRs should go straight to pre_approval_gate
-  // without requiring an external Copilot review cycle.
-  let reviewMode = null;
-  try {
-    const internalResult = await detectInternalOnly({ repo: options.repo, pr: options.pr }, gh);
-    if (internalResult?.ok && internalResult.internalOnly) {
-      reviewMode = "internal_only";
+  // `review` (#1808) is reachable on ANY PR with NO gate obligations: it never
+  // waits on CI, never auto-resolves, is never forbidden by draft/pre-approval
+  // lifecycle state, and never satisfies/consults draft_gate or pre_approval_gate
+  // evidence. It therefore skips the coordination-context load below entirely
+  // (the one place this function would otherwise read CI status) and posts
+  // straight from the caller-supplied --head-sha.
+  const isReviewGate = options.gate === "review";
+  let coordinationContext = null;
+  let evidence = null;
+  let coordination = null;
+  let canonicalHeadSha = options.headSha;
+  let draftGateConfig = null;
+  let preApprovalGateConfig = null;
+  if (!isReviewGate) {
+    // Thread the light-dispatch signal (#1210) so the context interpreter and the
+    // maxCopilotRounds resolution below both use the composed lightweight cap —
+    // the two must never disagree at the cap boundary (#1126).
+    coordinationContext = await loadPrGateCoordinationContext({ repo: options.repo, pr: options.pr, lightweight: options.lightweight === true }, gh);
+    evidence = coordinationContext.gateEvidence;
+    canonicalHeadSha = resolveRequestedHeadSha(options.headSha, evidence.currentHeadSha);
+    draftGateConfig = resolveGateConfig(config, "draft");
+    preApprovalGateConfig = resolveGateConfig(config, "preApproval");
+    const maxCopilotRounds = options.lightweight === true
+      ? resolveEffectiveCopilotRoundCap(config, { lightweight: true })
+      : resolveRefinementConfig(config, "maxCopilotRounds");
+    // Root cause 2: detect internal-only PRs so the Copilot convergence requirement
+    // is suppressed. Docs-only / tooling-only PRs should go straight to pre_approval_gate
+    // without requiring an external Copilot review cycle.
+    let reviewMode = null;
+    try {
+      const internalResult = await detectInternalOnly({ repo: options.repo, pr: options.pr }, gh);
+      if (internalResult?.ok && internalResult.internalOnly) {
+        reviewMode = "internal_only";
+      }
+    } catch {
+      // Non-fatal: internal-only detection failure is best-effort.
+      // Proceed with the default (external Copilot review) mode.
     }
-  } catch {
-    // Non-fatal: internal-only detection failure is best-effort.
-    // Proceed with the default (external Copilot review) mode.
-  }
-  const coordination = evaluatePrGateCoordination(buildCoordinationEvaluatorInput({
-    coordinationContext,
-    maxCopilotRounds,
-    draftGateConfig,
-    preApprovalGateConfig,
-    reviewMode,
-  }));
-  if (!options.gate) {
-    if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE)) {
-      options.gate = "draft_gate";
-    } else if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE)) {
-      options.gate = "pre_approval_gate";
-    } else if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)) {
-      options.gate = "draft_gate";
-    } else {
-      throw new Error(`Cannot auto-resolve gate for ${options.repo}#${options.pr}: no gate action is currently allowed (${coordination.reason})`);
+    coordination = evaluatePrGateCoordination(buildCoordinationEvaluatorInput({
+      coordinationContext,
+      maxCopilotRounds,
+      draftGateConfig,
+      preApprovalGateConfig,
+      reviewMode,
+    }));
+    if (!options.gate) {
+      if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_DRAFT_GATE)) {
+        options.gate = "draft_gate";
+      } else if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RUN_PRE_APPROVAL_GATE)) {
+        options.gate = "pre_approval_gate";
+      } else if (coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)) {
+        options.gate = "draft_gate";
+      } else {
+        throw new Error(`Cannot auto-resolve gate for ${options.repo}#${options.pr}: no gate action is currently allowed (${coordination.reason})`);
+      }
     }
-  }
-  const requestedGateAction = resolveGateAction(options.gate);
-  const prIsDraft = Boolean(coordinationContext.prData?.isDraft);
-  if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
-    // The draft gate is a one-time boundary: a non-draft PR with clean draft_gate
-    // evidence (on any head) has already passed it, and the pre-merge gate check
-    // accepts that evidence. Re-posting is therefore a no-op, not an error —
-    // return idempotent success so scripted/automated callers are not dead-ended
-    // by a hard throw. (#891)
-    const satisfied = coordinationContext.gateEvidence?.draftGate ?? {};
-    // executionMode lives on the gate MARKER summary, not the COMMENT (strict)
-    // summary: the strict `draftGate` summary is parsed from the visible comment
-    // body via normalizeGateSummary, which carries no executionMode field, so it
-    // would always collapse to inline_single_agent — misleading when the satisfied
-    // gate actually ran fanout_fanin. Prefer the marker's executionMode; if the
-    // marker is unavailable, OMIT the field rather than report a misleading default.
-    const satisfiedExecutionMode =
-      coordinationContext.gateEvidence?.draftGateMarker?.executionMode
-      ?? satisfied.executionMode
-      ?? null;
-    return {
-      ok: true,
-      action: "noop",
-      reason: "draft_gate already satisfied (clean evidence exists; draft→ready boundary recorded)",
-      repo: options.repo,
-      pr: options.pr,
-      gate: "draft_gate",
-      // Report the head the existing clean evidence was recorded on (which may be a
-      // stale head — the draft gate is a one-time boundary accepted on any head),
-      // not the request's canonical head, so the field is not misleading.
-      headSha: satisfied.headSha ?? canonicalHeadSha,
-      currentHeadSha: evidence.currentHeadSha,
-      draftGateAlreadySatisfied: true,
-      // Mirror the field shape of the other success paths for consistent consumers.
-      blockCleanOnFindingSeverities: draftGateConfig.blockCleanOnFindingSeverities,
-      ...(satisfiedExecutionMode != null ? { executionMode: satisfiedExecutionMode } : {}),
-      ...(satisfied.commentId != null ? { commentId: satisfied.commentId } : {}),
-      ...(satisfied.commentUrl ? { commentUrl: satisfied.commentUrl } : {}),
-    };
-  }
-  const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
-  // Draft gate can only be posted while the PR is a draft (RUN_DRAFT_GATE is
-  // forbidden once the PR is ready). A PR opened directly as ready — or any ready
-  // PR that still needs clean draft_gate evidence for the pre-merge check — would
-  // otherwise dead-end: the poster refuses, yet the pre-merge gate check fails
-  // closed on "missing visible clean draft_gate comment". Rather than force the
-  // operator to manually toggle the PR back to draft, perform the
-  // draft→post→ready transition here, preserving the caller's verdict, execution
-  // mode (e.g. fanout_fanin), findings, and ledger. This is the fanout-aware
-  // analogue of `reconcile-draft-gate` (which only posts inline and so cannot
-  // satisfy requireFanoutEvidence on draft_gate). (#891)
-  //
-  // Trigger ONLY when coordination explicitly allows RECONCILE_DRAFT_GATE — i.e. the
-  // state machine determined this ready PR genuinely needs draft-gate evidence
-  // reconciled (a converged/merge-progression state with no clean draft evidence).
-  // RUN_DRAFT_GATE is forbidden on a ready PR in many OTHER states too (merge
-  // conflicts, waiting-for-CI, unresolved feedback, blocked); converting those to
-  // draft would be wrong, so we must NOT key off `gateActionForbidden` alone. (#891)
-  if (
-    options.gate === "draft_gate"
-    && !prIsDraft
-    && !options._draftTransitionInProgress
-    && !coordination.draftGateAlreadySatisfied
-    && coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)
-  ) {
-    return await postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot, runChild });
-  }
-  // Fail closed on a lagged draft-state read: we are re-entering FROM
-  // postDraftGateViaDraftTransition (which just converted the PR to draft) yet the
-  // coordination context still reports the PR as non-draft. Recursing would loop
-  // indefinitely (the original #1020 hang → exit 13, error swallowed). Surface a
-  // clear, actionable error instead so the operator knows the draft conversion did
-  // not take (or GitHub's read lags the mutation) and can retry. (#1020)
-  if (
-    options.gate === "draft_gate"
-    && !prIsDraft
-    && options._draftTransitionInProgress
-  ) {
-    throw new Error(
-      `draft_gate self-heal for ${options.repo}#${options.pr} failed: the PR was converted to draft ` +
-      `to post the verdict, but GitHub still reports it as non-draft on re-entry (draft-state read lagged ` +
-      `the conversion mutation, or the conversion did not take). Not recursing. Re-run the draft_gate post ` +
-      `once the PR reflects the draft state, or reconcile manually with ` +
-      `\`gh pr ready ${options.pr} --repo ${options.repo}\` / ` +
-      `\`node scripts/github/reconcile-draft-gate.mjs --repo ${options.repo} --pr ${options.pr}\`.`,
+    const requestedGateAction = resolveGateAction(options.gate);
+    const prIsDraft = Boolean(coordinationContext.prData?.isDraft);
+    if (options.gate === "draft_gate" && coordination.draftGateAlreadySatisfied) {
+      // The draft gate is a one-time boundary: a non-draft PR with clean draft_gate
+      // evidence (on any head) has already passed it, and the pre-merge gate check
+      // accepts that evidence. Re-posting is therefore a no-op, not an error —
+      // return idempotent success so scripted/automated callers are not dead-ended
+      // by a hard throw. (#891)
+      const satisfied = coordinationContext.gateEvidence?.draftGate ?? {};
+      // executionMode lives on the gate MARKER summary, not the COMMENT (strict)
+      // summary: the strict `draftGate` summary is parsed from the visible comment
+      // body via normalizeGateSummary, which carries no executionMode field, so it
+      // would always collapse to inline_single_agent — misleading when the satisfied
+      // gate actually ran fanout_fanin. Prefer the marker's executionMode; if the
+      // marker is unavailable, OMIT the field rather than report a misleading default.
+      const satisfiedExecutionMode =
+        coordinationContext.gateEvidence?.draftGateMarker?.executionMode
+        ?? satisfied.executionMode
+        ?? null;
+      return {
+        ok: true,
+        action: "noop",
+        reason: "draft_gate already satisfied (clean evidence exists; draft→ready boundary recorded)",
+        repo: options.repo,
+        pr: options.pr,
+        gate: "draft_gate",
+        // Report the head the existing clean evidence was recorded on (which may be a
+        // stale head — the draft gate is a one-time boundary accepted on any head),
+        // not the request's canonical head, so the field is not misleading.
+        headSha: satisfied.headSha ?? canonicalHeadSha,
+        currentHeadSha: evidence.currentHeadSha,
+        draftGateAlreadySatisfied: true,
+        // Mirror the field shape of the other success paths for consistent consumers.
+        blockCleanOnFindingSeverities: draftGateConfig.blockCleanOnFindingSeverities,
+        ...(satisfiedExecutionMode != null ? { executionMode: satisfiedExecutionMode } : {}),
+        ...(satisfied.commentId != null ? { commentId: satisfied.commentId } : {}),
+        ...(satisfied.commentUrl ? { commentUrl: satisfied.commentUrl } : {}),
+      };
+    }
+    const gateActionForbidden = coordination.forbiddenActions.includes(requestedGateAction);
+    // Draft gate can only be posted while the PR is a draft (RUN_DRAFT_GATE is
+    // forbidden once the PR is ready). A PR opened directly as ready — or any ready
+    // PR that still needs clean draft_gate evidence for the pre-merge check — would
+    // otherwise dead-end: the poster refuses, yet the pre-merge gate check fails
+    // closed on "missing visible clean draft_gate comment". Rather than force the
+    // operator to manually toggle the PR back to draft, perform the
+    // draft→post→ready transition here, preserving the caller's verdict, execution
+    // mode (e.g. fanout_fanin), findings, and ledger. This is the fanout-aware
+    // analogue of `reconcile-draft-gate` (which only posts inline and so cannot
+    // satisfy requireFanoutEvidence on draft_gate). (#891)
+    //
+    // Trigger ONLY when coordination explicitly allows RECONCILE_DRAFT_GATE — i.e. the
+    // state machine determined this ready PR genuinely needs draft-gate evidence
+    // reconciled (a converged/merge-progression state with no clean draft evidence).
+    // RUN_DRAFT_GATE is forbidden on a ready PR in many OTHER states too (merge
+    // conflicts, waiting-for-CI, unresolved feedback, blocked); converting those to
+    // draft would be wrong, so we must NOT key off `gateActionForbidden` alone. (#891)
+    if (
+      options.gate === "draft_gate"
+      && !prIsDraft
+      && !options._draftTransitionInProgress
+      && !coordination.draftGateAlreadySatisfied
+      && coordination.allowedNextActions.includes(PR_CHECKPOINT_ACTION.RECONCILE_DRAFT_GATE)
+    ) {
+      return await postDraftGateViaDraftTransition(options, { env, ghCommand, repoRoot, runChild });
+    }
+    // Fail closed on a lagged draft-state read: we are re-entering FROM
+    // postDraftGateViaDraftTransition (which just converted the PR to draft) yet the
+    // coordination context still reports the PR as non-draft. Recursing would loop
+    // indefinitely (the original #1020 hang → exit 13, error swallowed). Surface a
+    // clear, actionable error instead so the operator knows the draft conversion did
+    // not take (or GitHub's read lags the mutation) and can retry. (#1020)
+    if (
+      options.gate === "draft_gate"
+      && !prIsDraft
+      && options._draftTransitionInProgress
+    ) {
+      throw new Error(
+        `draft_gate self-heal for ${options.repo}#${options.pr} failed: the PR was converted to draft ` +
+        `to post the verdict, but GitHub still reports it as non-draft on re-entry (draft-state read lagged ` +
+        `the conversion mutation, or the conversion did not take). Not recursing. Re-run the draft_gate post ` +
+        `once the PR reflects the draft state, or reconcile manually with ` +
+        `\`gh pr ready ${options.pr} --repo ${options.repo}\` / ` +
+        `\`node scripts/github/reconcile-draft-gate.mjs --repo ${options.repo} --pr ${options.pr}\`.`,
+      );
+    }
+    if (gateActionForbidden) {
+      throw new Error(buildGateEntryRefusalError({ options, coordination }));
+    }
+    // Post-time fan-out evidence enforcement: refuse an under-qualified inline
+    // verdict here, before it is posted, for every verdict value. No override
+    // flag — requireFanoutEvidence: false is the only opt-out, and that is
+    // already handled inside buildFanoutEnforcement.
+    await enforcePostTimeFanoutMode(
+      {
+        repo: options.repo,
+        pr: options.pr,
+        gate: options.gate,
+        executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
+        inlineReason: options.inlineReason,
+        headSha: canonicalHeadSha,
+        config,
+      },
+      { env, ghCommand, repoRoot, runChild },
     );
   }
-  if (gateActionForbidden) {
-    throw new Error(buildGateEntryRefusalError({ options, coordination }));
-  }
-  // Post-time fan-out evidence enforcement: refuse an under-qualified inline
-  // verdict here, before it is posted, for every verdict value. No override
-  // flag — requireFanoutEvidence: false is the only opt-out, and that is
-  // already handled inside buildFanoutEnforcement.
-  await enforcePostTimeFanoutMode(
-    {
-      repo: options.repo,
-      pr: options.pr,
-      gate: options.gate,
-      executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
-      inlineReason: options.inlineReason,
-      headSha: canonicalHeadSha,
-      config,
-    },
-    { env, ghCommand, repoRoot, runChild },
-  );
-  const activeGateConfig = options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig;
+  // review carries no gate obligations, so no configured blocking severities
+  // apply to it (a "clean" review claim is advisory, never merge-blocking).
+  const activeGateConfig = isReviewGate
+    ? { blockCleanOnFindingSeverities: [] }
+    : (options.gate === "draft_gate" ? draftGateConfig : preApprovalGateConfig);
   // Normalized at the CONSUME site, not only in the CLI parser: a direct
   // programmatic caller may pass legacy-keyed counts, and the guard below
   // must compare canonical keys on both sides.
@@ -2241,9 +2264,13 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   const effectiveFindingsSummary = structuredFindings
     ? buildStructuredFindingsDigest(structuredFindings, options.findingsSeverityCounts)
     : options.findingsSummary;
-  const gateEvidence = selectGateEvidence(evidence, options.gate);
-  const existing = summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
-  const warning = detectStaleGateCommentWarning({ strict: gateEvidence.strict, headSha: canonicalHeadSha, gate: options.gate });
+  // review consults no draft_gate/pre_approval_gate evidence (it must never
+  // match, dedupe against, or overwrite either gate's posted verdict) and is a
+  // single-shot post with no re-run dedup of its own — it always creates a
+  // fresh review.
+  const gateEvidence = isReviewGate ? { strict: null, marker: null } : selectGateEvidence(evidence, options.gate);
+  const existing = isReviewGate ? null : summarizeExistingComment({ ...gateEvidence, headSha: canonicalHeadSha });
+  const warning = isReviewGate ? null : detectStaleGateCommentWarning({ strict: gateEvidence.strict, headSha: canonicalHeadSha, gate: options.gate });
   // The round's finding surface (this same review): resolved BEFORE the body is
   // rendered, since the body carries the round number, the body-filed findings,
   // and the reduced per-angle digest that depends on them.
@@ -2256,7 +2283,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     headSha: canonicalHeadSha,
     findingsSummary: effectiveFindingsSummary,
     structuredFindings,
-    gateEvidenceNote: coordination.gateEvidenceNote ?? null,
+    gateEvidenceNote: coordination?.gateEvidenceNote ?? null,
     blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
     ...(findingSurface ? { round: findingSurface.round, nonLocatableFindings: findingSurface.nonLocatable } : {}),
   });
@@ -2284,7 +2311,10 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // structuredFindings is finalized) and applied on the created/updated/noop
   // paths — noop re-applies it too (idempotent) so a prior post whose label
   // application failed is retried at the same head, never left un-escalated.
-  const escalateGateFullLabel = resolveRequireFanoutEvidence(config)
+  // review never escalates to gate:full — it has no fan-out obligation of its
+  // own to escalate, and never re-gates.
+  const escalateGateFullLabel = !isReviewGate
+    && resolveRequireFanoutEvidence(config)
     && desiredExecutionMode === "inline_single_agent"
     && roundCarriesBlockingSeverity({
       verdict: options.verdict,
@@ -2455,7 +2485,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     pr: options.pr,
     gate: options.gate,
     headSha: canonicalHeadSha,
-    currentHeadSha: evidence.currentHeadSha,
+    currentHeadSha: evidence?.currentHeadSha ?? canonicalHeadSha,
     surface: "review",
     commentId: created.commentId,
     commentUrl: created.commentUrl,

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -34,7 +34,7 @@ import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
-import { GATE_ANGLE_SCOPES, GATE_FULL_LABEL, loadDevLoopConfig, resolveFanoutGroups, resolveFanoutMaxConcurrent, resolveFanoutSequential, resolveFanoutEffectiveConcurrency, resolveGateAngleContract, resolveGateAngleScope, resolveGateAnglesDynamic, resolveMaxAnglesPerGroup, resolveRoleModel } from "@dev-loops/core/config";
+import { GATE_ANGLE_SCOPES, GATE_FULL_LABEL, loadDevLoopConfig, resolveFanoutGroups, resolveFanoutMaxConcurrent, resolveFanoutSequential, resolveFanoutEffectiveConcurrency, resolveGateAngleContract, resolveGateAngleScope, resolveGateAngles, resolveGateAnglesDynamic, resolveMaxAnglesPerGroup, resolveRoleModel } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
 import { baseAngleName, reviewerBudgetPreflight, scheduleFanoutWaves } from "@dev-loops/core/loop/gate-fanin";
 import { buildAngleRequestGroups, buildReviewDispatchPlan, normalizeHarnessCapabilities } from "@dev-loops/core/loop/review-dispatch-plan";
@@ -63,6 +63,42 @@ export function mapGateToConfigKey(gate) {
   if (gate === "draft_gate") return "draft";
   if (gate === "pre_approval_gate") return "preApproval";
   throw new Error(`Unknown gate: ${JSON.stringify(gate)} (expected draft_gate or pre_approval_gate)`);
+}
+
+/**
+ * `review` (#1808) angle resolution — a standalone gate with no config key of
+ * its own (it is not "draft" or "preApproval"): its resolved angle set is the
+ * UNION of both gates' configured angle sets (resolveGateAngles, the STATIC
+ * pool — dynamic/tiered subtractive resolution is deliberately not applied to
+ * review; it always sees the full union), never resolveGateAnglesDynamic.
+ *
+ * `acceptance-criteria` is dropped from that union (with a rationale entry,
+ * reason "no spec-of-record") when the PR carries no spec-of-record at all —
+ * it closes no issue AND its own body carries no AC checklist. It is kept
+ * when either is true: a linked issue is presumed to carry the real spec even
+ * when its body could not be classified, and a PR that inlines its own AC
+ * checklist is its own spec-of-record.
+ *
+ * @param {import("@dev-loops/core/config").DevLoopConfig} config
+ * @param {{ hasClosingIssue: boolean, hasAcChecklist: boolean }} facts
+ * @returns {{ recommendedAngles: string[], skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: false, dynamicAnglesActive: false, addedAngles: string[], addedReasons: Record<string,string> }}
+ */
+export function resolveReviewGateAngles(config, { hasClosingIssue, hasAcChecklist }) {
+  const union = [...new Set([
+    ...(resolveGateAngles(config, "draft") ?? []),
+    ...(resolveGateAngles(config, "preApproval") ?? []),
+  ])];
+  const hasSpecOfRecord = hasClosingIssue === true || hasAcChecklist === true;
+  const dropAcceptanceCriteria = !hasSpecOfRecord && union.includes("acceptance-criteria");
+  return {
+    recommendedAngles: dropAcceptanceCriteria ? union.filter((a) => a !== "acceptance-criteria") : union,
+    skippedAngles: dropAcceptanceCriteria ? ["acceptance-criteria"] : [],
+    reasons: dropAcceptanceCriteria ? { "acceptance-criteria": "no spec-of-record" } : {},
+    fallbackToAll: false,
+    dynamicAnglesActive: false,
+    addedAngles: [],
+    addedReasons: {},
+  };
 }
 
 /**
@@ -132,12 +168,12 @@ export function rationaleFromResolver(resolverResult) {
   return { resolvedAngles: [...recommended], rationale };
 }
 
-const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> [--angles <json>] [--rationale <json>] [--branch <name>] [--touched-files <json>] [--base <ref>] [--acceptance-criteria <pointer>] [--pr-body <text>] [--issue-body <text>] [--prefix-file <path>] [--validation-posture <text>] [--tmp-root <path>]
+const USAGE = `Usage: write-gate-context.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate|review> --head-sha <sha> [--angles <json>] [--rationale <json>] [--branch <name>] [--touched-files <json>] [--base <ref>] [--acceptance-criteria <pointer>] [--pr-body <text>] [--issue-body <text>] [--prefix-file <path>] [--validation-posture <text>] [--tmp-root <path>]
 Write a deterministic gate-review context-builder handoff artifact under tmp/ paths.
 Required:
   --repo <owner/name>
   --pr <number>
-  --gate <draft_gate|pre_approval_gate>
+  --gate <draft_gate|pre_approval_gate|review>
   --head-sha <sha>
 Optional:
   --angles <json>               JSON array of review-angle name strings. OPTIONAL: when omitted, angles resolve dynamically from the loaded config (.devloops) + the --base diff via resolveGateAnglesDynamic (the same path buildGateContext uses). When supplied, the list is used VERBATIM as an explicit override (dynamic resolution is bypassed) — an escape hatch for forcing a specific angle set.
@@ -337,7 +373,7 @@ export function parseWriteGateContextCliArgs(argv) {
     }
     if (token.name === "gate") {
       const gate = normalizeGate(requireTokenValue(token, parseError));
-      if (!gate) throw parseError("--gate must be draft_gate or pre_approval_gate");
+      if (!gate) throw parseError(`--gate must be one of: ${GATE_NAMES.join(", ")}`);
       options.gate = gate;
       continue;
     }
@@ -2504,16 +2540,27 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
  * seeded with this verbatim instead of re-deriving the diff + adjacent code.
  */
 export async function buildGateContext(input, { repoRoot = process.cwd() } = {}) {
-  const configKey = mapGateToConfigKey(input.gate);
+  const isReviewGate = input.gate === "review";
+  // review has no config key of its own (resolveGateAnglesDynamic only
+  // understands "draft"/"preApproval"); its angle scope/fanout lookups below
+  // fall back to draft's config shape — a reasonable default since neither
+  // gate config exists for it — while its ANGLE SET is the dedicated union
+  // resolver below, never resolveGateAnglesDynamic.
+  const configKey = isReviewGate ? "draft" : mapGateToConfigKey(input.gate);
   // input.hasFullLabel is an ATTESTATION about the live PR's gate:full label,
   // not a preference: only an explicit `false` (caller checked the labels and
   // the label is absent) enables diff-class tier reduction. An omitted or
   // truthy value fails closed to the untriered set, so a caller that never
   // looked at the labels can never grant the reduced tier on a labelled PR.
-  const resolverResult = await resolveGateAnglesDynamic(input.config, configKey, {
-    diff: input.diff,
-    hasFullLabel: input.hasFullLabel !== false,
-  });
+  const resolverResult = isReviewGate
+    ? resolveReviewGateAngles(input.config, {
+        hasClosingIssue: input.hasClosingIssue === true,
+        hasAcChecklist: detectIssueRefinementArtifact({ body: input.prBody ?? "" }).hasACs,
+      })
+    : await resolveGateAnglesDynamic(input.config, configKey, {
+        diff: input.diff,
+        hasFullLabel: input.hasFullLabel !== false,
+      });
   const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
 
   // AC3 (#1572): each resolved angle's declared surface scope, straight from
@@ -2726,12 +2773,18 @@ export async function resolvePrSpecContext(options, { run = runChild, env = proc
   // the throw above, which is the unresolvable case.
   if (needsBody) options.prBody = typeof pr.body === "string" ? pr.body : "";
 
+  // Recorded whenever `pr` was actually fetched (regardless of the acProvided
+  // short-circuit below), for the `review` gate's own angle resolution (#1808
+  // AC2): whether this PR closes an issue at all, independent of whether the
+  // caller also supplied an --acceptance-criteria pointer.
+  const closingNumbers = resolveLinkedIssuesFromPr(pr);
+  options.hasClosingIssue = closingNumbers.length > 0;
+
   if (!needsIssue) {
     options.acceptanceCriteriaSource = "provided";
     return options;
   }
 
-  const closingNumbers = resolveLinkedIssuesFromPr(pr);
   if (closingNumbers.length === 0) {
     // Genuinely no closing reference (and no body-keyword fallback match) —
     // recorded as such, so a consumer can tell "this PR closes no issue" from
@@ -2911,28 +2964,39 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       // --prefix-file mode never touches GitHub, so the label CANNOT be
       // derived there — an omitted flag in that mode also fails closed to the
       // untriered set rather than silently tier-reducing a labelled PR.
-      if (options.fullLabel !== true && !options.prefixFile) {
-        try {
-          const { pr } = await viewPr(
-            { repo: options.repo, pr: options.pr, fields: "labels" },
-            { run },
-          );
-          options.fullLabel = Array.isArray(pr?.labels)
-            && pr.labels.some((label) => (label?.name ?? label) === GATE_FULL_LABEL);
-        } catch (error) {
+      // review never diff-class-tiers (no gate:full label lookup needed) — its
+      // angle set is always the dedicated union resolver, never
+      // resolveGateAnglesDynamic.
+      let resolverResult;
+      if (options.gate === "review") {
+        resolverResult = resolveReviewGateAngles(config, {
+          hasClosingIssue: options.hasClosingIssue === true,
+          hasAcChecklist: detectIssueRefinementArtifact({ body: options.prBody ?? "" }).hasACs,
+        });
+      } else {
+        if (options.fullLabel !== true && !options.prefixFile) {
+          try {
+            const { pr } = await viewPr(
+              { repo: options.repo, pr: options.pr, fields: "labels" },
+              { run },
+            );
+            options.fullLabel = Array.isArray(pr?.labels)
+              && pr.labels.some((label) => (label?.name ?? label) === GATE_FULL_LABEL);
+          } catch (error) {
+            options.fullLabel = true;
+            process.stderr.write(
+              `[write-gate-context] warning: could not read PR labels to check for ${GATE_FULL_LABEL} (${error?.message ?? error}); failing closed to the untriered angle set.\n`,
+            );
+          }
+        } else if (options.fullLabel !== true && options.prefixFile) {
           options.fullLabel = true;
           process.stderr.write(
-            `[write-gate-context] warning: could not read PR labels to check for ${GATE_FULL_LABEL} (${error?.message ?? error}); failing closed to the untriered angle set.\n`,
+            `[write-gate-context] note: --prefix-file mode cannot read PR labels; resolving the untriered angle set (pass --angles to override).\n`,
           );
         }
-      } else if (options.fullLabel !== true && options.prefixFile) {
-        options.fullLabel = true;
-        process.stderr.write(
-          `[write-gate-context] note: --prefix-file mode cannot read PR labels; resolving the untriered angle set (pass --angles to override).\n`,
-        );
+        const configKey = mapGateToConfigKey(options.gate);
+        resolverResult = await resolveGateAnglesDynamic(config, configKey, { diff, hasFullLabel: options.fullLabel === true });
       }
-      const configKey = mapGateToConfigKey(options.gate);
-      const resolverResult = await resolveGateAnglesDynamic(config, configKey, { diff, hasFullLabel: options.fullLabel === true });
       const { resolvedAngles, rationale } = rationaleFromResolver(resolverResult);
       if (resolvedAngles.length === 0) {
         process.stderr.write(
@@ -2960,7 +3024,9 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
     // rather than loading it a second time.
     if (options.angles.length > 0) {
       const scopeConfig = config;
-      const scopeConfigKey = mapGateToConfigKey(options.gate);
+      // review has no config key of its own; scope/fanout lookups fall back
+      // to draft's config shape (see buildGateContext's own configKey note).
+      const scopeConfigKey = options.gate === "review" ? "draft" : mapGateToConfigKey(options.gate);
       options.angleScopes = Object.fromEntries(
         options.angles.map((name) => [name, resolveGateAngleScope(scopeConfig, scopeConfigKey, name)]),
       );

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -73,14 +73,18 @@ export function mapGateToConfigKey(gate) {
  * review; it always sees the full union), never resolveGateAnglesDynamic.
  *
  * `acceptance-criteria` is dropped from that union (with a rationale entry,
- * reason "no spec-of-record") when the PR carries no spec-of-record at all —
- * it closes no issue AND its own body carries no AC checklist. It is kept
- * when either is true: a linked issue is presumed to carry the real spec even
- * when its body could not be classified, and a PR that inlines its own AC
- * checklist is its own spec-of-record.
+ * reason "no spec-of-record") only when both facts are DEFINITIVELY known
+ * false — it closes no issue AND its own body carries no AC checklist. It is
+ * kept when either is true: a linked issue is presumed to carry the real spec
+ * even when its body could not be classified, and a PR that inlines its own
+ * AC checklist is its own spec-of-record. `hasClosingIssue` is `undefined`
+ * (not `false`) when the caller never queried GitHub — e.g. `--prefix-file`
+ * mode, which never touches GitHub — and an unknown fact must never be
+ * coerced to "false": we cannot prove there is no spec-of-record, so this
+ * fails CLOSED and keeps acceptance-criteria.
  *
  * @param {import("@dev-loops/core/config").DevLoopConfig} config
- * @param {{ hasClosingIssue: boolean, hasAcChecklist: boolean }} facts
+ * @param {{ hasClosingIssue: boolean|undefined, hasAcChecklist: boolean|undefined }} facts
  * @returns {{ recommendedAngles: string[], skippedAngles: string[], reasons: Record<string,string>, fallbackToAll: false, dynamicAnglesActive: false, addedAngles: string[], addedReasons: Record<string,string> }}
  */
 export function resolveReviewGateAngles(config, { hasClosingIssue, hasAcChecklist }) {
@@ -88,8 +92,10 @@ export function resolveReviewGateAngles(config, { hasClosingIssue, hasAcChecklis
     ...(resolveGateAngles(config, "draft") ?? []),
     ...(resolveGateAngles(config, "preApproval") ?? []),
   ])];
-  const hasSpecOfRecord = hasClosingIssue === true || hasAcChecklist === true;
-  const dropAcceptanceCriteria = !hasSpecOfRecord && union.includes("acceptance-criteria");
+  // Definitively-false, not merely falsy: `undefined` (unknown) must not
+  // collapse into the same branch as a real "no" answer from GitHub.
+  const provablyNoSpecOfRecord = hasClosingIssue === false && hasAcChecklist === false;
+  const dropAcceptanceCriteria = provablyNoSpecOfRecord && union.includes("acceptance-criteria");
   return {
     recommendedAngles: dropAcceptanceCriteria ? union.filter((a) => a !== "acceptance-criteria") : union,
     skippedAngles: dropAcceptanceCriteria ? ["acceptance-criteria"] : [],
@@ -2554,7 +2560,11 @@ export async function buildGateContext(input, { repoRoot = process.cwd() } = {})
   // looked at the labels can never grant the reduced tier on a labelled PR.
   const resolverResult = isReviewGate
     ? resolveReviewGateAngles(input.config, {
-        hasClosingIssue: input.hasClosingIssue === true,
+        // Pass through verbatim — undefined means "never queried GitHub"
+        // (e.g. --prefix-file mode) and must reach the resolver as undefined,
+        // not be coerced to false, so it fails closed (keeps
+        // acceptance-criteria) rather than fail-open (drops it).
+        hasClosingIssue: input.hasClosingIssue,
         hasAcChecklist: detectIssueRefinementArtifact({ body: input.prBody ?? "" }).hasACs,
       })
     : await resolveGateAnglesDynamic(input.config, configKey, {
@@ -2969,8 +2979,11 @@ export async function main(argv = process.argv.slice(2), { repoRoot = process.cw
       // resolveGateAnglesDynamic.
       let resolverResult;
       if (options.gate === "review") {
+        // Pass through verbatim — see buildGateContext's identical call for
+        // why undefined (never queried GitHub, e.g. --prefix-file mode) must
+        // not be coerced to false here.
         resolverResult = resolveReviewGateAngles(config, {
-          hasClosingIssue: options.hasClosingIssue === true,
+          hasClosingIssue: options.hasClosingIssue,
           hasAcChecklist: detectIssueRefinementArtifact({ body: options.prBody ?? "" }).hasACs,
         });
       } else {

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -13,13 +13,13 @@ import { GATE_CONFIG_KEY, SEVERITY_ORDER, VALID_SEVERITIES, applyJudgeDispositio
 import { JUDGE_DISPOSITIONS as _JUDGE_DISPOSITIONS_ARRAY } from "@dev-loops/core/loop/gate-fanin";
 const JUDGE_DISPOSITIONS = new Set(_JUDGE_DISPOSITIONS_ARRAY);
 import { loadDevLoopConfig, resolveFanoutGroups, resolveGateAngleContract, resolveRejectForeignAngles } from "@dev-loops/core/config";
-import { normalizeGate as normalizeGateShared, normalizeVerdict as normalizeVerdictShared } from "./_gate-names.mjs";
-const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings <json> | --findings-file <path>) [--tmp-root <path>]
+import { GATE_NAMES, normalizeGate as normalizeGateShared, normalizeVerdict as normalizeVerdictShared } from "./_gate-names.mjs";
+const USAGE = `Usage: write-gate-findings-log.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate|review> --head-sha <sha> --verdict <clean|findings_present|blocked> (--findings <json> | --findings-file <path>) [--tmp-root <path>]
 Write a durable <gate>-<headSha>.json log under deterministic tmp/ paths.
 Required:
   --repo <owner/name>
   --pr <number>
-  --gate <draft_gate|pre_approval_gate>
+  --gate <draft_gate|pre_approval_gate|review>
   --head-sha <sha>              FULL head commit SHA (40 or 64 hex chars) — a short prefix is rejected (it would write an unfindable ledger)
   --verdict <clean|findings_present|blocked>
   --findings <json>              JSON array of finding objects with severity, disposition, angle, summary, and optional positive-integer line
@@ -382,7 +382,7 @@ export function parseWriteGateFindingsLogCliArgs(argv) {
     }
     if (token.name === "gate") {
       const gate = normalizeGate(requireTokenValue(token, parseError));
-      if (!gate) throw parseError("--gate must be draft_gate or pre_approval_gate");
+      if (!gate) throw parseError(`--gate must be one of: ${GATE_NAMES.join(", ")}`);
       options.gate = gate;
       continue;
     }

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -67,7 +67,7 @@ import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName
 import { enforceCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { enforcePrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
 
-const USAGE = `Usage: consolidate-fanin.mjs --findings-dir <dir> [--head-sha <sha>] [--gate <draft_gate|pre_approval_gate>] [--out <path>] [--ledger-out <path>] [--pr-checklist-matrix clean] [--carried-angles <json> --carry-forward-plan <json>] [--repo-root <path>] [--expected-dispatch-units <n>] [--tmp-root <path>]
+const USAGE = `Usage: consolidate-fanin.mjs --findings-dir <dir> [--head-sha <sha>] [--gate <draft_gate|pre_approval_gate|review>] [--out <path>] [--ledger-out <path>] [--pr-checklist-matrix clean] [--carried-angles <json> --carry-forward-plan <json>] [--repo-root <path>] [--expected-dispatch-units <n>] [--tmp-root <path>]
 Consolidate the per-angle *.json findings artifacts a gate-review fan-out wrote into
 --findings-dir into the JSON shapes write-gate-findings-log.mjs, post-gate-findings.mjs
 (--findings / --findings-file), and upsert-checkpoint-verdict.mjs (--findings-json) accept.
@@ -91,7 +91,7 @@ Optional:
                                  pre-stamp behavior (no head check). This is what makes a
                                  stale artifact staged from an earlier round distinguishable
                                  from a fresh verdict at the reviewed head.
-  --gate <draft_gate|pre_approval_gate>   Echoed onto the result as "gate"; also loads this
+  --gate <draft_gate|pre_approval_gate|review>   Echoed onto the result as "gate"; also loads this
                                  worktree's config and applies gates.<gate>.blockCleanOnFindingSeverities
                                  to the overall verdict (default when omitted: ["high"]). When given,
                                  a config that could not be fully loaded/validated FAILS CLOSED (exit 1)
@@ -657,7 +657,7 @@ export function parseConsolidateFaninCliArgs(argv) {
     if (token.name === "gate") {
       const gate = requireTokenValue(token, parseError).trim();
       if (!VALID_GATES.has(gate)) {
-        throw parseError("--gate must be draft_gate or pre_approval_gate");
+        throw parseError(`--gate must be one of: ${GATE_NAMES.join(", ")}`);
       }
       options.gate = gate;
       continue;
@@ -1179,12 +1179,23 @@ export async function consolidateGateFanin(options) {
     if (Array.isArray(errors) && errors.length > 0) {
       throw new Error(`--gate ${options.gate} was given but this worktree's config (--repo-root ${JSON.stringify(repoRoot)}) could not be fully loaded/validated: ${JSON.stringify(errors)}`);
     }
+    // review (#1808) has no config section of its own; its computed verdict
+    // reuses pre_approval_gate's configured blocking severities (the stricter
+    // gate's bar) purely to decide "clean" vs "findings_present" TRUTHFULLY —
+    // review carries no gate obligations, so nothing here actually blocks a
+    // merge/ready transition, and it carries no mandatory-angle enforcement
+    // of its own (this repo's own configured mandatory angles are not
+    // review's to enforce; #1808 non-goal: no new reviewer angles).
     const gateKey = options.gate === "draft_gate" ? "draft" : "preApproval";
     blockCleanOnFindingSeverities = resolveGateConfig(config, gateKey).blockCleanOnFindingSeverities;
-    // Lowercased to match the base+lowercase key compared against alwaysRerun
-    // below — a mandatory angle configured with case drift (e.g. "Correctness")
-    // must be refused exactly like its lowercase form.
-    mandatoryAngles = resolveGateAngleContract(config, gateKey).mandatoryAngles.map((name) => String(name).trim().toLowerCase());
+    if (options.gate === "review") {
+      mandatoryAngles = [];
+    } else {
+      // Lowercased to match the base+lowercase key compared against alwaysRerun
+      // below — a mandatory angle configured with case drift (e.g. "Correctness")
+      // must be refused exactly like its lowercase form.
+      mandatoryAngles = resolveGateAngleContract(config, gateKey).mandatoryAngles.map((name) => String(name).trim().toLowerCase());
+    }
   }
 
   // A carried angle (Phase 1.2's plan.carried) got no Phase 2 artifact — upsert

--- a/scripts/loop/run-gate-validation.mjs
+++ b/scripts/loop/run-gate-validation.mjs
@@ -21,7 +21,7 @@ import { parseArgs } from "node:util";
 
 import { parsePrNumber, requireTokenValue } from "../_cli-primitives.mjs";
 import { formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
-import { normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "../github/_gate-names.mjs";
+import { GATE_NAMES, normalizeGate as normalizeGateShared, normalizeHeadSha as normalizeHeadShaShared } from "../github/_gate-names.mjs";
 import { assertWorktreeAtHead, buildValidationResultsPath } from "../github/write-gate-context.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -29,14 +29,14 @@ const DEFAULT_SUITES = ["verify"];
 const OUTPUT_TAIL_CHARS = 4000;
 const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
-const USAGE = `Usage: run-gate-validation.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate> --head-sha <sha> [--suite <name>]... [--tmp-root <dir>]
+const USAGE = `Usage: run-gate-validation.mjs --repo <owner/name> --pr <number> --gate <draft_gate|pre_approval_gate|review> --head-sha <sha> [--suite <name>]... [--tmp-root <dir>]
 Run this round's validation suites ONCE and record the results in the shared
 validation-results artifact (GATE-EXEC-VALIDATION-ARTIFACT) so every per-angle
 gate reviewer reads this record instead of re-running the same suites.
 Required:
   --repo <owner/name>
   --pr <number>
-  --gate <draft_gate|pre_approval_gate>
+  --gate <draft_gate|pre_approval_gate|review>
   --head-sha <sha>
 Optional:
   --suite <name>              npm script name to run (repeatable). MUST be a key
@@ -115,7 +115,7 @@ export function parseRunGateValidationCliArgs(argv) {
     }
     if (token.name === "gate") {
       const gate = normalizeGate(requireTokenValue(token, parseError));
-      if (!gate) throw parseError("--gate must be draft_gate or pre_approval_gate");
+      if (!gate) throw parseError(`--gate must be one of: ${GATE_NAMES.join(", ")}`);
       options.gate = gate;
       continue;
     }

--- a/skills/docs/gate-review-comment-contract.md
+++ b/skills/docs/gate-review-comment-contract.md
@@ -80,11 +80,19 @@ outside this contract's scope: a standalone, on-demand review pass reachable on
 any PR with no lifecycle obligation of its own (see the
 [Review skill](../review/SKILL.md)). It posts through the same single-surface
 poster and required-fields shape this document defines, but is a deliberately
-NON-EVIDENCE gate — `review` is absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header vocabulary
-a `draft_gate`/`pre_approval_gate` comment is parsed against
-(`@dev-loops/core/github/copilot-helpers`), so a `review` comment never
-satisfies `draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
+NON-EVIDENCE gate. The guard is authoritative recognition, not absence:
+`review` IS a recognized gate name in the gate-comment header vocabulary a
+comment is parsed against (`@dev-loops/core/github/copilot-helpers`), and
+recognizing a comment's header as `review` is exactly what makes the parser
+return non-evidence immediately — before it ever falls through to the
+lenient whole-body `draft_gate`/`pre_approval_gate` token scan that a
+genuinely unidentifiable comment relies on. That holds regardless of
+`--findings-ledger`/the gate-findings-review marker. (`review` is also absent
+from `GATE_CONFIG_KEY` in `@dev-loops/core/loop/gate-fanin`, but that is a
+separate, unrelated fact — `review` has no `draft`/`preApproval`-style config
+threshold — not the mechanism that keeps its comments from being misread as
+draft/pre-approval evidence.) So a `review` comment never satisfies
+`draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
 SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
 authorizes nothing this contract's two gates require.
 

--- a/skills/docs/gate-review-comment-contract.md
+++ b/skills/docs/gate-review-comment-contract.md
@@ -75,6 +75,19 @@ This contract covers exactly two gates with distinct lifecycle semantics:
   merge readiness on the current head SHA. A new pass is required for each new head
   after post-draft changes.
 
+A THIRD gate, `review` (`GATE_NAMES`, `scripts/github/_gate-names.mjs`), exists
+outside this contract's scope: a standalone, on-demand review pass reachable on
+any PR with no lifecycle obligation of its own (see the
+[Review skill](../review/SKILL.md)). It posts through the same single-surface
+poster and required-fields shape this document defines, but is a deliberately
+NON-EVIDENCE gate — `review` is absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header vocabulary
+a `draft_gate`/`pre_approval_gate` comment is parsed against
+(`@dev-loops/core/github/copilot-helpers`), so a `review` comment never
+satisfies `draft_gate` or `pre_approval_gate` evidence and `GATE-COMMENT-NON-
+SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
+authorizes nothing this contract's two gates require.
+
 ## Separate chains per gate
 
 Each gate runs its own independent review chain (`GATE-EXEC-SEPARATE-CHAINS`, owned by

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -48,10 +48,18 @@ fan-out, Phase 3 fan-in + verdict-post) with `--gate review`, but stops after
 Phase 3 — it never reaches Phase 3.5 (judge), Phase 4 (fix), or Phase 5
 (repeat), and carries no gate obligation of its own (reachable on any PR, no
 auto-resolve, no forbidden-action refusal, no CI wait). It is a deliberately
-NON-EVIDENCE gate: absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header
-vocabulary, so a `review` verdict never satisfies `draft_gate` or
-`pre_approval_gate` evidence. See the [Review skill](../review/SKILL.md).
+NON-EVIDENCE gate: `review` IS a recognized gate name in the gate-comment
+header vocabulary a comment is parsed against
+(`@dev-loops/core/github/copilot-helpers`) — recognized, not absent — and
+that recognition is exactly what makes the parser return non-evidence
+immediately for a `review`-headed comment, before it can ever fall through
+to the lenient whole-body token scan a genuinely unidentifiable comment
+relies on, regardless of whether the comment carries the
+`--findings-ledger` gate-findings-review marker. (It is separately, and
+unrelatedly, absent from `GATE_CONFIG_KEY` in `@dev-loops/core/loop/gate-fanin`
+— it has no `draft`/`preApproval`-style config threshold — but that absence
+is not what keeps a `review` verdict from satisfying `draft_gate` or
+`pre_approval_gate` evidence.) See the [Review skill](../review/SKILL.md).
 
 ## Separate chains per gate
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -42,6 +42,17 @@ This contract owns the **execution shape** of gate-review work. It does not own:
 - the visible gate-review PR comment format (owned by [Gate Review Comment Contract](./gate-review-comment-contract.md), whose evidence is also required for a gate to be satisfied)
 - the broader PR lifecycle sequencing (owned by the workflow skill and [PR Lifecycle Contract](./pr-lifecycle-contract.md))
 
+A THIRD gate, `review` (`GATE_NAMES`, `scripts/github/_gate-names.mjs`), reuses
+this execution shape (Phase 1 context-builder, Phase 1.5 primer, Phase 2
+fan-out, Phase 3 fan-in + verdict-post) with `--gate review`, but stops after
+Phase 3 — it never reaches Phase 3.5 (judge), Phase 4 (fix), or Phase 5
+(repeat), and carries no gate obligation of its own (reachable on any PR, no
+auto-resolve, no forbidden-action refusal, no CI wait). It is a deliberately
+NON-EVIDENCE gate: absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the gate-comment header
+vocabulary, so a `review` verdict never satisfies `draft_gate` or
+`pre_approval_gate` evidence. See the [Review skill](../review/SKILL.md).
+
 ## Separate chains per gate
 
 <!-- rule: GATE-EXEC-SEPARATE-CHAINS -->

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -76,15 +76,26 @@ instruction, not something this skill initiates itself.
 
 ## Non-evidence, by construction
 
-`review` is deliberately absent from `GATE_CONFIG_KEY`
-(`@dev-loops/core/loop/gate-fanin`) and from the core gate-comment header
-vocabulary (`GATE_REVIEW_NAMES`/`GATE_REVIEW_COMMENT_HEADER_RE`,
-`@dev-loops/core/github/copilot-helpers`): a posted `review` verdict comment
-never parses as a `draft_gate` or `pre_approval_gate` comment, so
+`review` is absent from `GATE_CONFIG_KEY` (`@dev-loops/core/loop/gate-fanin`:
+it has no `draft`/`preApproval`-style config threshold), but that absence is
+NOT what keeps a posted `review` verdict comment from being misread as
+draft/pre-approval evidence. The real guard lives in
+`parseGateReviewCommentFields` (`@dev-loops/core/github/copilot-helpers`):
+`review` IS a recognized gate name there — recognized, not absent — and
+recognizing it as `review` is exactly what makes the parser return `null`
+immediately, before its lenient whole-body `draft_gate`/`pre_approval_gate`
+token-scan fallback ever runs. That short circuit holds independent of
+whether the comment carries the `--findings-ledger` gate-findings-review
+marker: a bare `review` post (no ledger, no marker) is caught the same way as
+a marker-bearing one. Without it, a `review` verdict whose findings text
+merely mentions "draft_gate" or "pre_approval_gate" (a plausible thing to say
+when reporting on this very mechanism) could otherwise be misread as real
+evidence by that fallback. Because of this guard,
 `detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs` never
-attribute it to either gate's evidence — `draftGateAlreadySatisfied` stays
-`false` and pre-approval readiness is unaffected, no matter how many `review`
-rounds a PR has carried. Posting `review` is purely informational.
+attribute a `review` comment to either gate's evidence — draft-gate
+satisfaction stays unaffected and pre-approval readiness is unaffected, no
+matter how many `review` rounds a PR has carried. Posting `review` is purely
+informational.
 
 ## Non-goals
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: review
+description: >-
+  Standalone, on-demand review entrypoint over the shared draft+pre-approval
+  fan-out/fan-in gate procedure. Runs ONE `review`-gate round on any PR — draft
+  or ready, with no dev-loop lifecycle obligation — and posts the single-surface
+  verdict. Never fixes, never flips ready-for-review, never moves a board item,
+  and never satisfies draft_gate/pre_approval_gate evidence.
+allowed-tools: read bash
+user-invocable: false
+---
+
+# Review
+
+`review` is a THIRD gate, alongside `draft_gate` and `pre_approval_gate`
+(`scripts/github/_gate-names.mjs` `GATE_NAMES`), reachable on **any** PR with
+**no gate obligations of its own**: it never blocks a draft→ready transition,
+never blocks merge, never auto-resolves, and never waits on CI. It exists for
+an on-demand "review this PR right now" pass — a code review someone asked for
+outside the normal draft/pre-approval lifecycle — without disturbing that
+lifecycle's own state.
+
+## Interface
+
+```
+/loop-review <pr>
+```
+
+`<pr>` is a pull request number or URL, required. `<owner/repo>` resolves from
+the git remote at invocation, same as the other loop commands.
+
+In a consumer (plugin) install this runs as `/dev-loops:loop-review <pr>`; the
+bare `/loop-review` form is dev-loops-repo-local (repo-local
+`.claude/commands`).
+
+## What it runs
+
+`review` reuses the SAME shared sub-loop
+([Gate-review sub-loop contract](../docs/gate-review-sub-loop-contract.md)) the
+draft/pre-approval gates run, with `--gate review` threaded through every stage,
+but stops after fan-in/verdict-post — it never reaches the judge, fix, or
+repeat phases those gates run:
+
+1. **Phase 1 — context-builder.** `node scripts/github/write-gate-context.mjs
+   --repo <owner/repo> --pr <n> --gate review --head-sha <sha> --base <ref>
+   [...]` — the SAME build-once neutral bundle (diff + adjacent code) draft/
+   pre-approval get. Angle resolution for `review` is NOT dynamic/tiered: it is
+   the deterministic UNION of `draft`'s and `preApproval`'s configured angle
+   sets (`resolveReviewGateAngles` in `write-gate-context.mjs`). The
+   `acceptance-criteria` angle is DROPPED (with a recorded rationale entry,
+   reason `"no spec-of-record"`) only when the PR closes no issue AND its own
+   body carries no AC checklist; it is KEPT when either is true.
+2. **Phase 1.5 — cache primer.** Same `GATE-EXEC-PRIME` contract as any other
+   gate fan-out — prime the shared prefix before releasing the rest of the
+   fan-out.
+3. **Phase 2 — fan-out.** One independent, fresh-context `review` agent per
+   resolved dispatch unit (`resolveFanoutGroups`), each seeded with the
+   identical neutral bundle plus its angle(s) — unchanged from draft/
+   pre-approval fan-out; no new reviewer angles, no bespoke review agent.
+4. **Phase 3 — fan-in + post.** `node scripts/loop/consolidate-fanin.mjs
+   --gate review [...] --ledger-out <path>` synthesizes the per-angle findings
+   into one disposition ledger and computed verdict, then `node
+   scripts/github/upsert-checkpoint-verdict.mjs --repo <owner/repo> --pr <n>
+   --gate review --head-sha <sha> --findings-ledger <path> --next-action "none
+   — informational review, no re-gate required" [...]` posts the SINGLE
+   visible PR review surface (`GATE-COMMENT-SINGLE-SURFACE`) straight from
+   that ledger — no CI wait, no coordination-context read, no auto-resolve, no
+   forbidden-action check (those are draft/pre-approval-only machinery `review`
+   never touches).
+
+**Stop here.** Never proceed to the judge pass, the fix cycle, a re-gate
+round, `pr ready-for-review`, or a board move — a `review` round is a single,
+complete, terminal pass. There is no `review` fixer loop and no re-gate path;
+if the operator wants findings fixed, that is a SEPARATE, explicit
+instruction, not something this skill initiates itself.
+
+## Non-evidence, by construction
+
+`review` is deliberately absent from `GATE_CONFIG_KEY`
+(`@dev-loops/core/loop/gate-fanin`) and from the core gate-comment header
+vocabulary (`GATE_REVIEW_NAMES`/`GATE_REVIEW_COMMENT_HEADER_RE`,
+`@dev-loops/core/github/copilot-helpers`): a posted `review` verdict comment
+never parses as a `draft_gate` or `pre_approval_gate` comment, so
+`detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs` never
+attribute it to either gate's evidence — `draftGateAlreadySatisfied` stays
+`false` and pre-approval readiness is unaffected, no matter how many `review`
+rounds a PR has carried. Posting `review` is purely informational.
+
+## Non-goals
+
+No fixer loop, no re-gate, no merge path, no new reviewer angles, and no
+headless CLI that spawns reviewers itself — fan-out stays agent-orchestrated
+exactly like draft/pre-approval fan-out. It does not change draft_gate or
+pre_approval_gate semantics in any way.

--- a/test/contracts/claude-plugin-manifest.test.mjs
+++ b/test/contracts/claude-plugin-manifest.test.mjs
@@ -47,7 +47,7 @@ test("the plugin exposes exactly the expected agents + skills (locks the surface
     if (existsSync(path.join(repoRoot, ".claude", "skills", d.name, "SKILL.md"))) skills.push(d.name);
   }
   skills.sort();
-  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation", "loop-grill", "ui-review"]);
+  assert.deepEqual(skills, ["copilot-pr-followup", "dev-loop", "final-approval", "local-implementation", "loop-grill", "review", "ui-review"]);
 });
 
 test("the publish files allowlist ships the plugin (not the project settings.json) and preserves Pi packaging", async () => {

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -26,11 +26,13 @@ import test from "node:test";
 import { runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import {
+  isGateMachineArtifactBody,
   parseGateReviewCommentMarkerBody,
   parseGateReviewCommentBody,
   summarizeGateReviewCommentMarkers,
   summarizeGateReviewComments,
 } from "../../scripts/_core-helpers.mjs";
+import { renderGateReviewCommentBody } from "../../scripts/github/upsert-checkpoint-verdict.mjs";
 import {
   parseDetectCheckpointEvidenceCliArgs,
   buildPreMergeGateCheck,
@@ -157,6 +159,54 @@ test("summarizeGateReviewComments keeps the newest valid comment for each gate",
   assert.equal(summary.draft_gate?.headSha, "abc1234");
   assert.equal(summary.pre_approval_gate?.commentId, 12);
   assert.equal(summary.pre_approval_gate?.nextAction, "await final human approval");
+});
+
+// #1808 AC3: a `review` verdict is a THIRD, non-evidence gate — it must never
+// satisfy draft_gate or pre_approval_gate evidence. "review" is deliberately
+// absent from GATE_REVIEW_NAMES/GATE_REVIEW_COMMENT_HEADER_RE
+// (packages/core/src/github/copilot-helpers.mjs), so a review comment's
+// header never parses as either canonical gate.
+test("summarizeGateReviewComments ignores a review-gate comment (#1808 AC3: review carries no draft/pre-approval evidence)", () => {
+  const summary = summarizeGateReviewComments([
+    {
+      id: 20,
+      body: [
+        "Gate review: review",
+        "Reviewed head SHA: abc1234",
+        "Verdict: clean",
+        "Findings summary: no issues found",
+        "Next action: none — informational review, no re-gate required",
+      ].join("\n"),
+      updated_at: "2026-05-29T23:00:00Z",
+    },
+  ]);
+  assert.equal(summary.draft_gate, null);
+  assert.equal(summary.pre_approval_gate, null);
+});
+
+// End-to-end proof against the REAL renderer (upsert-checkpoint-verdict.mjs's
+// own renderGateReviewCommentBody), including the gate-findings-review marker
+// a --findings-ledger round renders: the whole comment is excluded even
+// before field parsing (isGateMachineArtifactBody: true, since its header
+// does not match GATE_REVIEW_COMMENT_HEADER_RE), and a PR carrying ONLY this
+// comment reports no draft_gate/pre_approval_gate evidence either way.
+test("a real review-gate verdict comment (with a findings-review marker) never satisfies draft_gate/pre_approval_gate evidence (#1808 AC3)", () => {
+  const body = renderGateReviewCommentBody({
+    gate: "review",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: "no issues found",
+    nextAction: "none — informational review, no re-gate required",
+    round: 1,
+  });
+  assert.equal(isGateMachineArtifactBody(body), true);
+  const comments = [{ id: 21, body, updated_at: "2026-05-29T23:30:00Z" }];
+  const summary = summarizeGateReviewComments(comments);
+  assert.equal(summary.draft_gate, null);
+  assert.equal(summary.pre_approval_gate, null);
+  const markerSummary = summarizeGateReviewCommentMarkers(comments, { headSha: "abc1234" });
+  assert.equal(markerSummary.draft_gate, null);
+  assert.equal(markerSummary.pre_approval_gate, null);
 });
 
 test("summarizeGateReviewCommentMarkers can target the newest marker for the current gate+head pair", () => {

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -162,10 +162,14 @@ test("summarizeGateReviewComments keeps the newest valid comment for each gate",
 });
 
 // #1808 AC3: a `review` verdict is a THIRD, non-evidence gate — it must never
-// satisfy draft_gate or pre_approval_gate evidence. "review" is deliberately
-// absent from GATE_REVIEW_NAMES/GATE_REVIEW_COMMENT_HEADER_RE
-// (packages/core/src/github/copilot-helpers.mjs), so a review comment's
-// header never parses as either canonical gate.
+// satisfy draft_gate or pre_approval_gate evidence. `review` IS a recognized
+// gate header (RECOGNIZED_GATE_NAMES in packages/core/src/github/
+// copilot-helpers.mjs) — recognized, not absent — and parseGateReviewCommentFields
+// explicitly short-circuits to null the instant its header identifies the
+// gate as `review`, before the lenient draft_gate/pre_approval_gate
+// token-scan fallback ever runs. Absence would have left the fallback free
+// to misread findings text that merely mentions "draft_gate" as real
+// evidence (see the regression test below).
 test("summarizeGateReviewComments ignores a review-gate comment (#1808 AC3: review carries no draft/pre-approval evidence)", () => {
   const summary = summarizeGateReviewComments([
     {
@@ -187,9 +191,12 @@ test("summarizeGateReviewComments ignores a review-gate comment (#1808 AC3: revi
 // End-to-end proof against the REAL renderer (upsert-checkpoint-verdict.mjs's
 // own renderGateReviewCommentBody), including the gate-findings-review marker
 // a --findings-ledger round renders: the whole comment is excluded even
-// before field parsing (isGateMachineArtifactBody: true, since its header
-// does not match GATE_REVIEW_COMMENT_HEADER_RE), and a PR carrying ONLY this
-// comment reports no draft_gate/pre_approval_gate evidence either way.
+// before field parsing (isGateMachineArtifactBody: true, since the raw
+// marker-bearing body carries no genuine gate verdict header per
+// GATE_REVIEW_COMMENT_HEADER_RE — that regex recognizes only draft_gate/
+// pre_approval_gate, so a review render with a marker is never mistaken for
+// the SAME surface's own verdict), and a PR carrying ONLY this comment
+// reports no draft_gate/pre_approval_gate evidence either way.
 test("a real review-gate verdict comment (with a findings-review marker) never satisfies draft_gate/pre_approval_gate evidence (#1808 AC3)", () => {
   const body = renderGateReviewCommentBody({
     gate: "review",
@@ -204,6 +211,52 @@ test("a real review-gate verdict comment (with a findings-review marker) never s
   const summary = summarizeGateReviewComments(comments);
   assert.equal(summary.draft_gate, null);
   assert.equal(summary.pre_approval_gate, null);
+  const markerSummary = summarizeGateReviewCommentMarkers(comments, { headSha: "abc1234" });
+  assert.equal(markerSummary.draft_gate, null);
+  assert.equal(markerSummary.pre_approval_gate, null);
+});
+
+// Regression (#1808 HIGH, draft-gate bypass): the bare `upsert-checkpoint-verdict
+// --gate review` path (no --findings-ledger) never renders the
+// gate-findings-review marker, so isGateMachineArtifactBody does NOT exclude
+// it — the body reaches parseGateReviewCommentFields on its structured-field
+// merits alone. Before the fix, a `review` header normalized to null (not
+// recognized), so the parser fell through to the lenient whole-body
+// draft_gate/pre_approval_gate token scan; a clean `review` verdict whose
+// findings text merely MENTIONED "draft_gate" (a plausible thing to say when
+// reporting on this very mechanism) was then recorded as real draft_gate
+// evidence — a draft-gate bypass. The fix recognizes `review` as an
+// identified, non-evidence gate and returns null before that scan ever runs.
+test("a marker-less review-gate verdict comment whose findings text mentions draft_gate/pre_approval_gate is never recorded as evidence (#1808 HIGH regression)", () => {
+  const draftGateMentionBody = renderGateReviewCommentBody({
+    gate: "review",
+    headSha: "abc1234",
+    verdict: "clean",
+    findingsSummary: "confirmed this PR never bypasses draft_gate evidence",
+    nextAction: "none — informational review, no re-gate required",
+  });
+  // No --findings-ledger round was supplied, so no marker is rendered — the
+  // exact bare-path shape the HIGH describes.
+  assert.equal(isGateMachineArtifactBody(draftGateMentionBody), false);
+
+  const preApprovalGateMentionBody = renderGateReviewCommentBody({
+    gate: "review",
+    headSha: "def5678",
+    verdict: "clean",
+    findingsSummary: "confirmed this PR never bypasses pre_approval_gate evidence",
+    nextAction: "none — informational review, no re-gate required",
+  });
+  assert.equal(isGateMachineArtifactBody(preApprovalGateMentionBody), false);
+
+  const comments = [
+    { id: 30, body: draftGateMentionBody, updated_at: "2026-05-29T23:40:00Z" },
+    { id: 31, body: preApprovalGateMentionBody, updated_at: "2026-05-29T23:41:00Z" },
+  ];
+
+  const summary = summarizeGateReviewComments(comments);
+  assert.equal(summary.draft_gate, null);
+  assert.equal(summary.pre_approval_gate, null);
+
   const markerSummary = summarizeGateReviewCommentMarkers(comments, { headSha: "abc1234" });
   assert.equal(markerSummary.draft_gate, null);
   assert.equal(markerSummary.pre_approval_gate, null);

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6184,6 +6184,111 @@ test("upsert-checkpoint-verdict posts a withheld fanout_fanin verdict when --fin
   }, { prefix: "dev-loops-upsert-withheld-covered-" });
 });
 
+// ---------------------------------------------------------------------------
+// #1808 AC4 — `review` is a THIRD, standalone gate: --gate review posts the
+// single-surface PR review straight from --findings-ledger and never touches
+// the draft/pre-approval coordination-context (no CI wait, no PR-view/
+// requested_reviewers/threads coordination reads, no auto-resolve, no
+// forbidden-action refusal). The gh mock below carries ONLY the
+// resolveFindingSurface reads a --findings-ledger round needs (login,
+// reviews, issue comments, threads, PR files) plus the POST — omitting every
+// coordination-context call makeGhMock would otherwise refuse as unexpected,
+// which is itself the proof that none of them ran.
+// ---------------------------------------------------------------------------
+
+function reviewGateFindingSurfaceEntries({ issueComments = [], reviews = [], threads = [], files = [] } = {}) {
+  return [
+    { assertArgs: ["api", "user"], stdout: '{"login":"gate-bot"}\n' },
+    { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/17/reviews?per_page=100"], stdout: JSON.stringify(reviews) + "\n" },
+    { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: JSON.stringify(issueComments) + "\n" },
+    {
+      assertArgs: ["api", "graphql"],
+      assertArgContains: ["reviewThreads"],
+      stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: threads } } } } }) + "\n",
+    },
+    ...(files === null ? [] : [{ assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/17/files?per_page=100"], stdout: JSON.stringify(files) + "\n" }]),
+  ];
+}
+
+async function writeReviewGateLedger(tempDir, findings, overrides = {}) {
+  const ledgerPath = path.join(tempDir, "review-ledger.json");
+  await writeFile(ledgerPath, JSON.stringify({
+    repo: "owner/repo",
+    pr: 17,
+    gate: "review",
+    headSha: SINGLE_SURFACE_HEAD,
+    verdict: "findings_present",
+    findings,
+    ...overrides,
+  }), "utf8");
+  return ledgerPath;
+}
+
+test("#1808: --gate review posts a created PR review straight from --findings-ledger, with NO coordination-context/CI gh calls (unmocked calls would refuse)", async () => {
+  await withTempDir(async (tempDir) => {
+    const ledgerPath = await writeReviewGateLedger(tempDir, [BODY_FILED_FINDING], { overallVerdict: "findings_present" });
+    const entries = [
+      ...reviewGateFindingSurfaceEntries(),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        stdout: '{"id":901,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-901"}\n',
+      },
+    ];
+    const { runChild } = makeGhMock(entries);
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "review",
+      headSha: SINGLE_SURFACE_HEAD,
+      // --verdict omitted on purpose: derived from the ledger's overallVerdict,
+      // same contract as draft_gate/pre_approval_gate (#1616).
+      nextAction: "none — informational review, no re-gate required",
+      findingsLedger: ledgerPath,
+      executionMode: "fanout_fanin",
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+    assert.equal(result.surface, "review");
+    assert.equal(result.gate, "review");
+    assert.equal(result.bodyFiled, 1);
+    // No draft_gate-shaped blocking-severity gating leaks onto review.
+    assert.deepEqual(result.blockCleanOnFindingSeverities, []);
+  }, { prefix: "dev-loops-upsert-review-gate-" });
+});
+
+test("#1808: --gate review on a CLEAN ledger renders with no blocking-severity line and requires no --findings-severity-counts", async () => {
+  await withTempDir(async (tempDir) => {
+    const ledgerPath = await writeReviewGateLedger(tempDir, [], { verdict: "clean", overallVerdict: "clean" });
+    const entries = [
+      // No findings at all: resolveFindingSurface returns before the PR-files
+      // read (nothing to locate), so files: null omits that mock entry.
+      ...reviewGateFindingSurfaceEntries({ files: null }),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        stdout: '{"id":902,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-902"}\n',
+      },
+    ];
+    const { runChild } = makeGhMock(entries);
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "review",
+      headSha: SINGLE_SURFACE_HEAD,
+      nextAction: "none — informational review, no re-gate required",
+      findingsLedger: ledgerPath,
+      executionMode: "fanout_fanin",
+      // No --findings-severity-counts: a draft_gate/pre_approval_gate clean
+      // verdict would refuse without it (see the #1621 clean-verdict tests
+      // above); review carries no blocking severities, so no proof is
+      // required for its "clean" claim.
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.action, "created");
+  }, { prefix: "dev-loops-upsert-review-gate-clean-" });
+});
+
 test("normalizeStructuredFindings aliases the legacy severity so no posted body renders it", () => {
   const angles = normalizeStructuredFindings([
     { angle: "docs", verdict: "findings_present", findings: [{ severity: "defer", summary: "legacy entry" }] },

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -39,6 +39,7 @@ import {
   renderBriefingPrefix,
   renderBriefingVolatile,
   renderScopedBriefingVariant,
+  resolveReviewGateAngles,
   writeGateContext,
 } from "../../scripts/github/write-gate-context.mjs";
 
@@ -594,6 +595,111 @@ test("mapGateToConfigKey maps artifact gate names to config keys", () => {
   assert.equal(mapGateToConfigKey("draft_gate"), "draft");
   assert.equal(mapGateToConfigKey("pre_approval_gate"), "preApproval");
   assert.throws(() => mapGateToConfigKey("bogus"), /Unknown gate/);
+});
+
+// #1808 review deliberately has no 1:1 config key (its angle set is a UNION
+// of draft's and pre-approval's, resolved by resolveReviewGateAngles below,
+// never resolveGateAnglesDynamic) — mapGateToConfigKey must keep refusing it.
+test("mapGateToConfigKey still refuses \"review\" (no 1:1 config key; see resolveReviewGateAngles)", () => {
+  assert.throws(() => mapGateToConfigKey("review"), /Unknown gate/);
+});
+
+// ---------------------------------------------------------------------------
+// resolveReviewGateAngles (#1808 AC2) — review's angle set is the UNION of
+// draft's and pre-approval's configured angles, with acceptance-criteria
+// dropped (rationale-recorded) only when the PR has no spec-of-record at all.
+// ---------------------------------------------------------------------------
+
+function reviewAnglesConfig({ draftAngles, preApprovalAngles }) {
+  return {
+    gates: {
+      draft: { angles: draftAngles.map((name) => ({ name })) },
+      preApproval: { angles: preApprovalAngles.map((name) => ({ name })) },
+    },
+  };
+}
+
+test("resolveReviewGateAngles unions draft's and pre-approval's configured angles (dedup, order-stable)", () => {
+  const config = reviewAnglesConfig({
+    draftAngles: ["correctness", "security"],
+    preApprovalAngles: ["security", "docs"],
+  });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: true, hasAcChecklist: false });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "security", "docs"]);
+  assert.deepEqual(result.skippedAngles, []);
+  assert.equal(result.dynamicAnglesActive, false);
+});
+
+test("resolveReviewGateAngles DROPS acceptance-criteria (with a \"no spec-of-record\" rationale) when the PR closes no issue and its body has no AC checklist", () => {
+  const config = reviewAnglesConfig({
+    draftAngles: ["correctness", "acceptance-criteria"],
+    preApprovalAngles: ["docs"],
+  });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: false, hasAcChecklist: false });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "docs"]);
+  assert.deepEqual(result.skippedAngles, ["acceptance-criteria"]);
+  assert.deepEqual(result.reasons, { "acceptance-criteria": "no spec-of-record" });
+});
+
+test("resolveReviewGateAngles KEEPS acceptance-criteria when the PR closes an issue (even with no AC checklist in its own body)", () => {
+  const config = reviewAnglesConfig({
+    draftAngles: ["correctness", "acceptance-criteria"],
+    preApprovalAngles: [],
+  });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: true, hasAcChecklist: false });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "acceptance-criteria"]);
+  assert.deepEqual(result.skippedAngles, []);
+});
+
+test("resolveReviewGateAngles KEEPS acceptance-criteria when the PR's own body carries an AC checklist (even closing no issue)", () => {
+  const config = reviewAnglesConfig({
+    draftAngles: ["correctness", "acceptance-criteria"],
+    preApprovalAngles: [],
+  });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: false, hasAcChecklist: true });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "acceptance-criteria"]);
+  assert.deepEqual(result.skippedAngles, []);
+});
+
+test("resolveReviewGateAngles is a no-op when acceptance-criteria was never in the union to begin with", () => {
+  const config = reviewAnglesConfig({ draftAngles: ["correctness"], preApprovalAngles: ["docs"] });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: false, hasAcChecklist: false });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "docs"]);
+  assert.deepEqual(result.skippedAngles, []);
+});
+
+// End-to-end wiring check (buildGateContext, not just the pure resolver above):
+// gate: "review" resolves the SAME union+drop shape through the actual artifact
+// builder — no resolveGateAnglesDynamic tiering, no config-key crash.
+test("buildGateContext --gate review resolves the draft+preApproval union and drops acceptance-criteria with no spec-of-record", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-review-"));
+  try {
+    const config = {
+      version: 1,
+      gates: {
+        draft: { angles: buildAngleEntries({ angles: ["correctness", "acceptance-criteria"], mandatoryAngles: [], excludeAngles: [] }) },
+        preApproval: { angles: buildAngleEntries({ angles: ["docs"], mandatoryAngles: [], excludeAngles: [] }) },
+      },
+    };
+    const result = await buildGateContext(
+      {
+        config,
+        gate: "review",
+        repo: "owner/repo",
+        pr: 12,
+        headSha: "abc1234567890",
+        hasClosingIssue: false,
+        prBody: "no AC checklist here",
+      },
+      { repoRoot },
+    );
+    assert.deepEqual(result.artifact.resolvedAngles, ["correctness", "docs"]);
+    const dropped = result.artifact.rationale.find((r) => r.angle === "acceptance-criteria");
+    assert.equal(dropped.action, "dropped");
+    assert.equal(dropped.reason, "no spec-of-record");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -641,6 +641,23 @@ test("resolveReviewGateAngles DROPS acceptance-criteria (with a \"no spec-of-rec
   assert.deepEqual(result.reasons, { "acceptance-criteria": "no spec-of-record" });
 });
 
+// #1839 Copilot round 1: --prefix-file mode never queries GitHub, so
+// options.hasClosingIssue is `undefined` (unknown), not `false` (a real "no"
+// answer). Coercing unknown to false would fail OPEN (drop a review angle we
+// cannot prove should be dropped). This must fail CLOSED: keep
+// acceptance-criteria, and record no "no spec-of-record" rationale, since we
+// never proved there is no spec-of-record.
+test("resolveReviewGateAngles KEEPS acceptance-criteria (no drop, no rationale) when hasClosingIssue is UNKNOWN (undefined, e.g. --prefix-file mode never queried GitHub)", () => {
+  const config = reviewAnglesConfig({
+    draftAngles: ["correctness", "acceptance-criteria"],
+    preApprovalAngles: ["docs"],
+  });
+  const result = resolveReviewGateAngles(config, { hasClosingIssue: undefined, hasAcChecklist: false });
+  assert.deepEqual(result.recommendedAngles, ["correctness", "acceptance-criteria", "docs"]);
+  assert.deepEqual(result.skippedAngles, []);
+  assert.deepEqual(result.reasons, {});
+});
+
 test("resolveReviewGateAngles KEEPS acceptance-criteria when the PR closes an issue (even with no AC checklist in its own body)", () => {
   const config = reviewAnglesConfig({
     draftAngles: ["correctness", "acceptance-criteria"],

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -176,7 +176,7 @@ test("parseConsolidateFaninCliArgs rejects missing --findings-dir", () => {
 test("parseConsolidateFaninCliArgs rejects invalid --gate", () => {
   assert.throws(
     () => parseConsolidateFaninCliArgs(["--findings-dir", "/tmp/x", "--gate", "bogus_gate"]),
-    /draft_gate or pre_approval_gate/,
+    /draft_gate, pre_approval_gate, review/,
   );
 });
 


### PR DESCRIPTION
## Objective

Add a standalone `review` gate entrypoint: one fan-out/fan-in review round over the union of the draft and pre-approval angle sets, on any PR, with NO gate obligations. It posts one single-surface PR review and stops; it never counts as gate evidence.

Closes #1808.

## Design

- Gate vocabulary: `review` added to `scripts/github/_gate-names.mjs` `GATE_NAMES`. `pre_approval_gate` is NOT reused (a clean pre-approval comment is merge-readiness evidence — GATE-COMMENT-NON-SUBSTITUTION).
- Angle set: `resolveReviewGateAngles` = `resolveGateAngles(config,"draft") ∪ resolveGateAngles(config,"preApproval")`. The `acceptance-criteria` angle is dropped with a recorded `{action:"dropped", reason:"no spec-of-record"}` rationale when the PR closes no issue AND its body has no AC checkboxes; kept when either exists.
- Non-evidence by construction: `review` is deliberately absent from core `GATE_CONFIG_KEY` and `GATE_REVIEW_NAMES`/the gate-comment header regex, so a review verdict never parses as draft/pre-approval and `isGateMachineArtifactBody` excludes it — `detect-checkpoint-evidence.mjs` and `detect-pr-gate-coordination-state.mjs` need no edits and report `draftGateAlreadySatisfied:false` / no pre-approval evidence.
- No CI wait / no obligations: `upsert-checkpoint-verdict.mjs --gate review` short-circuits before `loadPrGateCoordinationContext` (no CI/coordination read), always creates a fresh review, carries `blockCleanOnFindingSeverities:[]`.
- Shared vocabulary: `run-gate-validation`, `consolidate-fanin`, `write-gate-findings-log`, `verify-briefing-prefixes` already validate `--gate` via the shared `VALID_GATES = new Set(GATE_NAMES)` import, so they accept `review` from the vocabulary change alone (AC5 — no per-script gate list).
- Surface: new `skills/review/SKILL.md` + `commands/loop-review.command.md` (`/loop-review <pr>`) mirror the ui-review/loop-grill pattern: resolve repo from the git remote, run Phases 1–4 once with `--gate review`, post the verdict, STOP. Explicit non-goals: never the fixer, `ready-for-review`, a board move, or a re-gate.

## Verification (DoD)

- `npm run verify` → exit 0, all suites green (test:core 2810/2810, test:scripts 4206/4206).
- `npm run assets:check` → `{ok:true, checked:90}` (assets auto-discover the new skill + command; no manifest hand-edits).
- `npm run test:docs` → validate-links / rule-ownership / decision-records clean.
- New tests: `resolveReviewGateAngles` union + drop/keep (6 unit + 1 e2e wiring); evidence-ignore (2, incl. the real rendered review body); `--gate review` posts from `--findings-ledger` with no coordination read (2 gh-mocked); plugin-manifest skill-surface + slash-command contract updated.

The manual `/loop-review` DoD step (run once against a loop-untouched PR and confirm no gate evidence) is the post-merge check.

## Acceptance criteria

- [x] `GATE_NAMES` includes `review`; `write-gate-context --gate review` and `verify-briefing-prefixes` accept it; sentinel scopes use `review-<angle>`.
- [x] `write-gate-context --gate review` resolves the union set; drops `acceptance-criteria` with a rationale when no linked issue and no AC checkboxes, keeps it otherwise; both cases unit-tested.
- [x] `detect-checkpoint-evidence` and `detect-pr-gate-coordination-state` ignore `review` verdicts (a clean `review` reports `draftGateAlreadySatisfied:false`, no pre-approval evidence); tested.
- [x] `upsert-checkpoint-verdict --gate review` posts the single-surface review with `--findings-ledger` and does not wait on CI.
- [x] `run-gate-validation`, `consolidate-fanin`, `write-gate-findings-log` accept `--gate review` via the shared vocabulary import (no per-script gate list).
- [x] New `skills/review/SKILL.md` and `/loop-review <pr>` command run Phases 1–4 once with `--gate review`, post the verdict, and stop; never fixer / ready-for-review / board move.
- [x] Assets regenerate cleanly and the command is listed in the CLI/skill contract tests.
- [x] Docs name `review` as a non-evidence gate; the CLI/help surfaces list it.

## Non-goals

- No fixer loop, re-gate, or merge path for `review`; no new reviewer angles; no headless node CLI that spawns reviewers (fan-out stays agent-orchestrated); no change to draft or pre-approval gate semantics.
