### PR TITLE
feat(review): pending deliverable + submit-mode + interactive end-of-run choice for /loop-review

### DIFF
--- a/.claude/commands/loop-review.md
+++ b/.claude/commands/loop-review.md
@@ -1,16 +1,19 @@
 ---
 description: "Run a single, standalone code-review pass over a PR (no gate obligations)."
-argument-hint: "<pr>"
+argument-hint: "<pr> [--auto]"
 ---
 <!-- GENERATED from commands/loop-review.command.md by scripts/claude/generate-claude-assets.mjs — do not edit; edit the source and regenerate. -->
 
 Invoke the `review` skill with `$ARGUMENTS`.
 
-**Usage:** `/dev-loops:loop-review <pr>` (or `/loop-review <pr>` in the dev-loops repo itself)
+**Usage:** `/dev-loops:loop-review <pr> [--auto]` (or `/loop-review <pr> [--auto]` in the dev-loops repo itself)
 
 **Arguments:**
 - `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+- `--auto` — headless/non-interactive (mirrors `/loop-grill`'s `--auto`, `/dev-loops:loop-grill` in a consumer install). Posts the review as `--submit comment` immediately, no prompt. Omit it for an interactive run.
 
-**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict and stops. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence. See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence, in EVERY submit mode (see below). See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+
+**Submit choice:** an interactive run posts the review `--submit pending` (an author-only draft, invisible until submitted) and then ends with a multiple-choice submit step — **Leave pending (default)**, Submit as Comment, Submit as Request-changes, Submit as Approve, or Discard; Request-changes and Approve state their GitHub branch-protection effect inline. A headless `--auto` run skips the prompt and posts `--submit comment` directly — `approve`/`request-changes` are refused headless (reachable only through the interactive choice), so automation can never auto-approve or auto-block a PR.
 
 **Stop conditions:** this command NEVER calls the fixer, never flips a PR to ready-for-review, and never moves a board item — a `review` round is a single, complete, terminal pass with no re-gate path. If the operator wants findings fixed, that is a separate, explicit follow-up instruction.

--- a/.claude/skills/docs/gate-review-comment-contract.md
+++ b/.claude/skills/docs/gate-review-comment-contract.md
@@ -96,6 +96,37 @@ draft/pre-approval evidence.) So a `review` comment never satisfies
 SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
 authorizes nothing this contract's two gates require.
 
+<!-- rule: GATE-REVIEW-SUBMIT-MODES -->
+### `review` gate submit modes (#1840)
+
+`GATE-REVIEW-SUBMIT-MODES`: `upsert-checkpoint-verdict.mjs`'s `--submit
+<pending|comment|request-changes|approve>` flag is SCOPED TO `--gate review`
+ONLY — passing it on `draft_gate`/`pre_approval_gate` is rejected with a named
+error (never silently ignored); those two gates always submit a `COMMENT`
+review per `GATE-COMMENT-SINGLE-SURFACE` (`GATE-COMMENT-NON-SUBSTITUTION`: a
+clean pre-approval must stay a submitted, visible evidence surface, never
+substitutable by a differently-submitted review).
+
+| Mode | GitHub review `event` | Effect |
+|---|---|---|
+| `pending` | omitted | Creates an author-only draft review — invisible to other reviewers until a human submits it |
+| `comment` (default when `--submit` is omitted) | `COMMENT` | Submits the review immediately (today's behavior, unchanged) |
+| `request-changes` | `REQUEST_CHANGES` | Submits the review; a GitHub-native branch-protection signal that can BLOCK merge until dismissed |
+| `approve` | `APPROVE` | Submits the review; a GitHub-native branch-protection signal that SATISFIES a required-approvals rule |
+
+`request-changes`/`approve` carry GitHub-native branch-protection effects
+independent of any dev-loops gate. A headless/non-interactive review run
+(`--auto`) is restricted to `pending`/`comment` — `--submit
+approve`/`--submit request-changes` are REFUSED headless, so automation can
+never auto-approve or auto-block a PR; they are reachable only through the
+[Review skill](../review/SKILL.md)'s interactive multiple-choice submit step.
+
+Every submit mode — including `approve` — stays a NON-evidence `review`
+verdict for dev-loops gates: the authoritative-`review`-header guard above
+reads only the comment body, never the review's `event`/`state`, so
+`detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs`
+report no draft/pre-approval evidence from it regardless of submit mode.
+
 ## Separate chains per gate
 
 Each gate runs its own independent review chain (`GATE-EXEC-SEPARATE-CHAINS`, owned by

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -20,11 +20,14 @@ lifecycle's own state.
 ## Interface
 
 ```
-/loop-review <pr>
+/loop-review <pr>          # interactive: ends with a submit choice
+/loop-review <pr> --auto   # headless: posts a COMMENT review, no prompt
 ```
 
 `<pr>` is a pull request number or URL, required. `<owner/repo>` resolves from
-the git remote at invocation, same as the other loop commands.
+the git remote at invocation, same as the other loop commands. `--auto`
+mirrors `/loop-grill`'s (`/dev-loops:loop-grill` in a consumer install)
+headless flag (`skills/loop-grill/SKILL.md`).
 
 In a consumer (plugin) install this runs as `/dev-loops:loop-review <pr>`; the
 bare `/loop-review` form is dev-loops-repo-local (repo-local
@@ -59,11 +62,41 @@ repeat phases those gates run:
    into one disposition ledger and computed verdict, then `node
    scripts/github/upsert-checkpoint-verdict.mjs --repo <owner/repo> --pr <n>
    --gate review --head-sha <sha> --findings-ledger <path> --next-action "none
