### PR TITLE
feat(gate): enforce cache-aligned reviewer dispatch (prefix-first prompt layout check; completes #1468)

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -579,6 +579,7 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
   operator decision per PR. Each reviewer:
 
 - starts in fresh context: run the mandatory `verify-fresh-review-context.mjs` invocation exactly as Phase 1 specifies. In the fan-out, `--scope` additionally keeps parallel reviewers in the same working directory from tripping false contamination on each other's sentinels, and `--context-path` (the Phase 1 artifact) fails a reviewer in the wrong/isolated checkout closed. A grouped reviewer runs this ONCE for the whole group, with `--scope <gate>-group-<name>` (below), not once per angle it covers. The sentinel is keyed per review ROUND by the current head SHA, so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle(s), and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
+- is composed prefix-first (`GATE-EXEC-BRIEFING-PREFIX`'s "Cache alignment" paragraph): right after composing its prompt (the same step as the `verify-fresh-review-context.mjs` call above), the orchestrator ALSO calls `scripts/github/record-dispatch-prompt-layout.mjs --scope <same scope> --head-sha <sha> --prefix-path <this round's invariant-prefix file path> --prompt-file <path to the ACTUAL composed prompt text>` to capture its leading bytes — the "Prompt-LAYOUT enforcement" paragraph under `GATE-EXEC-BRIEFING-PREFIX` above owns the full capture/verify contract; this is a rollout, not a precondition (a round that never captures is never newly blocked).
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when a covered angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph. When it widens, it records in the findings artifact's optional `contextWidened` field ONLY the files that actually moved its judgment, never every file it opened. Absence of `contextWidened` (or an empty one) means "not consulted" — never "consulted and clean"; carry-forward and audit logic MUST NOT infer clean-ness from that omission.
 - is scoped to exactly one review angle (one angle per unit under `mode: per-angle`, which bypasses configured groups; every angle in its resolved group (grouped mode, the default — including `gate:full`, which dispatches grouped) — each angle keeps its own prompt, all appended after the one shared invariant prefix (`GATE-EXEC-BRIEFING-PREFIX`)
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -783,6 +784,34 @@ closed. Only when no on-disk records exist (offline/legacy) does it fall back to
 rule that all of the round's sentinels share ONE identical hash. See
 `verify-briefing-prefixes.mjs --help` for the worked same-head two-gate example.
 
+**Prompt-LAYOUT enforcement (issue #1841, completes #1468).** Everything above proves the
+recorded prefix HASH is byte-identical across a round's sentinels — it proves nothing about
+whether any reviewer's ACTUAL dispatched prompt LED with those bytes, since the prompt is
+composed by the orchestrating agent at fan-out time with no code template. This closes that
+gap with a minimal capture point: right after composing each reviewer's prompt (the same
+fan-out step that already runs `verify-fresh-review-context.mjs`), call
+`scripts/github/record-dispatch-prompt-layout.mjs --scope <gate>-<angle-or-group> --head-sha
+<sha> --prefix-path <the invariant-prefix file path this reviewer's prompt was composed
+from/points at> --prompt-file <path to the ACTUAL composed prompt text>`. It captures the
+prompt's leading bytes (up to `DISPATCH_PROMPT_LEADING_CAP_BYTES`,
+`@dev-loops/core/loop/review-dispatch-plan`) to `tmp/checkpoint-dispatch-prompt-<scope>-<headSha>.json`.
+Before Phase 3 consolidation, the fan-in ALSO runs
+`scripts/github/verify-dispatch-prompt-layout.mjs --head-sha <sha>` (wired into
+`consolidate-fanin.mjs`'s own `--head-sha` block, alongside `verify-briefing-prefixes.mjs`),
+which fails closed (exit 1) when a recorded prompt's leading bytes do NOT match either: the
+round's byte-identical invariant prefix itself (inline mode), or the byte-identical pointer
+LINE naming the SAME prefix path, rendered by `renderBriefingPointerLine`
+(`@dev-loops/core/loop/review-dispatch-plan`) — the fixed line `verifyPromptLeadingAlignment`
+checks the leading bytes against under pointer-seeding mode, with the angle-specific text
+strictly AFTER it. An angle-first prompt (dynamic per-unit prose ahead of the prefix/pointer)
+matches neither and fails this mechanically, not only by prose review. Ground truth is ALWAYS
+re-discovered on disk from the round's real `<gate>-<headSha>.briefing-prefix.txt` record —
+never trusted from a captured record's own stored path — so a stale/tampered record can never
+smuggle in different bytes. A round with NO dispatch-prompt records at all is never newly
+blocked (progressive/optional capture, same posture as `GATE-EXEC-PRIMER-EVIDENCE` below): the
+orchestrator adopting this capture step is a rollout, not a precondition for every existing
+caller.
+
 <!-- rule: GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK -->
 `GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK`: Reviewers SHOULD run in parallel when practical; when parallel execution is impractical
 (for example due to tooling or resource constraints), the fan-out MUST run all reviewers
@@ -917,7 +946,12 @@ Before consolidating, `consolidate-fanin.mjs` itself runs
 had ZERO callers, so the rule's own cited proof was never invoked); a fail-closed
 result (mismatched or missing prefix hashes across this round's reviewer
 sentinels, or a sentinel count short of the dispatch units the conductor spawned)
-MUST stop the pass rather than proceed to consolidation. The conductor supplies
+MUST stop the pass rather than proceed to consolidation. In the SAME `--head-sha`
+block it ALSO runs `scripts/github/verify-dispatch-prompt-layout.mjs --head-sha
+<sha>` (issue #1841, completing #1468's own acceptance — see the "Prompt-LAYOUT
+enforcement" paragraph under `GATE-EXEC-BRIEFING-PREFIX` above), which fails
+closed on any recorded reviewer prompt that does not LEAD with the round's
+byte-identical invariant prefix or pointer line. The conductor supplies
 the expected dispatch-unit count via `--expected-dispatch-units <n>` (the Phase 1
 context artifact's `fanout.pendingGroups.length` — the dispatched dispatch-UNIT
 count, NOT `fanout.wavePlan.length`, which is the WAVE count, typically 1, not
@@ -1011,6 +1045,25 @@ plan hash is missing or mismatched. The refusal names the failing check
 `shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
 barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
+
+**Enforcement stays OPT-IN, not default-on (issue #1841, investigated as part of
+completing #1468).** `consolidate-fanin.mjs` validates this evidence ONLY when the
+conductor supplies both `--primer-evidence` and `--primer-plan`; a round that
+supplies neither proceeds unenforced, same as before. #1841 investigated flipping
+this to default-on and could NOT prove, within the shipped harness and without a
+live multi-reviewer dispatch to observe, that the Phase 1.5 primer measurably
+produces org+model content-hash cache reads on reviewers 2..N — `primer-evidence.mjs`'s
+own ordering/binding checks are deterministic and offline (timestamps, fingerprints),
+which proves ordering and request-fingerprint invariants but never MEASURES
+provider cache reuse itself (that measurement is `GATE-EXEC-CACHE-TELEMETRY`'s job,
+below, and it is ALSO opt-in for the same reason: no in-repo artifact yet records a
+real harness's cache-creation/cache-read token counts for a primed round). Flipping
+primer-evidence enforcement to default-on without that proof risked false-blocking a
+legitimately-primed fan-out on a harness/mechanism combination nobody had measured.
+Ship the dispatch-LAYOUT check above as unconditional (it needs no such proof — it
+verifies BYTES the orchestrator already controls, not provider-side cache behavior),
+and revisit this default once a real round's cache-telemetry evidence demonstrates
+the primer reliably produces reads on the shipped harness.
 
 <!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
 `GATE-EXEC-CACHE-TELEMETRY`: when a round records cache-telemetry evidence

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -728,3 +728,78 @@ export function partitionPrimerGroups(requestGroups, capabilities = {}) {
   }
   return out;
 }
+
+/* ------------------------------------------------------------------ *
+ * 6. Dispatch-prompt layout alignment (issue #1841, completes #1468)
+ * ------------------------------------------------------------------ */
+
+// Leading-bytes capture cap for a dispatched reviewer prompt (issue #1841's
+// record-dispatch-prompt-layout.mjs). Sized comfortably above
+// write-gate-context.mjs's BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES (200 KiB) so
+// a full byte-for-byte alignment check never runs out of captured bytes for
+// an inline-mode round.
+export const DISPATCH_PROMPT_LEADING_CAP_BYTES = 512 * 1024;
+
+/**
+ * Render the byte-identical pointer LINE a reviewer prompt must lead with
+ * under pointer-seeding mode (GATE-EXEC-BRIEFING-PREFIX's "Cache alignment"
+ * paragraph): the orchestrator points every reviewer of the round at the SAME
+ * invariant-prefix file path rather than inlining its bytes. Deterministic in
+ * `prefixPath` alone, so two reviewers given the same path render the
+ * identical line, and a per-reviewer/angle-varying path (which would defeat
+ * prefix matching) renders a DIFFERENT line, exactly reproducing the defect
+ * this line exists to catch.
+ *
+ * @param {string} prefixPath — the invariant-prefix file path every reviewer
+ *   of the round is pointed at (e.g. the `<gate>-<headSha>.briefing-prefix.txt`
+ *   path).
+ * @returns {string}
+ */
+export function renderBriefingPointerLine(prefixPath) {
+  if (typeof prefixPath !== "string" || prefixPath.trim().length === 0) {
+    throw new Error("renderBriefingPointerLine requires a non-empty prefixPath");
+  }
+  return `Read ${prefixPath.trim()} FIRST, in full, before anything else in this prompt — it is this round's byte-identical invariant briefing prefix (GATE-EXEC-BRIEFING-PREFIX). Your angle-specific instructions follow below, after it.`;
+}
+
+/**
+ * Decide whether a dispatched reviewer prompt's LEADING bytes are
+ * cache-aligned (GATE-EXEC-BRIEFING-PREFIX layout, issue #1841): either the
+ * prompt's leading bytes are byte-identical to the round's invariant prefix
+ * (inline mode), or the prompt leads with the byte-identical pointer line
+ * naming the round's invariant-prefix path (pointer-seeding mode), with any
+ * angle-specific text strictly AFTER it. An angle-first prompt (dynamic
+ * per-unit prose ahead of the prefix/pointer) matches neither and is
+ * REJECTED — this is the mechanical proof the prose-only rule lacked.
+ *
+ * Pure and offline: takes the already-captured leading bytes and the already-
+ * read prefix bytes/path, never reads a file itself (the CLI wrapper owns
+ * I/O), so this is directly unit-testable with in-memory strings.
+ *
+ * @param {object} input
+ * @param {string} input.promptLeading — the captured leading bytes of the
+ *   ACTUAL reviewer prompt (record-dispatch-prompt-layout.mjs's capture).
+ * @param {string} input.prefixBytes — the round's recorded byte-identical
+ *   invariant-prefix content (the `<gate>-<headSha>.briefing-prefix.txt`
+ *   bytes).
+ * @param {string} input.prefixPath — the path used to render this round's
+ *   pointer line (must be the SAME path every reviewer was pointed at).
+ * @returns {{ aligned: boolean, mode: "inline"|"pointer"|null, reason: string|null }}
+ */
+export function verifyPromptLeadingAlignment({ promptLeading, prefixBytes, prefixPath } = {}) {
+  const leading = typeof promptLeading === "string" ? promptLeading : "";
+  if (typeof prefixBytes === "string" && prefixBytes.length > 0 && leading.startsWith(prefixBytes)) {
+    return { aligned: true, mode: "inline", reason: null };
+  }
+  if (typeof prefixPath === "string" && prefixPath.trim().length > 0) {
+    const pointerLine = renderBriefingPointerLine(prefixPath);
+    if (leading.startsWith(pointerLine)) {
+      return { aligned: true, mode: "pointer", reason: null };
+    }
+  }
+  return {
+    aligned: false,
+    mode: null,
+    reason: "reviewer prompt does not LEAD with the round's byte-identical invariant prefix (inline mode) or its byte-identical pointer line (pointer-seeding mode) — an angle-first prompt (dynamic per-unit prose ahead of the prefix/pointer) defeats prefix matching (GATE-EXEC-BRIEFING-PREFIX)",
+  };
+}

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -20,6 +20,9 @@ import {
   partitionPrimerGroups,
   resolvePrimerForm,
   sha256Hex,
+  DISPATCH_PROMPT_LEADING_CAP_BYTES,
+  renderBriefingPointerLine,
+  verifyPromptLeadingAlignment,
 } from "../src/loop/review-dispatch-plan.mjs";
 
 describe("normalizeHarnessCapabilities — explicit capability model (Section D)", () => {
@@ -749,5 +752,94 @@ describe("sha256Hex — deterministic hashing + opaque markers", () => {
     assert.equal(a, sha256Hex({ bytes: Buffer.from("hello"), label: "x" }));
     // A Buffer and an identical hex string must NOT collide (prefix disambiguates).
     assert.notEqual(a, sha256Hex({ bytes: "hello", label: "x" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyPromptLeadingAlignment / renderBriefingPointerLine — dispatch-prompt
+// LAYOUT check (#1841, completes #1468): mechanically proving whether a
+// dispatched reviewer prompt actually LEADS with the round's byte-identical
+// invariant prefix/pointer line, never angle-first.
+// ---------------------------------------------------------------------------
+describe("renderBriefingPointerLine — pointer-seeding mode's byte-identical pointer line", () => {
+  test("is deterministic for the same prefixPath", () => {
+    const a = renderBriefingPointerLine("tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt");
+    const b = renderBriefingPointerLine("tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt");
+    assert.equal(a, b);
+  });
+
+  test("differs when the prefixPath differs (a per-reviewer/angle-varying path would defeat prefix matching)", () => {
+    const a = renderBriefingPointerLine("tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt");
+    const b = renderBriefingPointerLine("tmp/gate-context/o-r/pr-1/draft_gate-abc-coverage.briefing-prefix.txt");
+    assert.notEqual(a, b);
+  });
+
+  test("throws on an empty prefixPath", () => {
+    assert.throws(() => renderBriefingPointerLine(""), /non-empty prefixPath/);
+  });
+});
+
+describe("verifyPromptLeadingAlignment — GATE-EXEC-BRIEFING-PREFIX layout check", () => {
+  const PREFIX_BYTES = "## Invariant prefix\nrepo: o/r\nhead: abc\n";
+  const PREFIX_PATH = "tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt";
+
+  test("inline mode: a prompt whose leading bytes ARE the prefix passes", () => {
+    const verdict = verifyPromptLeadingAlignment({
+      promptLeading: `${PREFIX_BYTES}## Angle: coverage\nDo the thing.`,
+      prefixBytes: PREFIX_BYTES,
+      prefixPath: PREFIX_PATH,
+    });
+    assert.equal(verdict.aligned, true);
+    assert.equal(verdict.mode, "inline");
+  });
+
+  test("pointer mode: a prompt leading with the byte-identical pointer line passes, angle suffix after", () => {
+    const pointerLine = renderBriefingPointerLine(PREFIX_PATH);
+    const verdict = verifyPromptLeadingAlignment({
+      promptLeading: `${pointerLine}\n## Angle: coverage\nDo the thing.`,
+      prefixBytes: PREFIX_BYTES,
+      prefixPath: PREFIX_PATH,
+    });
+    assert.equal(verdict.aligned, true);
+    assert.equal(verdict.mode, "pointer");
+  });
+
+  test("REJECTS an angle-first prompt (dynamic per-unit prose ahead of the invariant prefix)", () => {
+    const verdict = verifyPromptLeadingAlignment({
+      promptLeading: `## Angle: coverage\nDo the thing.\n${PREFIX_BYTES}`,
+      prefixBytes: PREFIX_BYTES,
+      prefixPath: PREFIX_PATH,
+    });
+    assert.equal(verdict.aligned, false);
+    assert.match(verdict.reason, /does not LEAD with/);
+  });
+
+  test("REJECTS an angle-first prompt in pointer-seeding mode (prose ahead of the pointer line)", () => {
+    const pointerLine = renderBriefingPointerLine(PREFIX_PATH);
+    const verdict = verifyPromptLeadingAlignment({
+      promptLeading: `## Angle: coverage\nDo the thing.\n${pointerLine}`,
+      prefixBytes: PREFIX_BYTES,
+      prefixPath: PREFIX_PATH,
+    });
+    assert.equal(verdict.aligned, false);
+  });
+
+  test("REJECTS a pointer line naming a DIFFERENT path (per-reviewer path variance defeats matching)", () => {
+    const otherPointerLine = renderBriefingPointerLine(`${PREFIX_PATH}.other`);
+    const verdict = verifyPromptLeadingAlignment({
+      promptLeading: `${otherPointerLine}\n## Angle: coverage\n`,
+      prefixBytes: PREFIX_BYTES,
+      prefixPath: PREFIX_PATH,
+    });
+    assert.equal(verdict.aligned, false);
+  });
+
+  test("REJECTS an empty/missing promptLeading", () => {
+    const verdict = verifyPromptLeadingAlignment({ promptLeading: "", prefixBytes: PREFIX_BYTES, prefixPath: PREFIX_PATH });
+    assert.equal(verdict.aligned, false);
+  });
+
+  test("DISPATCH_PROMPT_LEADING_CAP_BYTES is comfortably above the 200 KiB inline-diff cap", () => {
+    assert.ok(DISPATCH_PROMPT_LEADING_CAP_BYTES > 200 * 1024);
   });
 });

--- a/scripts/github/record-dispatch-prompt-layout.mjs
+++ b/scripts/github/record-dispatch-prompt-layout.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+import { GATE_NAMES } from "./_gate-names.mjs";
+import { DISPATCH_PROMPT_LEADING_CAP_BYTES } from "@dev-loops/core/loop/review-dispatch-plan";
+
+const USAGE = `Usage: record-dispatch-prompt-layout.mjs --scope <name> --head-sha <sha> --prefix-path <path> --prompt-file <path> [--help]
+Capture the LEADING bytes of a dispatched reviewer's ACTUAL composed prompt
+(GATE-EXEC-BRIEFING-PREFIX layout, issue #1841/completes #1468) as a fan-in
+dispatch artifact. The orchestrator composes the reviewer prompt at fan-out
+time with no code template — this is the minimal capture point that gives
+verify-dispatch-prompt-layout.mjs / consolidate-fanin.mjs's fan-in something
+mechanical to check: whether the prompt actually LEADS with the round's
+byte-identical invariant prefix (inline mode) or its byte-identical pointer
+line (pointer-seeding mode), never angle-first.
+
+Call this ONCE per dispatched reviewer/group, right after composing its
+prompt and BEFORE (or immediately after) spawning it, from the SAME
+orchestrator step that already runs write-gate-context.mjs's Phase 1.
+
+Required:
+  --scope <name>       Reviewer/group scope, same vocabulary as
+                        verify-fresh-review-context.mjs --scope (e.g.
+                        "draft-gate-coverage" or "draft-gate-group-a").
+  --head-sha <sha>      The FULL 40- or 64-char reviewed head SHA (git rev-parse HEAD).
+  --prefix-path <path>  The invariant-prefix file path this reviewer's prompt
+                        was composed from/points at (write-gate-context.mjs's
+                        \`<gate>-<headSha>.briefing-prefix.txt\`). Its BASENAME
+                        must be \`<gate>-<headSha>.briefing-prefix.txt\` for a
+                        canonical gate name and this exact head SHA — anything
+                        else fails closed (exit 1). Recorded verbatim, but
+                        NEVER trusted for its own bytes at verify time: the
+                        fan-in independently re-discovers the real
+                        \`<tmp-root>/gate-context/**\` record for the
+                        (gate, headSha) pair extracted from this basename, so a
+                        record pointing at an arbitrary/tampered file can never
+                        smuggle in different ground-truth bytes.
+  --prompt-file <path>  Path to a file holding the ACTUAL composed reviewer
+                        prompt text (UTF-8) — the literal bytes the reviewer
+                        was dispatched with, not a paraphrase. Its leading
+                        ${DISPATCH_PROMPT_LEADING_CAP_BYTES} bytes are captured;
+                        a longer prompt is truncated (recorded as "truncated":
+                        true — a truncated capture can still prove misalignment
+                        but never prove alignment beyond the captured bytes).
+Optional:
+  --tmp-root <path>     The tmp/ directory to write the record under (default:
+                        process.cwd()/tmp). Must match the --tmp-root/cwd the
+                        fan-in (consolidate-fanin.mjs) later reads from.
+Output (stdout, JSON):
+  { "ok": true, "recorded": true, "scope": "...", "headSha": "...", "prefixPath": "...", "truncated": false }
+  { "ok": true, "recorded": false, "reason": "..." }
+  On error (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+${JQ_OUTPUT_USAGE}
+Exit codes:
+  0  Recorded
+  1  Refused to record: --prefix-path's basename is not a canonical
+     <gate>-<headSha>.briefing-prefix.txt record name for the given
+     --head-sha, or --prompt-file is missing/unreadable
+  2  Usage or internal error, or invalid --jq filter`.trim();
+
+const HEAD_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const VALID_SCOPE_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const parseError = buildParseError(USAGE);
+
+function resolveFlagValue(argv, flag) {
+  const idx = argv.indexOf(flag);
+  if (idx === -1) return null;
+  const val = argv[idx + 1];
+  if (val === undefined || val === "" || (val.length > 0 && val[0] === "-")) return "";
+  return val;
+}
+
+/**
+ * Validate that `prefixPath`'s BASENAME is a canonical
+ * `<gate>-<headSha>.briefing-prefix.txt` record name for the given head SHA
+ * (write-gate-context.mjs's `buildGateBriefingPrefixPath` naming). Pure and
+ * path-resolution-free by design (issue #1841): the caller's directory portion
+ * of `prefixPath` is NEVER trusted as ground truth — only the gate name it
+ * encodes is extracted, and the ACTUAL bytes are always re-discovered from the
+ * real on-disk `<tmp-root>/gate-context/**` record (see
+ * verify-dispatch-prompt-layout.mjs's `findGateBriefingPrefixBytes`), so a
+ * captured record naming a directory that doesn't exist (or has since moved)
+ * can never smuggle in different ground-truth bytes. Shared by the CLI here
+ * and by verify-dispatch-prompt-layout.mjs so the naming rule cannot drift.
+ *
+ * @param {string} prefixPath
+ * @param {string} headSha — already lowercased/trimmed
+ * @returns {{ ok: true, gate: string } | { ok: false, reason: string }}
+ */
+export function validateBriefingPrefixPath(prefixPath, headSha) {
+  const basename = path.basename(String(prefixPath ?? ""));
+  const suffix = `-${headSha}.briefing-prefix.txt`;
+  if (!basename.endsWith(suffix)) {
+    return { ok: false, reason: `--prefix-path ${JSON.stringify(prefixPath)} basename is not a canonical "<gate>-${headSha}.briefing-prefix.txt" record` };
+  }
+  const gate = basename.slice(0, -suffix.length);
+  if (!GATE_NAMES.includes(gate)) {
+    return { ok: false, reason: `--prefix-path ${JSON.stringify(prefixPath)} basename names an unknown gate ${JSON.stringify(gate)} (must be one of ${GATE_NAMES.join(", ")})` };
+  }
+  return { ok: true, gate };
+}
+
+export function dispatchPromptLayoutRecordPath(tmpRoot, scope, headSha) {
+  return path.join(tmpRoot, `checkpoint-dispatch-prompt-${scope}-${headSha}.json`);
+}
+
+export async function main(argv = process.argv.slice(2), { tmpRootDefault = path.join(process.cwd(), "tmp") } = {}) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  const scope = resolveFlagValue(argv, "--scope");
+  if (scope === null || scope === "" || !VALID_SCOPE_RE.test(scope)) {
+    process.stderr.write(`${formatCliError(parseError(`--scope is required and must be non-empty, alphanumeric/hyphen only${scope ? ` (got ${JSON.stringify(scope)})` : ""}.`))}\n`);
+    return 2;
+  }
+  const headShaArg = resolveFlagValue(argv, "--head-sha");
+  if (headShaArg === null || headShaArg === "" || !HEAD_SHA_RE.test(headShaArg)) {
+    process.stderr.write(`${formatCliError(parseError(`--head-sha is required and must be the FULL 40- or 64-character hex head SHA${headShaArg ? ` (got ${JSON.stringify(headShaArg)})` : ""}.`))}\n`);
+    return 2;
+  }
+  const headSha = headShaArg.toLowerCase();
+  const prefixPathArg = resolveFlagValue(argv, "--prefix-path");
+  if (prefixPathArg === null || prefixPathArg === "") {
+    process.stderr.write(`${formatCliError(parseError("--prefix-path is required and must be non-empty."))}\n`);
+    return 2;
+  }
+  const promptFileArg = resolveFlagValue(argv, "--prompt-file");
+  if (promptFileArg === null || promptFileArg === "") {
+    process.stderr.write(`${formatCliError(parseError("--prompt-file is required and must be non-empty."))}\n`);
+    return 2;
+  }
+  const tmpRootArg = resolveFlagValue(argv, "--tmp-root");
+  if (tmpRootArg === "") {
+    process.stderr.write(`${formatCliError(parseError("Invalid --tmp-root value: must be non-empty."))}\n`);
+    return 2;
+  }
+  const tmpRoot = tmpRootArg ?? tmpRootDefault;
+  const jqArg = resolveFlagValue(argv, "--jq");
+  if (jqArg === "") {
+    process.stderr.write(`${formatCliError(parseError("Invalid --jq value: must be non-empty."))}\n`);
+    return 2;
+  }
+  const jq = jqArg === null ? undefined : jqArg;
+  const silent = argv.includes("--silent") || argv.includes("-s");
+  const finish = (payload, ok) => emitResult(payload, { jq, silent, ok });
+
+  const pathCheck = validateBriefingPrefixPath(prefixPathArg, headSha);
+  if (!pathCheck.ok) {
+    return finish({ ok: true, recorded: false, scope, headSha, reason: pathCheck.reason }, false);
+  }
+  let promptText;
+  try {
+    promptText = await readFile(path.resolve(process.cwd(), promptFileArg), "utf8");
+  } catch (err) {
+    return finish({ ok: true, recorded: false, scope, headSha, reason: `--prompt-file "${promptFileArg}" is unreadable (${err.code ?? "error"})` }, false);
+  }
+  const truncated = promptText.length > DISPATCH_PROMPT_LEADING_CAP_BYTES;
+  const leading = truncated ? promptText.slice(0, DISPATCH_PROMPT_LEADING_CAP_BYTES) : promptText;
+
+  const recordPath = dispatchPromptLayoutRecordPath(tmpRoot, scope, headSha);
+  try {
+    await mkdir(path.dirname(recordPath), { recursive: true });
+  } catch (err) {
+    process.stderr.write(`${formatCliError(err)}\n`);
+    return 2;
+  }
+  const record = {
+    scope,
+    headSha,
+    prefixPath: prefixPathArg,
+    gate: pathCheck.gate,
+    leading,
+    truncated,
+    capturedAt: new Date().toISOString(),
+  };
+  try {
+    await writeFile(recordPath, JSON.stringify(record, null, 2) + "\n", "utf8");
+  } catch (err) {
+    process.stderr.write(`${formatCliError(err)}\n`);
+    return 2;
+  }
+  return finish({ ok: true, recorded: true, scope, headSha, prefixPath: prefixPathArg, truncated }, true);
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  try {
+    process.exitCode = await main();
+  } catch (err) {
+    process.stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/github/verify-dispatch-prompt-layout.mjs
+++ b/scripts/github/verify-dispatch-prompt-layout.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { JQ_OUTPUT_USAGE, emitResult } from "../lib/jq-output.mjs";
+import { verifyPromptLeadingAlignment } from "@dev-loops/core/loop/review-dispatch-plan";
+import { validateBriefingPrefixPath } from "./record-dispatch-prompt-layout.mjs";
+
+const USAGE = `Usage: verify-dispatch-prompt-layout.mjs --head-sha <sha> [--tmp-root <path>] [--help]
+Fan-in enforcement of the reviewer-PROMPT layout half of GATE-EXEC-BRIEFING-PREFIX
+(skills/docs/gate-review-sub-loop-contract.md), completing #1468: verify-briefing-
+prefixes.mjs proves the recorded prefix HASH is byte-identical across a round's
+reviewer sentinels, but proves nothing about whether any reviewer's ACTUAL prompt
+led with those bytes. This checker reads the leading-bytes dispatch records
+record-dispatch-prompt-layout.mjs writes at fan-out and fails closed (exit 1) when
+any recorded prompt does NOT lead with the round's byte-identical invariant prefix
+(inline mode) or its byte-identical pointer line (pointer-seeding mode) — an
+angle-first prompt (dynamic per-unit prose ahead of the prefix/pointer) fails this
+mechanically instead of only being documented.
+
+Ground truth for the comparison is ALWAYS re-discovered on disk here (never
+trusted from a record's own stored "prefixPath" directory): each record's
+basename names a (gate, headSha) pair, and this checker independently locates
+that gate's real \`<tmp-root>/gate-context/**/<gate>-<headSha>.briefing-prefix.txt\`
+record (the same file write-gate-context.mjs/verify-briefing-prefixes.mjs treat
+as authoritative) to read its bytes.
+
+Required:
+  --head-sha <sha>  The FULL 40- or 64-char reviewed head SHA (git rev-parse HEAD);
+                     dispatch-prompt records are read from
+                     tmp/checkpoint-dispatch-prompt-<scope>-<headSha>.json.
+Optional:
+  --tmp-root <path>  The tmp/ directory to read records/gate-context from (default: process.cwd()/tmp).
+Output (stdout, JSON):
+  { "ok": true, "verified": true, "headSha": "...", "recordCount": <n>, "reason"?: "no dispatch-prompt records found for this round" }
+  { "ok": true, "verified": false, "headSha": "...", "recordCount": <n>, "reason": "...", "misaligned": [{ "scope", "reason" }] }
+  On error (stderr, JSON):
+  { "ok": false, "error": "...", "usage": "..." }
+${JQ_OUTPUT_USAGE}
+Exit codes:
+  0  Verified: no dispatch-prompt records found for this round (progressive/optional
+     capture — a round the orchestrator has not yet been updated to capture never
+     newly blocks), OR every recorded prompt is aligned
+  1  Fail closed: at least one recorded prompt does not lead with the round's
+     byte-identical invariant prefix or pointer line, or a record's own
+     "prefixPath" basename no longer names a real on-disk gate-context record
+  2  Usage or internal error, or invalid --jq filter`.trim();
+
+const HEAD_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const RECORD_PREFIX = "checkpoint-dispatch-prompt-";
+const parseError = buildParseError(USAGE);
+
+function resolveFlagValue(argv, flag) {
+  const idx = argv.indexOf(flag);
+  if (idx === -1) return null;
+  const val = argv[idx + 1];
+  if (val === undefined || val === "" || (val.length > 0 && val[0] === "-")) return "";
+  return val;
+}
+
+/**
+ * Read every dispatch-prompt-layout record for this round (head SHA) from
+ * `<tmpRoot>/`. A malformed/unreadable record is still counted, with
+ * `leading: null` — downstream fails closed on it, deliberately (mirrors
+ * verify-briefing-prefixes.mjs's own malformed-sentinel posture): a corrupt
+ * record means the prompt-layout proof cannot be verified for that reviewer.
+ * @param {string} tmpRoot
+ * @param {string} headSha — lowercase hex, already validated
+ * @returns {Promise<Array<{ scope: string, prefixPath: string|null, leading: string|null }>>}
+ */
+async function readDispatchPromptRecords(tmpRoot, headSha) {
+  const suffix = `-${headSha}.json`;
+  let entries;
+  try {
+    entries = await readdir(tmpRoot, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+  const matches = entries
+    .filter((e) => e.isFile() && e.name.startsWith(RECORD_PREFIX) && e.name.endsWith(suffix))
+    .map((e) => ({ file: e.name, scope: e.name.slice(RECORD_PREFIX.length, -suffix.length) }))
+    .filter((m) => m.scope.length > 0)
+    .sort((a, b) => a.scope.localeCompare(b.scope));
+  const results = [];
+  for (const { file, scope } of matches) {
+    try {
+      const raw = await readFile(path.join(tmpRoot, file), "utf8");
+      const parsed = JSON.parse(raw);
+      const prefixPath = typeof parsed?.prefixPath === "string" && parsed.prefixPath.length > 0 ? parsed.prefixPath : null;
+      const leading = typeof parsed?.leading === "string" ? parsed.leading : null;
+      results.push({ scope, prefixPath, leading });
+    } catch {
+      results.push({ scope, prefixPath: null, leading: null });
+    }
+  }
+  return results;
+}
+
+/**
+ * Re-discover the REAL on-disk invariant-prefix bytes for `gate`/`headSha`
+ * under `<tmpRoot>/gate-context/**` (write-gate-context.mjs's
+ * `<gate>-<headSha>.briefing-prefix.txt`, the same record
+ * verify-briefing-prefixes.mjs treats as authoritative) — never the caller's
+ * stored path, so a dispatch-prompt record naming a stale/tampered directory
+ * can never smuggle in different ground-truth bytes. Returns `null` when no
+ * such record exists.
+ * @param {string} tmpRoot
+ * @param {string} gate
+ * @param {string} headSha — lowercase hex, already validated
+ * @returns {Promise<string|null>}
+ */
+async function findGateBriefingPrefixBytes(tmpRoot, gate, headSha) {
+  const root = path.join(tmpRoot, "gate-context");
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true, recursive: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+  const targetName = `${gate}-${headSha}.briefing-prefix.txt`;
+  const matches = entries
+    .filter((e) => e.isFile() && e.name === targetName)
+    .sort((a, b) => (a.parentPath ?? "").localeCompare(b.parentPath ?? ""));
+  if (matches.length === 0) return null;
+  const dir = matches[0].parentPath ?? root;
+  try {
+    return await readFile(path.join(dir, targetName), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure comparison over already-read records + already-read prefix bytes.
+ * Exported for direct unit testing without touching the filesystem.
+ *
+ * @param {Array<{ scope: string, prefixPath: string|null, leading: string|null }>} records
+ * @param {Map<string, string>} prefixBytesByPath — record's raw "prefixPath" string -> the RE-DISCOVERED real prefix bytes for its (gate, headSha)
+ * @returns {{ verified: boolean, reason?: string, misaligned?: Array<{scope:string, reason:string}> }}
+ */
+export function evaluateDispatchPromptLayout(records, prefixBytesByPath) {
+  if (records.length === 0) {
+    return { verified: true, reason: "no dispatch-prompt records found for this round" };
+  }
+  const misaligned = [];
+  for (const r of records) {
+    if (r.prefixPath === null || r.leading === null) {
+      misaligned.push({ scope: r.scope, reason: "dispatch-prompt record is missing/malformed (no recorded prefixPath or leading bytes) — never grandfathered in" });
+      continue;
+    }
+    const prefixBytes = prefixBytesByPath.get(r.prefixPath);
+    if (prefixBytes === undefined) {
+      misaligned.push({ scope: r.scope, reason: `recorded "prefixPath" ${JSON.stringify(r.prefixPath)} no longer names a real on-disk gate-context briefing-prefix record` });
+      continue;
+    }
+    const verdict = verifyPromptLeadingAlignment({ promptLeading: r.leading, prefixBytes, prefixPath: r.prefixPath });
+    if (!verdict.aligned) {
+      misaligned.push({ scope: r.scope, reason: verdict.reason });
+    }
+  }
+  if (misaligned.length > 0) {
+    return {
+      verified: false,
+      reason: `${misaligned.length} of ${records.length} dispatched reviewer prompt(s) for this round do not lead with the round's byte-identical invariant prefix or pointer line (GATE-EXEC-BRIEFING-PREFIX) — an angle-first prompt defeats cache alignment.`,
+      misaligned,
+    };
+  }
+  return { verified: true };
+}
+
+/**
+ * Programmatic entry: read this round's dispatch-prompt records, re-discover
+ * each record's REAL on-disk (gate, headSha) prefix bytes on disk (never the
+ * record's own stored path), and return the verdict
+ * `evaluateDispatchPromptLayout` produces. Used by `consolidate-fanin.mjs`
+ * (Phase 3 fan-in) alongside `verifyBriefingPrefixesForHead`.
+ * @param {string} tmpRoot
+ * @param {string} headSha — already lowercased/trimmed by the caller
+ * @returns {Promise<object>}
+ */
+export async function verifyDispatchPromptLayoutForHead(tmpRoot, headSha) {
+  const records = await readDispatchPromptRecords(tmpRoot, headSha);
+  const prefixBytesByPath = new Map();
+  for (const r of records) {
+    if (r.prefixPath === null || prefixBytesByPath.has(r.prefixPath)) continue;
+    const check = validateBriefingPrefixPath(r.prefixPath, headSha);
+    if (!check.ok) continue; // left unset -> evaluateDispatchPromptLayout fails closed on it
+    const bytes = await findGateBriefingPrefixBytes(tmpRoot, check.gate, headSha);
+    if (bytes !== null) prefixBytesByPath.set(r.prefixPath, bytes);
+  }
+  const verdict = evaluateDispatchPromptLayout(records, prefixBytesByPath);
+  return {
+    verified: verdict.verified,
+    headSha,
+    recordCount: records.length,
+    ...(verdict.reason ? { reason: verdict.reason } : {}),
+    ...(verdict.misaligned ? { misaligned: verdict.misaligned } : {}),
+  };
+}
+
+export async function main(argv = process.argv.slice(2), { tmpRoot = path.join(process.cwd(), "tmp") } = {}) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  const headShaArg = resolveFlagValue(argv, "--head-sha");
+  if (headShaArg === null || headShaArg === "" || !HEAD_SHA_RE.test(headShaArg)) {
+    process.stderr.write(`${formatCliError(parseError(`--head-sha is required and must be the FULL 40- or 64-character hex head SHA${headShaArg ? ` (got ${JSON.stringify(headShaArg)})` : ""}.`))}\n`);
+    return 2;
+  }
+  const headSha = headShaArg.toLowerCase();
+  const tmpRootArg = resolveFlagValue(argv, "--tmp-root");
+  if (tmpRootArg === "") {
+    process.stderr.write(`${formatCliError(parseError("Invalid --tmp-root value: must be non-empty."))}\n`);
+    return 2;
+  }
+  const resolvedTmpRoot = tmpRootArg ?? tmpRoot;
+  const jqArg = resolveFlagValue(argv, "--jq");
+  if (jqArg === "") {
+    process.stderr.write(`${formatCliError(parseError("Invalid --jq value: must be non-empty."))}\n`);
+    return 2;
+  }
+  const jq = jqArg === null ? undefined : jqArg;
+  const silent = argv.includes("--silent") || argv.includes("-s");
+
+  const verdict = await verifyDispatchPromptLayoutForHead(resolvedTmpRoot, headSha);
+  const payload = { ok: true, ...verdict };
+  return emitResult(payload, { jq, silent, ok: verdict.verified });
+}
+
+if (isDirectCliRun(import.meta.url)) {
+  try {
+    process.exitCode = await main();
+  } catch (err) {
+    process.stderr.write(`${formatCliError(err)}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/loop/consolidate-fanin.mjs
+++ b/scripts/loop/consolidate-fanin.mjs
@@ -61,6 +61,7 @@ import { GATE_NAMES } from "../github/_gate-names.mjs";
 import { normalizeCarriedAngleElements, parseCarriedAnglesJsonArray } from "../github/_carried-angles.mjs";
 import { isPostedCommentLimitError, normalizeStructuredFindings, renderStructuredFindings } from "../github/upsert-checkpoint-verdict.mjs";
 import { verifyBriefingPrefixesForHead } from "../github/verify-briefing-prefixes.mjs";
+import { verifyDispatchPromptLayoutForHead } from "../github/verify-dispatch-prompt-layout.mjs";
 import { loadDevLoopConfig, resolveGateAngleContract, resolveGateConfig } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
 import { FANIN_SYNTHETIC_ANGLES, SEVERITY_ORDER, VALID_SEVERITIES, baseAngleName, checkResolvedAngleEvidence, consolidateFanin, normalizeSeverity, severityRank, tallySeverities, toFindingsLogShape } from "@dev-loops/core/loop/gate-fanin";
@@ -199,6 +200,14 @@ Optional:
                                  GROUP reviewer, so this is the dispatch-UNIT count, NOT the per-angle
                                  artifact count — comparing against the angle count would false-fail
                                  every grouped round.
+                                 When --head-sha is given, the fan-in ALSO reads any
+                                 tmp/checkpoint-dispatch-prompt-<scope>-<headSha>.json records
+                                 (record-dispatch-prompt-layout.mjs) and FAILS CLOSED (exit 1) when a
+                                 recorded reviewer prompt does not LEAD with the round's
+                                 byte-identical invariant prefix or its byte-identical pointer line
+                                 (GATE-EXEC-BRIEFING-PREFIX layout, #1841/completes #1468) — an
+                                 angle-first prompt fails this mechanically. A round with no such
+                                 records is never newly blocked (progressive/optional capture).
   --primer-evidence <path>       The recorded primer-dispatch ordering evidence artifact
                                  (<gate>-<headSha>.primer-evidence.json, Phase 1.5 step 4) as JSON.
                                  Must be paired with --primer-plan (either flag alone fails closed at
@@ -285,8 +294,10 @@ Exit codes:
      malformed "carriedFromHead" (not a 7-64 char hex SHA), a round still over the
      render budget at minimum summary length with --ledger-out not given, or a
      GATE-EXEC-BRIEFING-PREFIX verification failure when --head-sha is given
-     (a sentinel records a divergent/missing prefix hash, or the sentinel count
-     is short of --expected-dispatch-units) — #1618, or (with --resolved-angles
+     (a sentinel records a divergent/missing prefix hash, the sentinel count
+     is short of --expected-dispatch-units, or a recorded reviewer prompt does
+     not lead with the round's byte-identical prefix/pointer line) — #1618,
+     #1841, or (with --resolved-angles
      and a "clean" verdict) a resolved angle with neither a per-angle artifact
      nor a proven carried-forward entry
   2  Invalid --jq filter`.trim();
@@ -1047,6 +1058,21 @@ export async function consolidateGateFanin(options) {
     if (options.expectedDispatchUnits !== undefined && prefixVerdict.reviewerCount > 0
         && prefixVerdict.reviewerCount < options.expectedDispatchUnits) {
       throw new Error(`GATE-EXEC-BRIEFING-PREFIX sentinel count (${prefixVerdict.reviewerCount}) is short of the expected dispatch-unit count (${options.expectedDispatchUnits}) for head ${options.headSha} — ${options.expectedDispatchUnits - prefixVerdict.reviewerCount} dispatched reviewer(s) never ran the fresh-context guard (no sentinel written). Re-run the missing reviewer(s), then re-consolidate.`);
+    }
+
+    // GATE-EXEC-BRIEFING-PREFIX dispatch-prompt LAYOUT (#1841, completes #1468):
+    // the hash checks above prove the recorded prefix is byte-identical across
+    // reviewers, but prove NOTHING about whether any reviewer's ACTUAL prompt
+    // LED with it. This reads the leading-bytes dispatch records
+    // record-dispatch-prompt-layout.mjs writes at fan-out and fails closed when
+    // a recorded prompt is angle-first (dynamic per-unit prose ahead of the
+    // invariant prefix/pointer line) instead of prefix-first. A round with NO
+    // dispatch-prompt records at all (the orchestrator has not yet been updated
+    // to capture them) is never newly blocked — progressive/optional capture,
+    // same posture as GATE-EXEC-PRIMER-EVIDENCE below.
+    const layoutVerdict = await verifyDispatchPromptLayoutForHead(tmpRoot, options.headSha);
+    if (layoutVerdict.recordCount > 0 && !layoutVerdict.verified) {
+      throw new Error(`GATE-EXEC-BRIEFING-PREFIX dispatch-prompt layout verification failed for head ${options.headSha} (${layoutVerdict.recordCount} dispatch-prompt record(s)): ${layoutVerdict.reason} — the fan-in refuses to consolidate a round whose reviewer prompt was not cache-aligned. Re-dispatch the offending reviewer(s) prefix-first, then re-consolidate.`);
     }
   }
 

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -579,6 +579,7 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
   operator decision per PR. Each reviewer:
 
 - starts in fresh context: run the mandatory `verify-fresh-review-context.mjs` invocation exactly as Phase 1 specifies. In the fan-out, `--scope` additionally keeps parallel reviewers in the same working directory from tripping false contamination on each other's sentinels, and `--context-path` (the Phase 1 artifact) fails a reviewer in the wrong/isolated checkout closed. A grouped reviewer runs this ONCE for the whole group, with `--scope <gate>-group-<name>` (below), not once per angle it covers. The sentinel is keyed per review ROUND by the current head SHA, so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle(s), and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
+- is composed prefix-first (`GATE-EXEC-BRIEFING-PREFIX`'s "Cache alignment" paragraph): right after composing its prompt (the same step as the `verify-fresh-review-context.mjs` call above), the orchestrator ALSO calls `scripts/github/record-dispatch-prompt-layout.mjs --scope <same scope> --head-sha <sha> --prefix-path <this round's invariant-prefix file path> --prompt-file <path to the ACTUAL composed prompt text>` to capture its leading bytes — the "Prompt-LAYOUT enforcement" paragraph under `GATE-EXEC-BRIEFING-PREFIX` above owns the full capture/verify contract; this is a rollout, not a precondition (a round that never captures is never newly blocked).
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when a covered angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph. When it widens, it records in the findings artifact's optional `contextWidened` field ONLY the files that actually moved its judgment, never every file it opened. Absence of `contextWidened` (or an empty one) means "not consulted" — never "consulted and clean"; carry-forward and audit logic MUST NOT infer clean-ness from that omission.
 - is scoped to exactly one review angle (one angle per unit under `mode: per-angle`, which bypasses configured groups; every angle in its resolved group (grouped mode, the default — including `gate:full`, which dispatches grouped) — each angle keeps its own prompt, all appended after the one shared invariant prefix (`GATE-EXEC-BRIEFING-PREFIX`)
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -783,6 +784,34 @@ closed. Only when no on-disk records exist (offline/legacy) does it fall back to
 rule that all of the round's sentinels share ONE identical hash. See
 `verify-briefing-prefixes.mjs --help` for the worked same-head two-gate example.
 
+**Prompt-LAYOUT enforcement (issue #1841, completes #1468).** Everything above proves the
+recorded prefix HASH is byte-identical across a round's sentinels — it proves nothing about
+whether any reviewer's ACTUAL dispatched prompt LED with those bytes, since the prompt is
+composed by the orchestrating agent at fan-out time with no code template. This closes that
+gap with a minimal capture point: right after composing each reviewer's prompt (the same
+fan-out step that already runs `verify-fresh-review-context.mjs`), call
+`scripts/github/record-dispatch-prompt-layout.mjs --scope <gate>-<angle-or-group> --head-sha
+<sha> --prefix-path <the invariant-prefix file path this reviewer's prompt was composed
+from/points at> --prompt-file <path to the ACTUAL composed prompt text>`. It captures the
+prompt's leading bytes (up to `DISPATCH_PROMPT_LEADING_CAP_BYTES`,
+`@dev-loops/core/loop/review-dispatch-plan`) to `tmp/checkpoint-dispatch-prompt-<scope>-<headSha>.json`.
+Before Phase 3 consolidation, the fan-in ALSO runs
+`scripts/github/verify-dispatch-prompt-layout.mjs --head-sha <sha>` (wired into
+`consolidate-fanin.mjs`'s own `--head-sha` block, alongside `verify-briefing-prefixes.mjs`),
+which fails closed (exit 1) when a recorded prompt's leading bytes do NOT match either: the
+round's byte-identical invariant prefix itself (inline mode), or the byte-identical pointer
+LINE naming the SAME prefix path, rendered by `renderBriefingPointerLine`
+(`@dev-loops/core/loop/review-dispatch-plan`) — the fixed line `verifyPromptLeadingAlignment`
+checks the leading bytes against under pointer-seeding mode, with the angle-specific text
+strictly AFTER it. An angle-first prompt (dynamic per-unit prose ahead of the prefix/pointer)
+matches neither and fails this mechanically, not only by prose review. Ground truth is ALWAYS
+re-discovered on disk from the round's real `<gate>-<headSha>.briefing-prefix.txt` record —
+never trusted from a captured record's own stored path — so a stale/tampered record can never
+smuggle in different bytes. A round with NO dispatch-prompt records at all is never newly
+blocked (progressive/optional capture, same posture as `GATE-EXEC-PRIMER-EVIDENCE` below): the
+orchestrator adopting this capture step is a rollout, not a precondition for every existing
+caller.
+
 <!-- rule: GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK -->
 `GATE-EXEC-FANOUT-SEQUENTIAL-FALLBACK`: Reviewers SHOULD run in parallel when practical; when parallel execution is impractical
 (for example due to tooling or resource constraints), the fan-out MUST run all reviewers
@@ -917,7 +946,12 @@ Before consolidating, `consolidate-fanin.mjs` itself runs
 had ZERO callers, so the rule's own cited proof was never invoked); a fail-closed
 result (mismatched or missing prefix hashes across this round's reviewer
 sentinels, or a sentinel count short of the dispatch units the conductor spawned)
-MUST stop the pass rather than proceed to consolidation. The conductor supplies
+MUST stop the pass rather than proceed to consolidation. In the SAME `--head-sha`
+block it ALSO runs `scripts/github/verify-dispatch-prompt-layout.mjs --head-sha
+<sha>` (issue #1841, completing #1468's own acceptance — see the "Prompt-LAYOUT
+enforcement" paragraph under `GATE-EXEC-BRIEFING-PREFIX` above), which fails
+closed on any recorded reviewer prompt that does not LEAD with the round's
+byte-identical invariant prefix or pointer line. The conductor supplies
 the expected dispatch-unit count via `--expected-dispatch-units <n>` (the Phase 1
 context artifact's `fanout.pendingGroups.length` — the dispatched dispatch-UNIT
 count, NOT `fanout.wavePlan.length`, which is the WAVE count, typically 1, not
@@ -1011,6 +1045,25 @@ plan hash is missing or mismatched. The refusal names the failing check
 `shared_prefix_hash` / `plan_hash`). This materially backs the `GATE-EXEC-PRIME`
 barrier: the primer write-before-read ordering is no longer asserted only in
 prose, but is a mechanically-checkable fail-closed input to consolidation.
+
+**Enforcement stays OPT-IN, not default-on (issue #1841, investigated as part of
+completing #1468).** `consolidate-fanin.mjs` validates this evidence ONLY when the
+conductor supplies both `--primer-evidence` and `--primer-plan`; a round that
+supplies neither proceeds unenforced, same as before. #1841 investigated flipping
+this to default-on and could NOT prove, within the shipped harness and without a
+live multi-reviewer dispatch to observe, that the Phase 1.5 primer measurably
+produces org+model content-hash cache reads on reviewers 2..N — `primer-evidence.mjs`'s
+own ordering/binding checks are deterministic and offline (timestamps, fingerprints),
+which proves ordering and request-fingerprint invariants but never MEASURES
+provider cache reuse itself (that measurement is `GATE-EXEC-CACHE-TELEMETRY`'s job,
+below, and it is ALSO opt-in for the same reason: no in-repo artifact yet records a
+real harness's cache-creation/cache-read token counts for a primed round). Flipping
+primer-evidence enforcement to default-on without that proof risked false-blocking a
+legitimately-primed fan-out on a harness/mechanism combination nobody had measured.
+Ship the dispatch-LAYOUT check above as unconditional (it needs no such proof — it
+verifies BYTES the orchestrator already controls, not provider-side cache behavior),
+and revisit this default once a real round's cache-telemetry evidence demonstrates
+the primer reliably produces reads on the shipped harness.
 
 <!-- rule: GATE-EXEC-CACHE-TELEMETRY -->
 `GATE-EXEC-CACHE-TELEMETRY`: when a round records cache-telemetry evidence

--- a/test/github/dispatch-prompt-layout.test.mjs
+++ b/test/github/dispatch-prompt-layout.test.mjs
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { renderBriefingPointerLine } from "@dev-loops/core/loop/review-dispatch-plan";
+import { evaluateDispatchPromptLayout, verifyDispatchPromptLayoutForHead } from "../../scripts/github/verify-dispatch-prompt-layout.mjs";
+import { validateBriefingPrefixPath, dispatchPromptLayoutRecordPath } from "../../scripts/github/record-dispatch-prompt-layout.mjs";
+
+const recordCliPath = path.resolve("scripts/github/record-dispatch-prompt-layout.mjs");
+const verifyCliPath = path.resolve("scripts/github/verify-dispatch-prompt-layout.mjs");
+
+function runRecordCli(args = [], opts = {}) {
+  return spawnSync("node", [recordCliPath, ...args], { encoding: "utf8", ...opts });
+}
+
+function runVerifyCli(args = [], opts = {}) {
+  return spawnSync("node", [verifyCliPath, ...args], { encoding: "utf8", ...opts });
+}
+
+async function withTmpDir(fn) {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-dispatch-prompt-layout-"));
+  try {
+    return await fn(tmpDir);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+const HEAD_SHA = "abc1234abc1234abc1234abc1234abc1234abc12";
+const GATE = "draft_gate";
+const PREFIX_BYTES = "## Invariant prefix\nrepo: o/r\nhead: abc\n";
+
+async function writeGateContextPrefix(tmpDir, headSha = HEAD_SHA, bytes = PREFIX_BYTES) {
+  const dir = path.join(tmpDir, "tmp", "gate-context", "o-r", "pr-1");
+  await mkdir(dir, { recursive: true });
+  const relPath = path.join("tmp", "gate-context", "o-r", "pr-1", `${GATE}-${headSha}.briefing-prefix.txt`);
+  await writeFile(path.join(tmpDir, relPath), bytes, "utf8");
+  return relPath;
+}
+
+// ---------------------------------------------------------------------------
+// Pure function: evaluateDispatchPromptLayout
+// ---------------------------------------------------------------------------
+
+test("evaluateDispatchPromptLayout: zero records is trivially verified (progressive/optional capture)", () => {
+  const result = evaluateDispatchPromptLayout([], new Map());
+  assert.equal(result.verified, true);
+  assert.match(result.reason, /no dispatch-prompt records/);
+});
+
+test("evaluateDispatchPromptLayout: a prefix-first (inline) record verifies", () => {
+  const prefixPath = "tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt";
+  const result = evaluateDispatchPromptLayout(
+    [{ scope: "draft-gate-coverage", prefixPath, leading: `${PREFIX_BYTES}## Angle: coverage\n` }],
+    new Map([[prefixPath, PREFIX_BYTES]]),
+  );
+  assert.equal(result.verified, true);
+});
+
+test("evaluateDispatchPromptLayout: REJECTS an angle-first record (dynamic prose ahead of the prefix)", () => {
+  const prefixPath = "tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt";
+  const result = evaluateDispatchPromptLayout(
+    [{ scope: "draft-gate-coverage", prefixPath, leading: `## Angle: coverage\n${PREFIX_BYTES}` }],
+    new Map([[prefixPath, PREFIX_BYTES]]),
+  );
+  assert.equal(result.verified, false);
+  assert.equal(result.misaligned.length, 1);
+  assert.equal(result.misaligned[0].scope, "draft-gate-coverage");
+});
+
+test("evaluateDispatchPromptLayout: a record with no matching prefix bytes fails closed", () => {
+  const result = evaluateDispatchPromptLayout(
+    [{ scope: "draft-gate-coverage", prefixPath: "does/not/exist.txt", leading: "anything" }],
+    new Map(),
+  );
+  assert.equal(result.verified, false);
+  assert.match(result.misaligned[0].reason, /no longer names a real on-disk/);
+});
+
+test("evaluateDispatchPromptLayout: a malformed record (null prefixPath/leading) fails closed, never grandfathered", () => {
+  const result = evaluateDispatchPromptLayout(
+    [{ scope: "draft-gate-coverage", prefixPath: null, leading: null }],
+    new Map(),
+  );
+  assert.equal(result.verified, false);
+  assert.match(result.misaligned[0].reason, /never grandfathered/);
+});
+
+test("evaluateDispatchPromptLayout: a pointer-mode record verifies against the byte-identical pointer line", () => {
+  const prefixPath = "tmp/gate-context/o-r/pr-1/draft_gate-abc.briefing-prefix.txt";
+  const pointerLine = renderBriefingPointerLine(prefixPath);
+  const result = evaluateDispatchPromptLayout(
+    [{ scope: "draft-gate-coverage", prefixPath, leading: `${pointerLine}\n## Angle: coverage\n` }],
+    new Map([[prefixPath, PREFIX_BYTES]]),
+  );
+  assert.equal(result.verified, true);
+});
+
+// ---------------------------------------------------------------------------
+// validateBriefingPrefixPath — basename-canonical naming guard (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+test("validateBriefingPrefixPath: accepts a canonical <gate>-<headSha>.briefing-prefix.txt basename", () => {
+  const check = validateBriefingPrefixPath(`tmp/gate-context/o-r/pr-1/${GATE}-${HEAD_SHA}.briefing-prefix.txt`, HEAD_SHA);
+  assert.equal(check.ok, true);
+  assert.equal(check.gate, GATE);
+});
+
+test("validateBriefingPrefixPath: rejects an unknown gate name", () => {
+  const check = validateBriefingPrefixPath(`tmp/gate-context/o-r/pr-1/not_a_gate-${HEAD_SHA}.briefing-prefix.txt`, HEAD_SHA);
+  assert.equal(check.ok, false);
+});
+
+test("validateBriefingPrefixPath: rejects a non-canonical basename (wrong head SHA)", () => {
+  const check = validateBriefingPrefixPath(`tmp/gate-context/o-r/pr-1/${GATE}-${HEAD_SHA}.briefing-prefix.txt`, "f".repeat(40));
+  assert.equal(check.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// verifyDispatchPromptLayoutForHead — programmatic fan-in entry
+// ---------------------------------------------------------------------------
+
+test("verifyDispatchPromptLayoutForHead: no records for the head -> verified (offline/legacy path unchanged)", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const result = await verifyDispatchPromptLayoutForHead(path.join(tmpDir, "tmp"), HEAD_SHA);
+    assert.equal(result.verified, true);
+    assert.equal(result.recordCount, 0);
+  });
+});
+
+test("verifyDispatchPromptLayoutForHead: reads a real record + real prefix file and verifies a prefix-first prompt", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const relPath = await writeGateContextPrefix(tmpDir);
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    await writeFile(
+      dispatchPromptLayoutRecordPath(path.join(tmpDir, "tmp"), "draft-gate-coverage", HEAD_SHA),
+      JSON.stringify({ scope: "draft-gate-coverage", headSha: HEAD_SHA, prefixPath: relPath, leading: `${PREFIX_BYTES}## Angle: coverage\n` }),
+    );
+    const result = await verifyDispatchPromptLayoutForHead(path.join(tmpDir, "tmp"), HEAD_SHA);
+    assert.equal(result.verified, true);
+    assert.equal(result.recordCount, 1);
+  });
+});
+
+test("verifyDispatchPromptLayoutForHead: fails closed on a real angle-first record", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const relPath = await writeGateContextPrefix(tmpDir);
+    await mkdir(path.join(tmpDir, "tmp"), { recursive: true });
+    await writeFile(
+      dispatchPromptLayoutRecordPath(path.join(tmpDir, "tmp"), "draft-gate-coverage", HEAD_SHA),
+      JSON.stringify({ scope: "draft-gate-coverage", headSha: HEAD_SHA, prefixPath: relPath, leading: `## Angle: coverage\n${PREFIX_BYTES}` }),
+    );
+    const result = await verifyDispatchPromptLayoutForHead(path.join(tmpDir, "tmp"), HEAD_SHA);
+    assert.equal(result.verified, false);
+    assert.equal(result.misaligned[0].scope, "draft-gate-coverage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: record-dispatch-prompt-layout.mjs
+// ---------------------------------------------------------------------------
+
+test("record-dispatch-prompt-layout.mjs --help exits 0", () => {
+  const result = runRecordCli(["--help"]);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /record-dispatch-prompt-layout/);
+});
+
+test("record-dispatch-prompt-layout.mjs writes a record readable back by the verifier and passes the round", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const relPath = await writeGateContextPrefix(tmpDir);
+    const promptFile = path.join(tmpDir, "prompt.txt");
+    await writeFile(promptFile, `${PREFIX_BYTES}## Angle: coverage\nDo the thing.`, "utf8");
+    const result = runRecordCli(
+      ["--scope", "draft-gate-coverage", "--head-sha", HEAD_SHA, "--prefix-path", relPath, "--prompt-file", promptFile],
+      { cwd: tmpDir },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.recorded, true);
+
+    const recordRaw = await readFile(dispatchPromptLayoutRecordPath(path.join(tmpDir, "tmp"), "draft-gate-coverage", HEAD_SHA), "utf8");
+    const record = JSON.parse(recordRaw);
+    assert.equal(record.prefixPath, relPath);
+    assert.equal(record.leading, `${PREFIX_BYTES}## Angle: coverage\nDo the thing.`);
+
+    const verifyResult = runVerifyCli(["--head-sha", HEAD_SHA], { cwd: tmpDir });
+    assert.equal(verifyResult.status, 0, verifyResult.stderr);
+    assert.equal(JSON.parse(verifyResult.stdout).verified, true);
+  });
+});
+
+test("record-dispatch-prompt-layout.mjs refuses (exit 1) a non-canonical --prefix-path basename", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const promptFile = path.join(tmpDir, "prompt.txt");
+    await writeFile(promptFile, "anything", "utf8");
+    const result = runRecordCli(
+      ["--scope", "draft-gate-coverage", "--head-sha", HEAD_SHA, "--prefix-path", "not-a-real-record.txt", "--prompt-file", promptFile],
+      { cwd: tmpDir },
+    );
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stdout).recorded, false);
+  });
+});
+
+test("record-dispatch-prompt-layout.mjs requires --scope/--head-sha/--prefix-path/--prompt-file", () => {
+  assert.equal(runRecordCli([]).status, 2);
+  assert.equal(runRecordCli(["--scope", "a"]).status, 2);
+});
+
+// ---------------------------------------------------------------------------
+// CLI: verify-dispatch-prompt-layout.mjs
+// ---------------------------------------------------------------------------
+
+test("verify-dispatch-prompt-layout.mjs --help exits 0", () => {
+  const result = runVerifyCli(["--help"]);
+  assert.equal(result.status, 0);
+});
+
+test("verify-dispatch-prompt-layout.mjs exits 0 with reviewerCount 0 when nothing is recorded", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const result = runVerifyCli(["--head-sha", HEAD_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.verified, true);
+    assert.equal(payload.recordCount, 0);
+  });
+});
+
+test("verify-dispatch-prompt-layout.mjs exits 1 (fails closed) on an angle-first dispatched prompt", async () => {
+  await withTmpDir(async (tmpDir) => {
+    const relPath = await writeGateContextPrefix(tmpDir);
+    const promptFile = path.join(tmpDir, "prompt.txt");
+    // Angle-first: dynamic per-unit prose BEFORE the invariant prefix.
+    await writeFile(promptFile, `## Angle: coverage\nDo the thing.\n${PREFIX_BYTES}`, "utf8");
+    const recordResult = runRecordCli(
+      ["--scope", "draft-gate-coverage", "--head-sha", HEAD_SHA, "--prefix-path", relPath, "--prompt-file", promptFile],
+      { cwd: tmpDir },
+    );
+    assert.equal(recordResult.status, 0, recordResult.stderr);
+
+    const result = runVerifyCli(["--head-sha", HEAD_SHA], { cwd: tmpDir });
+    assert.equal(result.status, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.verified, false);
+    assert.equal(payload.misaligned[0].scope, "draft-gate-coverage");
+  });
+});
+
+test("verify-dispatch-prompt-layout.mjs rejects a malformed --head-sha", () => {
+  const result = runVerifyCli(["--head-sha", "not-hex!"]);
+  assert.equal(result.status, 2);
+});

--- a/test/loop/consolidate-fanin.test.mjs
+++ b/test/loop/consolidate-fanin.test.mjs
@@ -14,7 +14,8 @@ import { normalizeStructuredFindings, renderGateReviewCommentBody } from "../../
 import { checkFanoutAngleCoverage } from "@dev-loops/core/loop/gate-fanin";
 import { buildCacheTelemetryEvidence } from "@dev-loops/core/loop/cache-telemetry-evidence";
 import { buildPrimerEvidence } from "@dev-loops/core/loop/primer-evidence";
-import { buildReviewDispatchPlan, CACHE_BOUNDARY_AFTER_SHARED_PREFIX, PRIMER_FORM_LEAD_REVIEWER } from "@dev-loops/core/loop/review-dispatch-plan";
+import { buildReviewDispatchPlan, CACHE_BOUNDARY_AFTER_SHARED_PREFIX, PRIMER_FORM_LEAD_REVIEWER, renderBriefingPointerLine } from "@dev-loops/core/loop/review-dispatch-plan";
+import { dispatchPromptLayoutRecordPath } from "../../scripts/github/record-dispatch-prompt-layout.mjs";
 import { runNode } from "../_helpers.mjs";
 
 // #1592: several fixtures below deliberately keep pre-rename severity
@@ -3182,6 +3183,136 @@ test("#1618 record-matching: a sentinel whose hash matches NO gate record fails 
           () => consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot }),
           (err) => err.message.includes("GATE-EXEC-BRIEFING-PREFIX") && /matches no gate briefing-prefix record/i.test(err.message),
         );
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #1841 (completes #1468): dispatch-prompt LAYOUT enforcement, wired into the
+// SAME --head-sha fan-in block as the GATE-EXEC-BRIEFING-PREFIX hash checks
+// above. The hash checks prove the recorded prefix is byte-identical; this
+// proves whether the reviewer's ACTUAL prompt led with it — an angle-first
+// prompt is caught mechanically here, not only documented.
+// ---------------------------------------------------------------------------
+
+async function writeDispatchPromptRecord(tmpRoot, scope, headSha, { prefixPath, leading }) {
+  await mkdir(tmpRoot, { recursive: true });
+  await writeFile(
+    dispatchPromptLayoutRecordPath(tmpRoot, scope, headSha),
+    JSON.stringify({ scope, headSha, prefixPath, leading }),
+  );
+}
+
+test("#1841 AC4: a head with no dispatch-prompt records still consolidates (offline/legacy path unchanged)", async () => {
+  await withFindingsDir(
+    { "scope.json": { angle: "scope", verdict: "clean", findings: [], headSha: HEAD_A } },
+    async (dir) => {
+      const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "consolidate-fanin-layout-"));
+      try {
+        const result = await consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot });
+        assert.equal(result.overallVerdict, "clean");
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+});
+
+test("#1841 AC1/AC2: a round whose dispatched reviewer prompt is prefix-first (inline) consolidates", async () => {
+  await withFindingsDir(
+    { "coverage.json": { angle: "coverage", verdict: "clean", findings: [], headSha: HEAD_A } },
+    async (dir) => {
+      const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "consolidate-fanin-layout-"));
+      try {
+        const bytes = "## Invariant prefix\nrepo: o/r\n";
+        await writeGateBriefingRecord(tmpRoot, "draft_gate", HEAD_A, bytes);
+        const prefixPath = path.join(tmpRoot, "gate-context", "mfittko-dev-loops", "pr-1646", `draft_gate-${HEAD_A}.briefing-prefix.txt`);
+        await writeDispatchPromptRecord(tmpRoot, "draft-gate-coverage", HEAD_A, {
+          prefixPath,
+          leading: `${bytes}## Angle: coverage\nDo the thing.`,
+        });
+        const result = await consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot });
+        assert.equal(result.overallVerdict, "clean");
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+});
+
+test("#1841 AC1/AC2: a round whose dispatched reviewer prompt leads with the byte-identical POINTER line consolidates", async () => {
+  await withFindingsDir(
+    { "coverage.json": { angle: "coverage", verdict: "clean", findings: [], headSha: HEAD_A } },
+    async (dir) => {
+      const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "consolidate-fanin-layout-"));
+      try {
+        const bytes = "## Invariant prefix\nrepo: o/r\n";
+        await writeGateBriefingRecord(tmpRoot, "draft_gate", HEAD_A, bytes);
+        const prefixPath = path.join(tmpRoot, "gate-context", "mfittko-dev-loops", "pr-1646", `draft_gate-${HEAD_A}.briefing-prefix.txt`);
+        const pointerLine = renderBriefingPointerLine(prefixPath);
+        await writeDispatchPromptRecord(tmpRoot, "draft-gate-coverage", HEAD_A, {
+          prefixPath,
+          leading: `${pointerLine}\n## Angle: coverage\nDo the thing.`,
+        });
+        const result = await consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot });
+        assert.equal(result.overallVerdict, "clean");
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+});
+
+test("#1841 AC1/AC2: fails closed when a dispatched reviewer prompt is ANGLE-FIRST (dynamic prose ahead of the invariant prefix)", async () => {
+  await withFindingsDir(
+    { "coverage.json": { angle: "coverage", verdict: "clean", findings: [], headSha: HEAD_A } },
+    async (dir) => {
+      const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "consolidate-fanin-layout-"));
+      try {
+        const bytes = "## Invariant prefix\nrepo: o/r\n";
+        await writeGateBriefingRecord(tmpRoot, "draft_gate", HEAD_A, bytes);
+        const prefixPath = path.join(tmpRoot, "gate-context", "mfittko-dev-loops", "pr-1646", `draft_gate-${HEAD_A}.briefing-prefix.txt`);
+        // Angle-first: dynamic per-unit prose BEFORE the invariant prefix.
+        await writeDispatchPromptRecord(tmpRoot, "draft-gate-coverage", HEAD_A, {
+          prefixPath,
+          leading: `## Angle: coverage\nDo the thing.\n${bytes}`,
+        });
+        await assert.rejects(
+          () => consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot }),
+          (err) => err.message.includes("GATE-EXEC-BRIEFING-PREFIX") && /do not lead with the round's byte-identical/.test(err.message),
+        );
+      } finally {
+        await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #1841 AC3: primer-evidence enforcement default decision. Investigation could
+// not prove (within the shipped harness, offline in this repo) that the Phase
+// 1.5 primer measurably produces provider cache reuse without a live
+// multi-reviewer dispatch to observe — so enforcement stays OPT-IN (unchanged):
+// the fan-in proceeds unchanged, primer evidence unenforced, when neither
+// --primer-evidence nor --primer-plan is given, even on a --head-sha round
+// that also passes the (now-enforced) dispatch-layout/prefix-hash checks.
+// This test pins that decision so a future default-on flip requires
+// deliberately breaking it, not silently drifting.
+// ---------------------------------------------------------------------------
+
+test("#1841 AC3: primer-evidence enforcement stays OPT-IN by default — a round with neither flag consolidates unenforced", async () => {
+  await withFindingsDir(
+    { "coverage.json": { angle: "coverage", verdict: "clean", findings: [], headSha: HEAD_A } },
+    async (dir) => {
+      const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "consolidate-fanin-primer-default-"));
+      try {
+        const hash = await writeGateBriefingRecord(tmpRoot, "draft_gate", HEAD_A, "invariant briefing bytes");
+        await writePrefixSentinel(tmpRoot, "draft-gate-coverage", HEAD_A, hash);
+        const result = await consolidateGateFanin({ findingsDir: dir, headSha: HEAD_A, tmpRoot });
+        assert.equal(result.overallVerdict, "clean");
       } finally {
         await rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
       }


### PR DESCRIPTION
Closes #1841

Enforce cache-aligned reviewer dispatch: add the machine check that was #1468's unmet acceptance. The cache machinery (prefix-first render, stable/volatile split, composeCacheAwareRequest, primer-evidence) was correct but two seams were unenforced; this adds teeth to the dispatch-layout one.

## What

- `record-dispatch-prompt-layout.mjs` captures the LEADING bytes of each dispatched reviewer's ACTUAL composed prompt at fan-out time (referencing the round's `<gate>-<headSha>.briefing-prefix.txt`).
- `verify-dispatch-prompt-layout.mjs` re-discovers the real on-disk prefix under `tmp/gate-context/**` (never trusting the record's stored path) and checks `verifyPromptLeadingAlignment` — inline byte-equality, or a byte-identical `renderBriefingPointerLine` match for pointer-seeding. An angle-first prompt (dynamic per-unit prose before the shared prefix/pointer) fails it.
- Wired into `consolidate-fanin.mjs`'s canonical `--head-sha` block alongside the existing prefix verification, failing closed when records exist and are misaligned. Progressive rollout: zero records = skip (no retroactive break).

## Primer default (AC3): kept opt-in

Flipping primer-evidence enforcement default-on was gated on proving the Phase 1.5 primer yields real provider-side cache reuse — not achievable without live cache telemetry from a multi-reviewer fan-out, and the offline validator can't substitute. Per the issue's explicit fallback, enforcement stays opt-in; the layout check ships unconditionally. Reasoning recorded on the issue and in `gate-review-sub-loop-contract.md`. The primer-default-on flip remains a #1468 backlog residual gated on a real measurement.

## Acceptance criteria

- [x] A machine check fails a gate fan-out whose reviewer prompt does not lead with the round's byte-identical invariant prefix: in inline mode the leading bytes must equal the recorded prefix; in pointer-seeding mode the leading content must be the byte-identical pointer line (same path, no per-reviewer/angle variance) with the angle-specific prompt strictly as a suffix. `verify-dispatch-prompt-layout.mjs` extends the prefix-file check to "reviewer prompt is prefix-aligned"; an angle-first prompt fails it.
- [x] The check is wired into the canonical fan-in / gate-evidence path (`consolidate-fanin.mjs`'s `--head-sha` block) so a non-cache-aligned dispatch is caught, not just documented.
- [x] Primer-evidence enforcement default decided per the issue's gated fallback: default-on could not be proven safe without live multi-reviewer cache telemetry, so enforcement stays opt-in and only the dispatch-layout check ships unconditionally, with the reasoning recorded on the issue and in `gate-review-sub-loop-contract.md`.
- [x] Tests pin: an angle-first reviewer prompt is rejected by the layout check (inline and pointer mode), a prefix/pointer-first prompt passes, the fan-in wiring fails closed on a misaligned record, and the opt-in primer default is pinned.

## Definition of done

- [x] All AC checked.
- [x] `npm run verify` green (core 2853, scripts 4259, extension 126, assets 290/290, pack, dev-loop 38, docs, workflows).
- [x] `npm run assets:check` clean (90).
- [x] 27 new/updated tests added covering the layout check, fan-in wiring, and primer-default pin.
- [x] #1468's unmet acceptance (cache-aware dispatch actually enforced) re-evaluated: with the layout check now machine-enforced, #1468 can be honestly closed or its residuals re-scoped; the primer-default-on flip is tracked as that residual.

## Non-goals

- No rewrite of the primer / stable-volatile / composeCacheAwareRequest machinery (shipped in #1474/#1475); this adds enforcement teeth, not new mechanism.
- No change to the accepted pointer-vs-inline seeding trade-off beyond enforcing the pointer-line-first, byte-identical invariant.
- No change to reviewer angles, personas, or gate semantics.
- No flip of primer-evidence enforcement to default-on in this PR — that requires live multi-reviewer cache-reuse proof and remains a tracked #1468 residual.

## Verification

- `npm run verify` green (core 2853, scripts 4259, extension 126, assets 290/290, pack, dev-loop 38, docs, workflows); `npm run assets:check` clean (90).
- 27 new/updated tests: angle-first prompt REJECTED (inline + pointer mode), prefix/pointer-first PASS, the fan-in wiring fails closed on a misaligned record, and the opt-in primer default is pinned.
