### PR TITLE
fix(tooling): pre-validate --jq filter syntax before mutation (fail-fast, no double-apply)

### DIFF
--- a/scripts/github/comment-issue.mjs
+++ b/scripts/github/comment-issue.mjs
@@ -4,7 +4,13 @@ import { parseIssueNumber, parseAllowedRefsCsv, requireTokenValue, runChild } fr
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { commentIssue as coreCommentIssue } from "@dev-loops/core/github/issue-ops";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import {
+  JQ_OUTPUT_PARSE_OPTIONS,
+  JQ_OUTPUT_USAGE,
+  emitResult,
+  matchJqOutputToken,
+  preflightJqFilter,
+} from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: comment-issue.mjs --repo <owner/name> --issue <number> (--body <text> | --body-file <path>)
 Post a comment on a GitHub issue. Thin wrapper over \`gh issue comment\` — use this
@@ -134,6 +140,12 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return 0;
   }
+  // Reject a syntactically invalid --jq BEFORE the mutation below, so a
+  // malformed filter can never post the comment then fail (BASE-JQ-OUTPUT-
+  // GUARANTEE would otherwise catch it after the fact -> ok:false on a call
+  // that already succeeded -> a caller retry double-posts).
+  const jqSyntaxError = preflightJqFilter(options.jq, { stderr });
+  if (jqSyntaxError !== undefined) return jqSyntaxError;
   let result;
   try {
     result = await commentIssue(options, { env, ghCommand, run });

--- a/scripts/github/create-issue.mjs
+++ b/scripts/github/create-issue.mjs
@@ -5,7 +5,13 @@ import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { buildCreateArgs as coreBuildCreateArgs, createIssue as coreCreateIssue } from "@dev-loops/core/github/issue-ops";
 import { enqueueBoardItem } from "./create-pr.mjs";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import {
+  JQ_OUTPUT_PARSE_OPTIONS,
+  JQ_OUTPUT_USAGE,
+  emitResult,
+  matchJqOutputToken,
+  preflightJqFilter,
+} from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: create-issue.mjs --repo <owner/name> --title <t> (--body <b> | --body-file <path>) [--milestone <m>] [--label <l>...] [--assignee <u>...]
 Create an issue. Thin wrapper over \`gh issue create\` — use this instead of an
@@ -178,6 +184,12 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return 0;
   }
+  // Reject a syntactically invalid --jq BEFORE the mutation below, so a
+  // malformed filter can never create the issue then fail (BASE-JQ-OUTPUT-
+  // GUARANTEE would otherwise catch it after the fact -> ok:false on a call
+  // that already succeeded -> a caller retry double-creates).
+  const jqSyntaxError = preflightJqFilter(options.jq, { stderr });
+  if (jqSyntaxError !== undefined) return jqSyntaxError;
   let result;
   try {
     result = await createIssue(options, { env, ghCommand, run });

--- a/scripts/github/edit-issue.mjs
+++ b/scripts/github/edit-issue.mjs
@@ -7,7 +7,13 @@ import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { editIssue as coreEditIssue } from "@dev-loops/core/github/issue-ops";
 import { detectGrillEmbedHeading } from "@dev-loops/core/loop/issue-refinement-artifact";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import {
+  JQ_OUTPUT_PARSE_OPTIONS,
+  JQ_OUTPUT_USAGE,
+  emitResult,
+  matchJqOutputToken,
+  preflightJqFilter,
+} from "../lib/jq-output.mjs";
 
 const USAGE = `Usage: edit-issue.mjs --repo <owner/name> --issue <number> [--title <t>] [--body <b> | --body-file <path>] [--add-assignee <u>] [--remove-assignee <u>] [--milestone <m>] [--state <open|closed>] [--reason <completed|not_planned>]
 Edit issue title/body/assignees/milestone/state. Thin wrapper over \`gh issue edit\`
@@ -259,6 +265,12 @@ export async function runCli(
     stdout.write(`${USAGE}\n`);
     return 0;
   }
+  // Reject a syntactically invalid --jq BEFORE the mutation below, so a
+  // malformed filter can never edit the issue then fail (BASE-JQ-OUTPUT-
+  // GUARANTEE would otherwise catch it after the fact -> ok:false on a call
+  // that already succeeded -> a caller retry double-edits).
+  const jqSyntaxError = preflightJqFilter(options.jq, { stderr });
+  if (jqSyntaxError !== undefined) return jqSyntaxError;
   let result;
   try {
     result = await editIssue(options, { env, ghCommand, run });

--- a/scripts/github/reply-resolve-review-thread.mjs
+++ b/scripts/github/reply-resolve-review-thread.mjs
@@ -9,7 +9,7 @@ import {
   replyAndMaybeResolve,
   validateResolutionMessage,
 } from "./_review-thread-mutations.mjs";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, preflightJqFilter } from "../lib/jq-output.mjs";
 import { formatCliError } from "../_core-helpers.mjs";
 
 export { hasCommitShaReference } from "./_review-thread-mutations.mjs";
@@ -91,6 +91,13 @@ async function run(argv) {
     process.stdout.write(`${USAGE}\n`);
     return 0;
   }
+
+  // Reject a syntactically invalid --jq BEFORE the mutation below, so a
+  // malformed filter can never reply/resolve the thread then fail
+  // (BASE-JQ-OUTPUT-GUARANTEE would otherwise catch it after the fact ->
+  // ok:false on a call that already succeeded -> a caller retry double-applies).
+  const jqSyntaxError = preflightJqFilter(parsed.jq, { stderr: process.stderr });
+  if (jqSyntaxError !== undefined) return jqSyntaxError;
 
   const { repo: repoSlug, pr, commentId, threadId, bodyFile, allowedRefs } = parsed;
   const rawBody = await readFile(bodyFile, "utf8");

--- a/scripts/lib/jq-output.mjs
+++ b/scripts/lib/jq-output.mjs
@@ -52,27 +52,29 @@ function parseLiteral(token) {
   return { ok: false };
 }
 
-// Resolve a single-value path expression like `.`, `.a.b`, `.a[0].b`, `.[2]`.
-// Returns undefined for a missing path (jq yields null; we map missing->undefined
-// then callers coerce). Throws JqFilterError on malformed path syntax.
-function resolvePath(value, path) {
+// Parse a path expression like `.`, `.a.b`, `.a[0].b`, `.[2]` into a step
+// list. Pure syntax: never touches data. Throws JqFilterError on malformed
+// path syntax. This is the syntactic core both resolvePath (real evaluation)
+// and assertJqFilterSyntax (parse-time pre-validation, no data) build on, so
+// the two never drift apart.
+function parsePathSteps(path) {
   const trimmed = path.trim();
   if (trimmed === "") {
     // An empty path is never valid jq (no empty filter). Fail closed so
     // malformed predicates like `select()` or `==5` don't pass as identity.
     throw new JqFilterError("Empty path expression");
   }
-  if (trimmed === ".") return value;
+  if (trimmed === ".") return [];
   if (!trimmed.startsWith(".")) {
     throw new JqFilterError(`Unsupported path (must start with '.'): ${path}`);
   }
   // Tokenize into .field and [index] steps.
   const stepRe = /\.([A-Za-z_][A-Za-z0-9_]*)|\[(\d+)\]/g;
-  let cursor = value;
   // Root index access (`.[N]`) starts with a leading '.' that is not part of any
   // step token; consume it so the first `[N]` match aligns at the cursor.
   let lastIndex = trimmed.startsWith(".[") ? 1 : 0;
   stepRe.lastIndex = lastIndex;
+  const steps = [];
   let match;
   let consumedAny = false;
   while ((match = stepRe.exec(trimmed)) !== null) {
@@ -81,41 +83,71 @@ function resolvePath(value, path) {
     }
     lastIndex = stepRe.lastIndex;
     consumedAny = true;
-    if (cursor === undefined || cursor === null) {
-      cursor = undefined;
-      continue;
-    }
     if (match[1] !== undefined) {
-      cursor = typeof cursor === "object" && !Array.isArray(cursor) ? cursor[match[1]] : undefined;
+      steps.push({ field: match[1] });
     } else {
-      const idx = Number(match[2]);
-      cursor = Array.isArray(cursor) ? cursor[idx] : undefined;
+      steps.push({ index: Number(match[2]) });
     }
   }
   if (!consumedAny || lastIndex !== trimmed.length) {
     throw new JqFilterError(`Unsupported path syntax: ${path}`);
   }
+  return steps;
+}
+
+// Resolve a single-value path expression against real data. Returns undefined
+// for a missing path (jq yields null; we map missing->undefined then callers
+// coerce). Throws JqFilterError on malformed path syntax (via parsePathSteps).
+function resolvePath(value, path) {
+  const steps = parsePathSteps(path);
+  let cursor = value;
+  for (const step of steps) {
+    if (cursor === undefined || cursor === null) {
+      cursor = undefined;
+      continue;
+    }
+    if (step.field !== undefined) {
+      cursor = typeof cursor === "object" && !Array.isArray(cursor) ? cursor[step.field] : undefined;
+    } else {
+      cursor = Array.isArray(cursor) ? cursor[step.index] : undefined;
+    }
+  }
   return cursor;
 }
 
-function evaluatePredicate(value, predicate) {
+// Parse a select(...)/top-level predicate's syntax without touching data:
+// a bare path (truthy test) or `<path> <op> <literal>`. Pure syntax; throws
+// JqFilterError for malformed path/operand syntax. Data-dependent checks
+// (order-comparing mismatched runtime types) happen later in evaluatePredicate,
+// once real data is available.
+function parsePredicateSyntax(predicate) {
   const cmpRe = /^(.*?)(==|!=|<=|>=|<|>)(.*)$/;
   const m = predicate.match(cmpRe);
   if (!m) {
     // Bare path => truthy test.
-    const resolved = resolvePath(value, predicate);
-    return resolved !== undefined && resolved !== null && resolved !== false;
+    parsePathSteps(predicate);
+    return { kind: "bare", path: predicate };
   }
   const [, leftRaw, op, rightRaw] = m;
-  // jq maps a missing path to null; resolvePath yields undefined -> normalize.
-  const resolvedLeft = resolvePath(value, leftRaw);
-  const left = resolvedLeft === undefined ? null : resolvedLeft;
+  parsePathSteps(leftRaw);
   const lit = parseLiteral(rightRaw);
   if (!lit.ok) {
     throw new JqFilterError(`Unsupported predicate operand: ${rightRaw.trim()}`);
   }
-  const right = lit.value;
-  switch (op) {
+  return { kind: "compare", leftRaw, op, literal: lit.value };
+}
+
+function evaluatePredicate(value, predicate) {
+  const parsed = parsePredicateSyntax(predicate);
+  if (parsed.kind === "bare") {
+    const resolved = resolvePath(value, parsed.path);
+    return resolved !== undefined && resolved !== null && resolved !== false;
+  }
+  // jq maps a missing path to null; resolvePath yields undefined -> normalize.
+  const resolvedLeft = resolvePath(value, parsed.leftRaw);
+  const left = resolvedLeft === undefined ? null : resolvedLeft;
+  const right = parsed.literal;
+  switch (parsed.op) {
     case "==":
       return left === right;
     case "!=":
@@ -129,13 +161,13 @@ function evaluatePredicate(value, predicate) {
       if (typeof left !== typeof right) {
         throw new JqFilterError(`Cannot order-compare ${typeof left} and ${typeof right}`);
       }
-      if (op === "<") return left < right;
-      if (op === "<=") return left <= right;
-      if (op === ">") return left > right;
+      if (parsed.op === "<") return left < right;
+      if (parsed.op === "<=") return left <= right;
+      if (parsed.op === ">") return left > right;
       return left >= right;
     }
     default:
-      throw new JqFilterError(`Unsupported operator: ${op}`);
+      throw new JqFilterError(`Unsupported operator: ${parsed.op}`);
   }
 }
 
@@ -177,6 +209,35 @@ function applyStage(stream, rawStage) {
   }
   // Plain path access (single value per input).
   return stream.map((v) => resolvePath(v, stage));
+}
+
+// Validate one pipe stage's syntax without touching data. Mirrors the
+// branching in applyStage exactly (same order, same subset) so the two never
+// drift apart; type/data-dependent failures (length on a non-collection,
+// iterating a scalar, order-comparing mismatched runtime types) are NOT
+// checked here — those can only be known once real data is present, so they
+// still surface at evaluation/emit time.
+function validateStageSyntax(stage) {
+  const trimmed = stage.trim();
+  if (trimmed === "") {
+    throw new JqFilterError("Empty filter stage");
+  }
+  if (trimmed === "length" || trimmed === "keys") return;
+  const selectMatch = trimmed.match(/^select\((.*)\)$/);
+  if (selectMatch) {
+    parsePredicateSyntax(selectMatch[1]);
+    return;
+  }
+  if (/(==|!=|<=|>=|<|>)/.test(trimmed)) {
+    parsePredicateSyntax(trimmed);
+    return;
+  }
+  if (trimmed === ".[]") return;
+  if (trimmed.endsWith("[]")) {
+    parsePathSteps(trimmed.slice(0, -2));
+    return;
+  }
+  parsePathSteps(trimmed);
 }
 
 function iterate(v) {
@@ -228,6 +289,23 @@ export function evaluateJqFilter(value, filter) {
   return stream;
 }
 
+// Validate a --jq filter's SYNTAX only, independent of any data. Throws
+// JqFilterError for anything outside the supported subset (same grammar
+// evaluateJqFilter enforces, via the same parsePathSteps/parsePredicateSyntax
+// helpers — one source of truth, so this can't silently drift from the real
+// evaluator). Returns normally for a syntactically valid filter, even one
+// that may still fail at evaluation time against a particular data shape
+// (e.g. `length` applied to a scalar) — those are data-dependent and stay at
+// emit time, never here.
+export function assertJqFilterSyntax(filter) {
+  if (typeof filter !== "string" || filter.trim() === "") {
+    throw new JqFilterError("Empty --jq filter");
+  }
+  for (const stage of splitPipes(filter)) {
+    validateStageSyntax(stage);
+  }
+}
+
 // jq truthiness for --silent: matches `jq -e` exit semantics — the status is
 // based on the LAST output value (empty output is falsy; a value is truthy
 // unless it is null or false).
@@ -235,6 +313,33 @@ function streamIsTruthy(stream) {
   if (stream.length === 0) return false;
   const last = stream[stream.length - 1];
   return last !== null && last !== false && last !== undefined;
+}
+
+// Single source of truth for the invalid-filter stderr envelope, shared by
+// emitResult's own (data-dependent-inclusive) error path and the parse-time
+// preflightJqFilter check below, so the two byte-for-byte agree.
+function formatJqFilterErrorEnvelope(error) {
+  return JSON.stringify({ ok: false, error: `--jq (BASE-JQ-OUTPUT-GUARANTEE): ${error.message}` });
+}
+
+// Fail-fast --jq syntax preflight for mutation wrappers: call this AFTER
+// argument parsing but BEFORE the wrapper's mutation runs. A syntactically
+// invalid filter writes the exact stderr envelope emitResult's own
+// JqFilterError branch would produce and returns 2 — the caller should
+// return that code immediately, skipping the mutation. `undefined` means
+// `jq` is absent or syntactically valid; the wrapper proceeds normally (its
+// own eventual emitResult call still handles data-dependent jq errors and
+// the success/failure path, unchanged).
+export function preflightJqFilter(jq, { stderr = process.stderr } = {}) {
+  if (jq === undefined) return undefined;
+  try {
+    assertJqFilterSyntax(jq);
+    return undefined;
+  } catch (error) {
+    if (!(error instanceof JqFilterError)) throw error;
+    stderr.write(`${formatJqFilterErrorEnvelope(error)}\n`);
+    return 2;
+  }
 }
 
 function renderJqStream(stream) {
@@ -299,7 +404,7 @@ export function emitResult(
     } catch (error) {
       if (error instanceof JqFilterError) {
         // Fail closed, distinct from a clean "predicate false". Exit 2.
-        stderr.write(`${JSON.stringify({ ok: false, error: `--jq (BASE-JQ-OUTPUT-GUARANTEE): ${error.message}` })}\n`);
+        stderr.write(`${formatJqFilterErrorEnvelope(error)}\n`);
         return 2;
       }
       throw error;

--- a/test/github/comment-issue.test.mjs
+++ b/test/github/comment-issue.test.mjs
@@ -130,11 +130,18 @@ test("runCli: --jq extracts the comment URL", async () => {
   assert.equal(stdout.get().trim(), COMMENT_URL);
 });
 
-test("runCli: invalid --jq filter fails closed with exit 2", async () => {
-  const { run } = stubGh([{ stdout: `${COMMENT_URL}\n` }]);
+test("runCli: invalid --jq filter fails closed with exit 2 BEFORE posting (no mutation)", async () => {
+  // Zero stubbed gh responses: if the comment gets posted despite the invalid
+  // filter, `run` throws "Unexpected gh call" and this test fails loudly
+  // instead of silently passing on a false-positive exit code (issue #1817:
+  // a mutation-then-fail ordering caused a caller retry to double-post).
+  const { run, calls } = stubGh([]);
   const stderr = captureStream();
-  const code = await runCli(["--repo", "o/n", "--issue", "7", "--body", "x", "--jq", "not!valid"], { run, stderr: stderr, stdout: captureStream() });
+  const code = await runCli(["--repo", "o/n", "--issue", "7", "--body", "x", "--jq", "not!valid"], { run, stderr, stdout: captureStream() });
   assert.equal(code, 2);
+  assert.match(stderr.get(), /--jq/);
+  assert.match(stderr.get(), /BASE-JQ-OUTPUT-GUARANTEE/);
+  assert.deepEqual(calls, [], "the comment must never post when --jq is syntactically invalid");
 });
 
 test("runCli: --silent maps success to exit 0 with no stdout", async () => {

--- a/test/github/reply-resolve-review-thread.test.mjs
+++ b/test/github/reply-resolve-review-thread.test.mjs
@@ -616,6 +616,32 @@ test("#1731: reply-resolve-review-thread allows a DELIBERATE cross-ref via --all
   }
 });
 
+test("#1817: reply-resolve-review-thread rejects a syntactically invalid --jq BEFORE replying/resolving (no mutation)", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-jq-invalid-"));
+  const bodyFile = path.join(tempDir, "reply.md");
+  await writeFile(bodyFile, "Fixed in 93cd7f8. Added coverage.\n", "utf8");
+  try {
+    // Zero stubbed gh responses AND no overflow repeat: if the code regresses
+    // to validating --jq only after mutating (the original #1817 footgun),
+    // the first gh call (the review-threads read) exits 97 from the stub and
+    // the script's own error handling reports exit 1 — distinct from the
+    // expected exit 2 below, so a regression here fails loudly.
+    const gh = await writeGhStubHelper(tempDir, [], { logCalls: true, repeatLastOnOverflow: false });
+    const result = await runNode(
+      ["--repo", "owner/repo", "--pr", "17", "--comment-id", "123", "--thread-id", "THREAD_123",
+       "--body-file", bodyFile, "--jq", "not!valid"],
+      { env: gh.env },
+    );
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /--jq/);
+    assert.match(result.stderr, /BASE-JQ-OUTPUT-GUARANTEE/);
+    const ghLog = (await readFile(gh.ghLogPath, "utf8")).trim();
+    assert.equal(ghLog, "", "no gh call (review-threads read, reply POST, or resolve) should happen when --jq is syntactically invalid");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("#1731: reply-resolve-review-thread rejects a non-numeric --allowed-refs entry", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-reply-resolve-allowed-refs-bad-"));
   const bodyFile = path.join(tempDir, "reply.md");

--- a/test/loop/jq-output.test.mjs
+++ b/test/loop/jq-output.test.mjs
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   JqFilterError,
   evaluateJqFilter,
+  assertJqFilterSyntax,
+  preflightJqFilter,
   emitResult,
   matchJqOutputToken,
 } from "../../scripts/lib/jq-output.mjs";
@@ -133,6 +135,67 @@ test("emitResult: invalid --jq fails closed (exit 2 + stderr), distinct from pre
   assert.equal(emitResult(sample, { jq: "bogus", silent: true, stdout: out, stderr: err }), 2);
   assert.equal(out.get(), "");
   assert.match(err.get(), /--jq/);
+});
+
+test("assertJqFilterSyntax: syntactically invalid filters throw JqFilterError (before any data exists)", () => {
+  assert.throws(() => assertJqFilterSyntax("ciStatus"), JqFilterError); // no leading '.'
+  assert.throws(() => assertJqFilterSyntax(".items | bogusfn"), JqFilterError); // unsupported stage
+  assert.throws(() => assertJqFilterSyntax(""), JqFilterError); // empty filter
+  assert.throws(() => assertJqFilterSyntax("select()"), JqFilterError); // empty predicate
+  assert.throws(() => assertJqFilterSyntax('== "x"'), JqFilterError); // empty LHS
+  assert.throws(() => assertJqFilterSyntax("select(.x > bogus)"), JqFilterError); // unparsable operand
+  assert.throws(() => assertJqFilterSyntax("{ok,url}"), JqFilterError); // object construction stays unsupported
+});
+
+test("assertJqFilterSyntax: syntactically valid filters pass (identical subset to evaluateJqFilter)", () => {
+  assert.doesNotThrow(() => assertJqFilterSyntax("."));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".ciStatus"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".snapshot.nested.deep"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".items[1].n"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".[0]"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".items[]"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".newComments[] | .body"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".items | length"));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".snapshot | keys"));
+  assert.doesNotThrow(() => assertJqFilterSyntax('.ciStatus=="success"'));
+  assert.doesNotThrow(() => assertJqFilterSyntax(".items[] | select(.n>1) | .n"));
+});
+
+test("assertJqFilterSyntax: a data-dependent failure is NOT rejected at parse time (only knowable once data exists)", () => {
+  // `length` on a scalar throws at evaluation (see evaluateJqFilter test below)
+  // but its syntax alone is valid — assertJqFilterSyntax must not pre-reject it.
+  assert.doesNotThrow(() => assertJqFilterSyntax(".foo | length"));
+  assert.throws(() => evaluateJqFilter({ foo: 5 }, ".foo | length"), JqFilterError);
+  // Order-compare across mismatched runtime types is the same story: valid
+  // syntax, data-dependent failure.
+  assert.doesNotThrow(() => assertJqFilterSyntax("select(.s > 3)"));
+  assert.throws(() => evaluateJqFilter({ s: "5" }, "select(.s > 3)"), JqFilterError);
+});
+
+test("preflightJqFilter: undefined jq is a no-op (nothing to validate)", () => {
+  const err = sink();
+  assert.equal(preflightJqFilter(undefined, { stderr: err }), undefined);
+  assert.equal(err.get(), "");
+});
+
+test("preflightJqFilter: a valid filter passes through", () => {
+  const err = sink();
+  assert.equal(preflightJqFilter(".ok", { stderr: err }), undefined);
+  assert.equal(err.get(), "");
+});
+
+test("preflightJqFilter: an invalid filter writes the same envelope emitResult would and returns 2", () => {
+  const err = sink();
+  assert.equal(preflightJqFilter("bogus", { stderr: err }), 2);
+  const parsed = JSON.parse(err.get().trim());
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /^--jq \(BASE-JQ-OUTPUT-GUARANTEE\):/);
+
+  // emitResult on the identical filter produces byte-identical stderr — proves
+  // the two share one formatter, not two grammars that could drift apart.
+  const emitErr = sink();
+  emitResult({}, { jq: "bogus", stdout: sink(), stderr: emitErr });
+  assert.equal(err.get(), emitErr.get());
 });
 
 test("matchJqOutputToken: consumes --jq/--silent tokens into options, ignores others", () => {


### PR DESCRIPTION
Closes #1817

Pre-validate `--jq` filter SYNTAX at argument-parse time so a mutation wrapper fails closed BEFORE it mutates. Previously an invalid `--jq` (e.g. object construction `{ok,url}`, outside the supported subset) was only caught in `emitResult`, AFTER the mutation ran, returning `ok:false` on a call that actually succeeded — a caller retry then double-applied the mutation.

## What

- `scripts/lib/jq-output.mjs`: factored the syntax-only grammar (`parsePathSteps` / `parsePredicateSyntax`) out of `resolvePath` / `evaluatePredicate`, so `evaluateJqFilter` and the new `assertJqFilterSyntax` / `preflightJqFilter` share ONE parser (no drift). `preflightJqFilter` reuses `emitResult`'s exact stderr envelope + exit-2 contract via a shared `formatJqFilterErrorEnvelope`.
- Wired `preflightJqFilter(options.jq, {stderr})` — one call right after arg parse, before the mutation — into the mutation wrappers the issue names: `comment-issue.mjs`, `create-issue.mjs`, `edit-issue.mjs`, `reply-resolve-review-thread.mjs`.
- Only SYNTACTIC errors move earlier. Data-dependent jq errors (e.g. `length` on a non-collection) still surface at emit time. Supported subset unchanged — object construction stays unsupported, it just fails at parse now.

## Scope note

Preflight is wired into the 4 mutation wrappers the issue names, not all ~80 jq-output consumers. The rest are read-only (no mutate-then-fail risk) and are already covered by the emit-time `BASE-JQ-OUTPUT-GUARANTEE` contract; routing them through the preflight would flip their exit code from 2 to 1 and break that contract test. Any future mutation wrapper adopts the same one-line call.

## Acceptance criteria

- [x] A syntactically invalid `--jq` filter is rejected during argument parsing, before any GitHub mutation runs, with exit 2 and an `ok:false` error naming the filter problem.
- [x] The check is shared: `comment-issue.mjs`, `create-issue.mjs`, `edit-issue.mjs`, `reply-resolve-review-thread.mjs`, and any other wrapper using the shared jq-output helpers inherit it without per-wrapper duplication.
- [x] Valid filters behave exactly as before (no change to supported subset or output).
- [x] Data-dependent jq errors still surface at emit time (unchanged); only syntactic errors move earlier.
- [x] A runnable check proves an invalid filter on a mutation wrapper performs no mutation, and a valid filter still filters output correctly.

## Definition of done

- [x] Pre-validation wired in the shared helper (`scripts/lib/jq-output.mjs`) and merged, with the self-check green.
- [x] At least one mutation wrapper's test proves no mutation occurs on an invalid filter (`comment-issue.test.mjs` and `reply-resolve-review-thread.test.mjs` stub the gh call and assert it is never invoked on a syntactically invalid `--jq`).

## Non-goals

- Not expanding the supported jq subset; object construction stays unsupported (this is about failing fast, not accepting more syntax).
- Not changing emit-time behavior for data-dependent errors.
- Not making mutations idempotent; the fix is fail-fast validation, not dedup.
- Not routing all ~80 jq-output consumers through the preflight — only the 4 mutation wrappers the issue names; read-only consumers keep the existing emit-time contract (Scope note above).

## Verification

- `npm run verify` green (all suites).
- No-mutation proof: `comment-issue.test.mjs` and `reply-resolve-review-thread.test.mjs` stub the gh call and assert it is NEVER invoked on a syntactically invalid `--jq` (exit 2), and that a valid filter still filters output.
- A dedicated test proves `assertJqFilterSyntax` passes while `evaluateJqFilter` still throws on the same filter+data (data-dependent errors stay at emit time).