-   — informational review, no re-gate required" [...]` posts the SINGLE
-   visible PR review surface (`GATE-COMMENT-SINGLE-SURFACE`) straight from
-   that ledger — no CI wait, no coordination-context read, no auto-resolve, no
-   forbidden-action check (those are draft/pre-approval-only machinery `review`
-   never touches).
+   — informational review, no re-gate required" --submit <mode> [--auto]
+   [...]` posts the SINGLE visible PR review surface
+   (`GATE-COMMENT-SINGLE-SURFACE`) straight from that ledger — no CI wait, no
+   coordination-context read, no auto-resolve, no forbidden-action check
+   (those are draft/pre-approval-only machinery `review` never touches). See
+   [Checkpoint Verdict Comment Contract](../docs/gate-review-comment-contract.md#review-gate-submit-modes-1840)
+   for the `--submit` vocabulary.
+5. **Phase 4 — submit choice.**
+   - **Interactive run:** the review was posted `--submit pending` — an
+     author-only draft, invisible to other reviewers until submitted. Present
+     an `AskUserQuestion` multiple choice (mirroring `/loop-grill`'s
+     interactive pattern, `skills/loop-grill/SKILL.md`):
+     - **Leave pending (default)** — print the PR review URL and how to
+       finish it (open the URL, or re-invoke with `--submit
+       comment`/`approve`/`request-changes` — see the option below); warn it
+       stays invisible to other reviewers until submitted.
+     - **Submit as Comment** — re-run `upsert-checkpoint-verdict.mjs --gate
+       review --submit comment` for the SAME round (do not re-fan-out).
+     - **Submit as Request-changes** — same re-run with `--submit
+       request-changes`. State inline: this is a GitHub-native review event
+       that can BLOCK merge (branch protection) until dismissed, independent
+       of any dev-loops gate.
+     - **Submit as Approve** — same re-run with `--submit approve`. State
+       inline: this is a GitHub-native review event that SATISFIES a
+       required-approvals branch-protection rule, independent of any
+       dev-loops gate — it never satisfies `draft_gate`/`pre_approval_gate`
+       evidence (see [Non-evidence, by construction](#non-evidence-by-construction)
+       below).
+     - **Discard** — delete the pending draft review (`gh api -X DELETE
+       repos/<owner>/<repo>/pulls/<n>/reviews/<id>`) so no dangling artifact
+       is left.
+   - **`--auto`/headless run:** skip the prompt entirely; the round already
+     posted `--submit comment` (the default, and the only escalation-capable
+     mode headless is allowed — `approve`/`request-changes` are refused
+     headless, reachable only through the interactive choice above).
 
 **Stop here.** Never proceed to the judge pass, the fix cycle, a re-gate
 round, `pr ready-for-review`, or a board move — a `review` round is a single,
@@ -94,9 +127,21 @@ satisfaction stays unaffected and pre-approval readiness is unaffected, no
 matter how many `review` rounds a PR has carried. Posting `review` is purely
 informational.
 
+This guard reads only the comment BODY (the header line) — it is entirely
+independent of the GitHub review's own `event`/`state`. A `review` verdict
+therefore stays non-evidence for dev-loops gates in EVERY `--submit` mode
+(#1840), including `approve`: a GitHub-native `APPROVE` review still counts
+toward GitHub branch protection (satisfying a required-approvals rule) — that
+is expected and separate, and is exactly why headless `--auto` review runs
+are refused `--submit approve`/`--submit request-changes` (see
+[`--submit`](#interface) above); only a deliberate interactive choice reaches
+those two events.
+
 ## Non-goals
 
 No fixer loop, no re-gate, no merge path, no new reviewer angles, and no
 headless CLI that spawns reviewers itself — fan-out stays agent-orchestrated
 exactly like draft/pre-approval fan-out. It does not change draft_gate or
-pre_approval_gate semantics in any way.
+pre_approval_gate semantics in any way. No auto-submit of a pending review on
+a later run — the human submits it (or discards it) via the interactive
+submit choice.

--- a/commands/loop-review.command.md
+++ b/commands/loop-review.command.md
@@ -1,14 +1,17 @@
 ---
 description: Run a single, standalone code-review pass over a PR (no gate obligations).
-argument-hint: <pr>
+argument-hint: <pr> [--auto]
 ---
 Invoke the `review` skill with `$ARGUMENTS`.
 
-**Usage:** `/dev-loops:loop-review <pr>` (or `/loop-review <pr>` in the dev-loops repo itself)
+**Usage:** `/dev-loops:loop-review <pr> [--auto]` (or `/loop-review <pr> [--auto]` in the dev-loops repo itself)
 
 **Arguments:**
 - `<pr>` — the pull request to review, as a number or URL. Required; with no argument the loop cannot resolve a target and stops. `<owner/repo>` resolves from the git remote at invocation, same as the other loop commands.
+- `--auto` — headless/non-interactive (mirrors `/loop-grill`'s `--auto`, `/dev-loops:loop-grill` in a consumer install). Posts the review as `--submit comment` immediately, no prompt. Omit it for an interactive run.
 
-**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict and stops. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence. See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+**What it does:** runs ONE `review`-gate round over the shared draft/pre-approval fan-out/fan-in sub-loop (context-builder, fan-out reviewers over the union of draft's and pre-approval's configured angles, fan-in), then posts the single-surface verdict. `review` is a THIRD gate reachable on any PR — draft or ready — with NO gate obligations of its own: it never blocks a draft→ready transition, never blocks merge, never waits on CI, and never satisfies `draft_gate`/`pre_approval_gate` evidence, in EVERY submit mode (see below). See the [Review skill](../skills/review/SKILL.md) for the phase-by-phase contract.
+
+**Submit choice:** an interactive run posts the review `--submit pending` (an author-only draft, invisible until submitted) and then ends with a multiple-choice submit step — **Leave pending (default)**, Submit as Comment, Submit as Request-changes, Submit as Approve, or Discard; Request-changes and Approve state their GitHub branch-protection effect inline. A headless `--auto` run skips the prompt and posts `--submit comment` directly — `approve`/`request-changes` are refused headless (reachable only through the interactive choice), so automation can never auto-approve or auto-block a PR.
 
 **Stop conditions:** this command NEVER calls the fixer, never flips a PR to ready-for-review, and never moves a board item — a `review` round is a single, complete, terminal pass with no re-gate path. If the operator wants findings fixed, that is a separate, explicit follow-up instruction.

--- a/scripts/github/_gate-finding-surface.mjs
+++ b/scripts/github/_gate-finding-surface.mjs
@@ -858,15 +858,23 @@ function parseReviewMutationResponse(payload) {
  * Create the round's ONE review: the verdict-marker body plus one inline
  * comment per locatable finding. GitHub 422s a COMMENT-event review with an
  * empty body, so the caller must always pass a rendered body.
+ *
+ * `event` defaults to "COMMENT" (draft_gate/pre_approval_gate's only submit
+ * mode — GATE-COMMENT-SINGLE-SURFACE). The standalone `review` gate's
+ * `pending` submit mode (#1840) passes `event: null` so GitHub leaves the
+ * review PENDING (author-only draft): a falsy `event` here — `null`, never
+ * the parameter-default-triggering `undefined` — omits the `event` key from
+ * the payload entirely, which is what the create-review API reads as "leave
+ * pending" rather than submitting it.
  */
-export async function createGateReview({ repo, pr, headSha, body, comments, allowedRefs }, { env, ghCommand, runChild = defaultRunChild }) {
+export async function createGateReview({ repo, pr, headSha, body, comments, allowedRefs, event = "COMMENT" }, { env, ghCommand, runChild = defaultRunChild }) {
   // ISSUE/PR-ID GUARD: refuse a verdict body or inline finding comment
   // that emits a raw issue/PR id (fail-closed) unless explicitly allowlisted.
   guardCommentBodyNoIssuePrIds(body, { ref: "gate verdict comment body", allowedRefs });
   for (const comment of comments ?? []) {
     guardCommentBodyNoIssuePrIds(comment?.body, { ref: "gate review inline finding comment", allowedRefs });
   }
-  const payload = { commit_id: headSha, event: "COMMENT", body, comments };
+  const payload = { commit_id: headSha, body, comments, ...(event ? { event } : {}) };
   const result = await runChild(
     ghCommand,
     ["api", "-X", "POST", `repos/${repo}/pulls/${pr}/reviews`, "--input", "-"],

--- a/scripts/github/upsert-checkpoint-verdict.mjs
+++ b/scripts/github/upsert-checkpoint-verdict.mjs
@@ -39,6 +39,27 @@ import {
 import { fetchAllReviewThreads } from "./list-review-threads.mjs";
 import { normalizeGate as normalizeGateShared, normalizeVerdict as normalizeVerdictShared } from "./_gate-names.mjs";
 const GATE_EXECUTION_MODES = new Set(["fanout_fanin", "inline_single_agent"]);
+// The `review` gate's submit-mode vocabulary (#1840), SCOPED TO --gate review
+// only. Mapped to the GitHub create-review `event` value in
+// resolveReviewSubmitEvent below: "pending" maps to a falsy value so
+// createGateReview (_gate-finding-surface.mjs) omits `event` from the payload
+// entirely, which is what leaves the review PENDING (author-only draft).
+const REVIEW_SUBMIT_MODES = new Set(["pending", "comment", "request-changes", "approve"]);
+const DEFAULT_REVIEW_SUBMIT_MODE = "comment";
+// Only these two modes may ever be reached without a deliberate interactive
+// choice (--auto/headless review runs, and the default when --submit is
+// omitted). approve/request-changes are reachable only via the review skill's
+// interactive multiple-choice, never automatically.
+const HEADLESS_ALLOWED_REVIEW_SUBMIT_MODES = new Set(["pending", "comment"]);
+function resolveReviewSubmitEvent(mode) {
+  switch (mode) {
+    case "pending": return null;
+    case "comment": return "COMMENT";
+    case "approve": return "APPROVE";
+    case "request-changes": return "REQUEST_CHANGES";
+    default: throw new Error(`Unreachable --submit mode: ${mode}`);
+  }
+}
 // Mirrors check-size-budget.mjs's computeSizeBudget outcome enum exactly —
 // this file never recomputes the outcome, only validates/renders it.
 const SIZE_BUDGET_OUTCOMES = new Set(["pass", "escalate", "block"]);
@@ -172,6 +193,38 @@ Optional:
   --gate <draft_gate|pre_approval_gate|review>     Auto-resolved from coordination state (draft_gate/pre_approval_gate only; review is never auto-resolved)
                                             when omitted. Explicit gate is validated
                                             against allowed coordination actions.
+  --submit <pending|comment|request-changes|approve>
+                                            SCOPED TO --gate review ONLY (#1840):
+                                            how the review's own PR review is
+                                            submitted. Passing --submit on
+                                            draft_gate/pre_approval_gate is
+                                            REJECTED (they always submit COMMENT
+                                            — GATE-COMMENT-NON-SUBSTITUTION, a
+                                            clean pre-approval must stay a
+                                            submitted visible evidence surface).
+                                            \`pending\` creates the review with
+                                            GitHub's \`event\` OMITTED — an
+                                            author-only draft, invisible to other
+                                            reviewers until submitted.
+                                            \`comment\` (the default when
+                                            --submit is omitted) submits a
+                                            COMMENT review, today's behavior.
+                                            \`request-changes\`/\`approve\` submit
+                                            with that GitHub review event — a
+                                            native GitHub branch-protection
+                                            signal independent of any dev-loops
+                                            gate. --auto (headless) allows only
+                                            \`pending\`/\`comment\`; \`approve\`/
+                                            \`request-changes\` are REFUSED
+                                            headless so automation can never
+                                            auto-approve or auto-block a PR —
+                                            they are reachable only through an
+                                            interactive choice.
+  --auto                                   Headless/non-interactive run (mirrors
+                                            scripts/projects/add-queue-item.mjs's
+                                            --auto). Only meaningful together with
+                                            --gate review --submit: restricts
+                                            --submit to pending/comment.
   --lightweight                             This PR is light-dispatched (#1210):
                                             resolve the Copilot round cap as
                                             min(lightMode.maxCopilotRounds ?? 1,
@@ -243,6 +296,10 @@ Output (stdout, JSON):
   \`commentId\`/\`commentUrl\` identify the posted PR review (a legacy verdict issue
   comment when \`surface\` is "issue_comment"). \`round\`/\`inlineComments\`/
   \`bodyFiled\`/\`suppressed\` are present only for a --findings-ledger round.
+  \`submit\` (present only for \`gate: "review"\`) echoes the resolved --submit
+  mode (\`pending\` when left as an author-only draft, otherwise the submitted
+  event's mode) — \`pending\` means \`commentUrl\` is invisible to other
+  reviewers until a human submits it.
 A \`warning\` field is included when a gate comment for the same gate already
 exists on a different head SHA (the old comment is stale for the current head).
 Error output (stderr, JSON):
@@ -450,6 +507,8 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       "allowed-refs": { type: "string" },
       lightweight: { type: "boolean" },
       "size-budget-json": { type: "string" },
+      submit: { type: "string" },
+      auto: { type: "boolean" },
       ...JQ_OUTPUT_PARSE_OPTIONS,
     },
     allowPositionals: true,
@@ -474,6 +533,8 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
     allowedRefs: [],
     lightweight: false,
     sizeBudgetJson: undefined,
+    submit: undefined,
+    auto: false,
     jq: undefined,
     silent: false,
   };
@@ -607,6 +668,18 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
       options.sizeBudgetJson = rawPath;
       continue;
     }
+    if (token.name === "submit") {
+      const raw = requireTokenValue(token, parseError).trim().toLowerCase();
+      if (!REVIEW_SUBMIT_MODES.has(raw)) {
+        throw parseError("--submit must be one of: pending, comment, request-changes, approve");
+      }
+      options.submit = raw;
+      continue;
+    }
+    if (token.name === "auto") {
+      options.auto = true;
+      continue;
+    }
     if (matchJqOutputToken(token, options, (t) => requireTokenValue(t, parseError))) continue;
     throw parseError(`Unknown argument: ${token.rawName}`);
   }
@@ -648,6 +721,29 @@ export function parseUpsertCheckpointVerdictCliArgs(argv) {
   if (options.executionMode === "inline_single_agent" && options.inlineReason === undefined) {
     throw parseError(
       "--inline-reason is required for executionMode inline_single_agent (the default). Pass --execution-mode fanout_fanin for fan-out/fan-in runs, or --inline-reason \"<why>\" to record why the gate ran inline.",
+    );
+  }
+  // --submit is SCOPED TO --gate review ONLY. --gate review is never
+  // auto-resolved (must be passed explicitly), so this covers both an
+  // explicit non-review gate AND an omitted --gate (which would otherwise
+  // auto-resolve to draft_gate/pre_approval_gate at runtime) — GATE-COMMENT-NON-SUBSTITUTION:
+  // draft_gate/pre_approval_gate always submit a COMMENT review; a clean
+  // pre-approval must stay a submitted, visible evidence surface, never
+  // substitutable by a differently-submitted review.
+  if (options.submit !== undefined && options.gate !== "review") {
+    throw parseError(
+      `--submit is scoped to --gate review only (draft_gate/pre_approval_gate always submit a COMMENT review and reject --submit — GATE-COMMENT-NON-SUBSTITUTION). Pass --gate review explicitly, or omit --submit.`,
+    );
+  }
+  // Headless/non-interactive safety (#1840): a review run under --auto may
+  // only leave the review pending or submit it as a comment. approve/
+  // request-changes carry GitHub-native branch-protection effects (satisfying
+  // required approvals / blocking merge) independent of any dev-loops gate,
+  // so automation must never reach them — they are reachable only via the
+  // review skill's interactive multiple-choice.
+  if (options.gate === "review" && options.auto && options.submit !== undefined && !HEADLESS_ALLOWED_REVIEW_SUBMIT_MODES.has(options.submit)) {
+    throw parseError(
+      `--submit ${options.submit} is not allowed with --auto (headless review runs may only leave a review pending or submit it as a comment); approve/request-changes are reachable only via the interactive submit choice.`,
     );
   }
   try {
@@ -1729,6 +1825,10 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
   // (the one place this function would otherwise read CI status) and posts
   // straight from the caller-supplied --head-sha.
   const isReviewGate = options.gate === "review";
+  // Resolved submit mode for the review gate only (#1840); parseUpsertCheckpointVerdictCliArgs
+  // already refused --submit on any other gate and refused approve/request-changes
+  // under --auto, so this is a pure default-fill, not further validation.
+  const reviewSubmitMode = isReviewGate ? (options.submit ?? DEFAULT_REVIEW_SUBMIT_MODE) : undefined;
   let coordinationContext = null;
   let evidence = null;
   let coordination = null;
@@ -2453,6 +2553,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
       body: renderInlineCommentBody(finding, { round: findingSurface.round }),
     })),
     allowedRefs: options.allowedRefs,
+    ...(isReviewGate ? { event: resolveReviewSubmitEvent(reviewSubmitMode) } : {}),
   }, gh);
   const created = { commentId: createdReview.reviewId, commentUrl: createdReview.reviewUrl };
   // Post-creation verification: verify the review is retrievable before returning.
@@ -2492,6 +2593,7 @@ export async function upsertCheckpointVerdict(options, { env = process.env, ghCo
     blockCleanOnFindingSeverities: activeGateConfig.blockCleanOnFindingSeverities,
     executionMode: options.executionMode ?? DEFAULT_EXECUTION_MODE,
     ...findingSurfaceFields,
+    ...(isReviewGate ? { submit: reviewSubmitMode } : {}),
     ...(options.inlineReason ? { inlineReason: options.inlineReason } : {}),
     ...(warning ? { warning } : {}),
     ...(verificationWarning ? { verificationWarning } : {}),

--- a/skills/docs/gate-review-comment-contract.md
+++ b/skills/docs/gate-review-comment-contract.md
@@ -96,6 +96,37 @@ draft/pre-approval evidence.) So a `review` comment never satisfies
 SUBSTITUTION` below applies to it symmetrically: a clean `review` comment
 authorizes nothing this contract's two gates require.
 
+<!-- rule: GATE-REVIEW-SUBMIT-MODES -->
+### `review` gate submit modes (#1840)
+
+`GATE-REVIEW-SUBMIT-MODES`: `upsert-checkpoint-verdict.mjs`'s `--submit
+<pending|comment|request-changes|approve>` flag is SCOPED TO `--gate review`
+ONLY — passing it on `draft_gate`/`pre_approval_gate` is rejected with a named
+error (never silently ignored); those two gates always submit a `COMMENT`
+review per `GATE-COMMENT-SINGLE-SURFACE` (`GATE-COMMENT-NON-SUBSTITUTION`: a
+clean pre-approval must stay a submitted, visible evidence surface, never
+substitutable by a differently-submitted review).
+
+| Mode | GitHub review `event` | Effect |
+|---|---|---|
+| `pending` | omitted | Creates an author-only draft review — invisible to other reviewers until a human submits it |
+| `comment` (default when `--submit` is omitted) | `COMMENT` | Submits the review immediately (today's behavior, unchanged) |
+| `request-changes` | `REQUEST_CHANGES` | Submits the review; a GitHub-native branch-protection signal that can BLOCK merge until dismissed |
+| `approve` | `APPROVE` | Submits the review; a GitHub-native branch-protection signal that SATISFIES a required-approvals rule |
+
+`request-changes`/`approve` carry GitHub-native branch-protection effects
+independent of any dev-loops gate. A headless/non-interactive review run
+(`--auto`) is restricted to `pending`/`comment` — `--submit
+approve`/`--submit request-changes` are REFUSED headless, so automation can
+never auto-approve or auto-block a PR; they are reachable only through the
+[Review skill](../review/SKILL.md)'s interactive multiple-choice submit step.
+
+Every submit mode — including `approve` — stays a NON-evidence `review`
+verdict for dev-loops gates: the authoritative-`review`-header guard above
+reads only the comment body, never the review's `event`/`state`, so
+`detect-checkpoint-evidence.mjs`/`detect-pr-gate-coordination-state.mjs`
+report no draft/pre-approval evidence from it regardless of submit mode.
+
 ## Separate chains per gate
 
 Each gate runs its own independent review chain (`GATE-EXEC-SEPARATE-CHAINS`, owned by

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -215,6 +215,10 @@
       "enforcement": "runtime"
     },
     {
+      "id": "GATE-REVIEW-SUBMIT-MODES",
+      "enforcement": "runtime"
+    },
+    {
       "id": "GATE-EXEC-ANGLE-CARRY-FORWARD"
     },
     {

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -23,11 +23,14 @@ lifecycle's own state.
 ## Interface
 
 ```
-/loop-review <pr>
+/loop-review <pr>          # interactive: ends with a submit choice
+/loop-review <pr> --auto   # headless: posts a COMMENT review, no prompt
 ```
 
 `<pr>` is a pull request number or URL, required. `<owner/repo>` resolves from
-the git remote at invocation, same as the other loop commands.
+the git remote at invocation, same as the other loop commands. `--auto`
+mirrors `/loop-grill`'s (`/dev-loops:loop-grill` in a consumer install)
+headless flag (`skills/loop-grill/SKILL.md`).
 
 In a consumer (plugin) install this runs as `/dev-loops:loop-review <pr>`; the
 bare `/loop-review` form is dev-loops-repo-local (repo-local
@@ -62,11 +65,41 @@ repeat phases those gates run:
    into one disposition ledger and computed verdict, then `node
    scripts/github/upsert-checkpoint-verdict.mjs --repo <owner/repo> --pr <n>
    --gate review --head-sha <sha> --findings-ledger <path> --next-action "none
-   — informational review, no re-gate required" [...]` posts the SINGLE
-   visible PR review surface (`GATE-COMMENT-SINGLE-SURFACE`) straight from
-   that ledger — no CI wait, no coordination-context read, no auto-resolve, no
-   forbidden-action check (those are draft/pre-approval-only machinery `review`
-   never touches).
+   — informational review, no re-gate required" --submit <mode> [--auto]
+   [...]` posts the SINGLE visible PR review surface
+   (`GATE-COMMENT-SINGLE-SURFACE`) straight from that ledger — no CI wait, no
+   coordination-context read, no auto-resolve, no forbidden-action check
+   (those are draft/pre-approval-only machinery `review` never touches). See
+   [Checkpoint Verdict Comment Contract](../docs/gate-review-comment-contract.md#review-gate-submit-modes-1840)
+   for the `--submit` vocabulary.
+5. **Phase 4 — submit choice.**
+   - **Interactive run:** the review was posted `--submit pending` — an
+     author-only draft, invisible to other reviewers until submitted. Present
+     an `AskUserQuestion` multiple choice (mirroring `/loop-grill`'s
+     interactive pattern, `skills/loop-grill/SKILL.md`):
+     - **Leave pending (default)** — print the PR review URL and how to
+       finish it (open the URL, or re-invoke with `--submit
+       comment`/`approve`/`request-changes` — see the option below); warn it
+       stays invisible to other reviewers until submitted.
+     - **Submit as Comment** — re-run `upsert-checkpoint-verdict.mjs --gate
+       review --submit comment` for the SAME round (do not re-fan-out).
+     - **Submit as Request-changes** — same re-run with `--submit
+       request-changes`. State inline: this is a GitHub-native review event
+       that can BLOCK merge (branch protection) until dismissed, independent
+       of any dev-loops gate.
+     - **Submit as Approve** — same re-run with `--submit approve`. State
+       inline: this is a GitHub-native review event that SATISFIES a
+       required-approvals branch-protection rule, independent of any
+       dev-loops gate — it never satisfies `draft_gate`/`pre_approval_gate`
+       evidence (see [Non-evidence, by construction](#non-evidence-by-construction)
+       below).
+     - **Discard** — delete the pending draft review (`gh api -X DELETE
+       repos/<owner>/<repo>/pulls/<n>/reviews/<id>`) so no dangling artifact
+       is left.
+   - **`--auto`/headless run:** skip the prompt entirely; the round already
+     posted `--submit comment` (the default, and the only escalation-capable
+     mode headless is allowed — `approve`/`request-changes` are refused
+     headless, reachable only through the interactive choice above).
 
 **Stop here.** Never proceed to the judge pass, the fix cycle, a re-gate
 round, `pr ready-for-review`, or a board move — a `review` round is a single,
@@ -97,9 +130,21 @@ satisfaction stays unaffected and pre-approval readiness is unaffected, no
 matter how many `review` rounds a PR has carried. Posting `review` is purely
 informational.
 
+This guard reads only the comment BODY (the header line) — it is entirely
+independent of the GitHub review's own `event`/`state`. A `review` verdict
+therefore stays non-evidence for dev-loops gates in EVERY `--submit` mode
+(#1840), including `approve`: a GitHub-native `APPROVE` review still counts
+toward GitHub branch protection (satisfying a required-approvals rule) — that
+is expected and separate, and is exactly why headless `--auto` review runs
+are refused `--submit approve`/`--submit request-changes` (see
+[`--submit`](#interface) above); only a deliberate interactive choice reaches
+those two events.
+
 ## Non-goals
 
 No fixer loop, no re-gate, no merge path, no new reviewer angles, and no
 headless CLI that spawns reviewers itself — fan-out stays agent-orchestrated
 exactly like draft/pre-approval fan-out. It does not change draft_gate or
-pre_approval_gate semantics in any way.
+pre_approval_gate semantics in any way. No auto-submit of a pending review on
+a later run — the human submits it (or discards it) via the interactive
+submit choice.

--- a/test/github/detect-checkpoint-evidence.test.mjs
+++ b/test/github/detect-checkpoint-evidence.test.mjs
@@ -2528,6 +2528,68 @@ test("detect-checkpoint-evidence finds gate comment posted as PR review (root ca
   }
 });
 
+// #1840 AC5 — extends the #1808 non-evidence regression: a `review` verdict
+// posted via the NEW `--submit approve` mode is STILL non-evidence for
+// dev-loops gates. approve/request-changes are reachable only via the
+// interactive submit choice (upsert-checkpoint-verdict.mjs), and a
+// GitHub-native APPROVE review carries real branch-protection weight
+// (satisfies required-approvals rules) — separate and expected — but that is
+// exactly why the dev-loops-internal evidence guard must stay unaffected by
+// the review's `state`/`event`: the guard is the authoritative `review`
+// header recognized by parseGateReviewCommentFields
+// (@dev-loops/core/github/copilot-helpers), which reads only the comment
+// BODY, never the review's submitted GitHub event/state. This test proves
+// that holds end to end through the real detect-checkpoint-evidence CLI, on
+// a review payload shaped exactly like GitHub's response to a submitted
+// APPROVE review (state: "APPROVED", a non-null submitted_at).
+test("detect-checkpoint-evidence: a `review`-gate verdict submitted as an APPROVE review (--submit approve, #1840) is still non-evidence for draft_gate/pre_approval_gate", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-detect-gate-review-approve-mode-"));
+  try {
+    await writeFile(path.join(tempDir, ".devloops"), "version: 1\ngates:\n  requireFanoutEvidence: false\n", "utf8");
+    const approvedReviewGateComment = {
+      id: 960,
+      body: renderGateReviewCommentBody({
+        gate: "review",
+        headSha: "abc1234",
+        verdict: "clean",
+        findingsSummary: "no issues found",
+        nextAction: "none — informational review, no re-gate required",
+      }),
+      // Shape of GitHub's response to a SUBMITTED review (state !== "PENDING",
+      // a non-empty submitted_at) — exactly what isSubmittedReview
+      // (_gate-finding-surface.mjs) requires before a review enters the
+      // evidence-scan comment stream at all, so this fixture is a genuine
+      // proof the guard holds even once the review clears that filter.
+      state: "APPROVED",
+      submitted_at: "2026-08-27T23:25:00Z",
+      html_url: "https://github.com/owner/repo/pull/17#pullrequestreview-960",
+    };
+    const env = await writeGhStub(tempDir, [
+      { assertArgs: ["pr", "view", "17", "--repo", "owner/repo", "--json", "headRefOid"], stdout: '{"headRefOid":"abc1234"}\n' },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/issues/17/comments?per_page=100"], stdout: "[]\n" },
+      { assertArgs: ["api", "--paginate", "--slurp", "repos/owner/repo/pulls/17/reviews?per_page=100"], stdout: JSON.stringify([approvedReviewGateComment]) + "\n" },
+      { assertArgs: ["api", "graphql"], stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }) + "\n" },
+    ]);
+
+    const result = await runNode(["--repo", "owner/repo", "--pr", "17"], { env, cwd: tempDir });
+
+    // With no genuine draft_gate/pre_approval_gate comment on the PR (only
+    // the APPROVE-mode `review` comment), evidence must remain ABSENT — the
+    // pre-merge check fails closed rather than reading the review as
+    // draft_gate evidence.
+    assert.equal(result.code, 1, result.stdout);
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.evidenceState, "not_established");
+    assert.equal(payload.preMergeGateCheck.ok, false);
+    assert.ok(
+      payload.preMergeGateCheck.failures.some((f) => f.includes("missing visible clean draft_gate comment")),
+      JSON.stringify(payload.preMergeGateCheck.failures),
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("detect-checkpoint-evidence: a posted gate-findings-review body can never win the newest-gate-marker tie-break (evidence-scan hijack)", async () => {
   // close-gate-findings.mjs's posted findings review always embeds the gate
   // name in its header line, and a finding's own free text can mention the

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -6289,6 +6289,135 @@ test("#1808: --gate review on a CLEAN ledger renders with no blocking-severity l
   }, { prefix: "dev-loops-upsert-review-gate-clean-" });
 });
 
+// ---------------------------------------------------------------------------
+// #1840 — `--submit <pending|comment|request-changes|approve>` on --gate
+// review only: the create path's GitHub `event`, the review-gate-only
+// scoping refusal, the headless (--auto) approve/request-changes refusal,
+// and the default-comment fallback.
+// ---------------------------------------------------------------------------
+
+test("parseUpsertCheckpointVerdictCliArgs: --submit is scoped to --gate review only (draft_gate/pre_approval_gate reject it with a named error)", () => {
+  const base = ["--repo", "owner/repo", "--pr", "17", "--head-sha", "abc1234000000000000000000000000000000000", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "go", "--execution-mode", "fanout_fanin"];
+  for (const gate of ["draft_gate", "pre_approval_gate"]) {
+    assert.throws(
+      () => parseUpsertCheckpointVerdictCliArgs([...base, "--gate", gate, "--submit", "comment"]),
+      /--submit is scoped to --gate review only.*GATE-COMMENT-NON-SUBSTITUTION/is,
+    );
+  }
+  // An omitted --gate would auto-resolve to draft_gate/pre_approval_gate at
+  // runtime, never review — --submit is refused up front rather than
+  // deferring to a runtime resolution that could never legally accept it.
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs([...base, "--submit", "pending"]),
+    /--submit is scoped to --gate review only/i,
+  );
+  // review accepts it.
+  const parsed = parseUpsertCheckpointVerdictCliArgs([...base, "--gate", "review", "--submit", "comment"]);
+  assert.equal(parsed.submit, "comment");
+});
+
+test("parseUpsertCheckpointVerdictCliArgs: --submit rejects an unrecognized mode", () => {
+  const base = ["--repo", "owner/repo", "--pr", "17", "--gate", "review", "--head-sha", "abc1234000000000000000000000000000000000", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "go", "--execution-mode", "fanout_fanin"];
+  assert.throws(
+    () => parseUpsertCheckpointVerdictCliArgs([...base, "--submit", "bogus"]),
+    /--submit must be one of: pending, comment, request-changes, approve/i,
+  );
+});
+
+test("parseUpsertCheckpointVerdictCliArgs: --auto refuses --submit approve/request-changes on --gate review (headless never auto-approves or auto-blocks)", () => {
+  const base = ["--repo", "owner/repo", "--pr", "17", "--gate", "review", "--head-sha", "abc1234000000000000000000000000000000000", "--verdict", "clean", "--findings-summary", "ok", "--next-action", "go", "--execution-mode", "fanout_fanin", "--auto"];
+  for (const submit of ["approve", "request-changes"]) {
+    assert.throws(
+      () => parseUpsertCheckpointVerdictCliArgs([...base, "--submit", submit]),
+      /not allowed with --auto.*interactive submit choice/is,
+    );
+  }
+  // Headless still allows pending/comment.
+  for (const submit of ["pending", "comment"]) {
+    const parsed = parseUpsertCheckpointVerdictCliArgs([...base, "--submit", submit]);
+    assert.equal(parsed.submit, submit);
+    assert.equal(parsed.auto, true);
+  }
+  // approve/request-changes ARE reachable without --auto (the interactive path).
+  for (const submit of ["approve", "request-changes"]) {
+    const interactiveBase = base.filter((token) => token !== "--auto");
+    const parsed = parseUpsertCheckpointVerdictCliArgs([...interactiveBase, "--submit", submit]);
+    assert.equal(parsed.submit, submit);
+    assert.equal(parsed.auto, false);
+  }
+});
+
+for (const { submit, expectedEvent, label } of [
+  { submit: undefined, expectedEvent: "COMMENT", label: "omitted --submit defaults to comment" },
+  { submit: "comment", expectedEvent: "COMMENT", label: "--submit comment" },
+  { submit: "request-changes", expectedEvent: "REQUEST_CHANGES", label: "--submit request-changes" },
+  { submit: "approve", expectedEvent: "APPROVE", label: "--submit approve" },
+]) {
+  test(`upsert-checkpoint-verdict --gate review: ${label} submits the review with GitHub event ${expectedEvent}`, async () => {
+    await withTempDir(async (tempDir) => {
+      const ledgerPath = await writeReviewGateLedger(tempDir, [], { verdict: "clean", overallVerdict: "clean" });
+      const entries = [
+        ...reviewGateFindingSurfaceEntries({ files: null }),
+        {
+          assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+          stdout: '{"id":950,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-950"}\n',
+        },
+      ];
+      const { runChild, calls } = makeGhMock(entries);
+      const result = await upsertCheckpointVerdict({
+        repo: "owner/repo",
+        pr: 17,
+        gate: "review",
+        headSha: SINGLE_SURFACE_HEAD,
+        nextAction: "none — informational review, no re-gate required",
+        findingsLedger: ledgerPath,
+        executionMode: "fanout_fanin",
+        ...(submit !== undefined ? { submit } : {}),
+      }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "created");
+      assert.equal(result.submit, submit ?? "comment");
+      const postCall = calls.find((c) => c.args.includes("repos/owner/repo/pulls/17/reviews") && c.args.includes("POST"));
+      const postedPayload = JSON.parse(postCall.stdinText);
+      assert.equal(postedPayload.event, expectedEvent);
+    }, { prefix: "dev-loops-upsert-review-submit-" });
+  });
+}
+
+test("upsert-checkpoint-verdict --gate review --submit pending creates the review with GitHub's `event` OMITTED (author-only draft)", async () => {
+  await withTempDir(async (tempDir) => {
+    const ledgerPath = await writeReviewGateLedger(tempDir, [], { verdict: "clean", overallVerdict: "clean" });
+    const entries = [
+      ...reviewGateFindingSurfaceEntries({ files: null }),
+      {
+        assertArgs: ["api", "-X", "POST", "repos/owner/repo/pulls/17/reviews", "--input", "-"],
+        stdout: '{"id":951,"html_url":"https://github.com/owner/repo/pull/17#pullrequestreview-951"}\n',
+      },
+    ];
+    const { runChild, calls } = makeGhMock(entries);
+    const result = await upsertCheckpointVerdict({
+      repo: "owner/repo",
+      pr: 17,
+      gate: "review",
+      headSha: SINGLE_SURFACE_HEAD,
+      nextAction: "none — informational review, no re-gate required",
+      findingsLedger: ledgerPath,
+      executionMode: "fanout_fanin",
+      submit: "pending",
+    }, { env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }), ghCommand: "gh", runChild, repoRoot: tempDir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.submit, "pending");
+    const postCall = calls.find((c) => c.args.includes("repos/owner/repo/pulls/17/reviews") && c.args.includes("POST"));
+    const postedPayload = JSON.parse(postCall.stdinText);
+    assert.equal("event" in postedPayload, false);
+    // The verdict body is still rendered in full — a pending review still
+    // carries the complete verdict for the human to inspect before submitting.
+    assert.match(postedPayload.body, /### Gate review: `review`/);
+  }, { prefix: "dev-loops-upsert-review-submit-pending-" });
+});
+
 test("normalizeStructuredFindings aliases the legacy severity so no posted body renders it", () => {
   const angles = normalizeStructuredFindings([
     { angle: "docs", verdict: "findings_present", findings: [{ severity: "defer", summary: "legacy entry" }] },


### PR DESCRIPTION
Closes #1840

Add a submit-mode to the standalone `review` deliverable plus an interactive end-of-run submit choice, so a reviewer can inspect the review before it goes public.

## What

- `upsert-checkpoint-verdict.mjs`: new `--submit <pending|comment|request-changes|approve>`, SCOPED to `--gate review`. `pending` creates an author-only draft review (GitHub `event` omitted); `comment` (default) / `request-changes` / `approve` submit with that event.
- Gate surfaces untouched: `--submit` on `draft_gate`/`pre_approval_gate` is rejected with a named error (GATE-COMMENT-NON-SUBSTITUTION) — those keep submitting a visible `COMMENT` evidence surface.
- Headless safety: with `--auto`, only `pending`/`comment` are allowed; `approve`/`request-changes` are refused (reachable only via the interactive choice), so automation can never auto-approve or auto-block a PR.
- `/loop-review` (SKILL + command doc): interactive runs end with a multiple-choice submit step (Leave pending [default] / Comment / Request-changes / Approve / Discard), with the branch-protection effect of approve/request-changes stated inline; `--auto` defaults to `comment` with no prompt.
- Preserves #1808: a `review` verdict in ANY submit mode (incl. `approve`) stays non-evidence for dev-loops gates — the authoritative-`review`-header guard is body-only, unaffected by review state/event.

## Acceptance criteria

- [x] `upsert-checkpoint-verdict.mjs --gate review --submit <pending|comment|request-changes|approve>` posts accordingly: `pending` creates an author-only draft review (event omitted); the others submit with the named event. Default when `--submit` is omitted is `comment`.
- [x] `--submit` on `draft_gate`/`pre_approval_gate` is rejected with a clear named error (never silently ignored); those gates keep submitting `COMMENT`. Pinned by a test.
- [x] A headless/non-interactive review run refuses `--submit approve` and `--submit request-changes` (only `pending`/`comment` allowed headless), so automation cannot auto-approve or auto-block; `approve`/`request-changes` are reachable only via the interactive multiple-choice. Pinned by a test.
- [x] `skills/review/SKILL.md` / `/loop-review`: interactive runs end with a multiple-choice submit step (default: leave pending); the Request-changes and Approve options state their branch-protection effect; on pending, the submit instructions are printed. `--auto`/headless runs default to `comment` with no prompt.
- [x] A `review` verdict posted via any `--submit` mode (including `approve`) is still non-evidence for dev-loops gates: `detect-checkpoint-evidence` / `detect-pr-gate-coordination-state` report no draft/pre-approval evidence. Pinned by a test extending the #1808 non-evidence regression.
- [x] Tests pin: the `pending` create path (event omitted), each submit event, the review-gate-only scoping, the headless approve/request-changes refusal, and the default-`comment` fallback.
- [x] Docs (gate-review-comment-contract, the SKILL) describe the submit modes, the interactive default, the headless restriction, and the branch-protection effect of approve/request-changes; `npm run assets:check` clean.

## Definition of done

- [x] All AC checked.
- [x] `npm run verify` green.
- [x] Docs link validation green (`npm run assets:check` clean, 90 checked).
- [x] New `GATE-REVIEW-SUBMIT-MODES` section added to gate-review-comment-contract and registered in required-rules.json.
- [x] Deterministic-only (corrected 2026-09-01, #1890): the interactive manual step — `/loop-review` run interactively against an open PR, Leave pending chosen, review confirmed author-only until submitted — was NOT performed; #1842 B3 records the interactive submit-choice flow as un-exercised. What was verified: the deterministic headless refusals (`--submit approve`/`--submit request-changes` refused under `--auto`; `--submit` on gate surfaces rejected) and the headless `--submit comment` posting (pull/1461#pullrequestreview-5062828929, verified COMMENTED).

## Non-goals

- No change to the gate (`draft_gate`/`pre_approval_gate`) submit behavior.
- No auto-submit of a pending review on a later run (the human submits it).
- No headless `approve`/`request-changes` (automation never approves or blocks a PR via a review event).

## Verification

- `npm run verify` green; `npm run assets:check` clean (90 checked).
- Tests pin: the pending create path (event omitted), each submit event, review-gate-only scoping, the headless approve/request-changes refusal, default-`comment` fallback, and a #1808-pattern regression proving an APPROVE-state review carrying the `review` header yields no draft/pre-approval evidence.
- New `GATE-REVIEW-SUBMIT-MODES` section in gate-review-comment-contract (registered in required-rules.json).


