### PR TITLE
feat(gate): inline a filtered diff into the composer's shared per-head block + gate-tooling hygiene sweep

### DIFF
--- a/.claude/skills/docs/gate-review-sub-loop-contract.md
+++ b/.claude/skills/docs/gate-review-sub-loop-contract.md
@@ -579,7 +579,7 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
   operator decision per PR. Each reviewer:
 
 - starts in fresh context: run the mandatory `verify-fresh-review-context.mjs` invocation exactly as Phase 1 specifies. In the fan-out, `--scope` additionally keeps parallel reviewers in the same working directory from tripping false contamination on each other's sentinels, and `--context-path` (the Phase 1 artifact) fails a reviewer in the wrong/isolated checkout closed. A grouped reviewer runs this ONCE for the whole group, with `--scope <gate>-group-<name>` (below), not once per angle it covers. The sentinel is keyed per review ROUND by the current head SHA, so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle(s), and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
-- is composed via the sanctioned composer (`GATE-EXEC-BRIEFING-PREFIX`'s "The composer" paragraph): the same step that runs `verify-fresh-review-context.mjs` (above) ALSO runs `scripts/github/compose-reviewer-prompt.mjs --repo <repo> --pr <n> --gate <gate> --head-sha <sha> --scope <same scope> --angle-suffix-file <path to the group's authored angle-specific prompt text>`, which inlines this round's invariant-prefix bytes as the leading bytes, appends the volatile tail and the angle suffix, writes the composed prompt, and records its dispatch-prompt layout ATOMICALLY (no separate `record-dispatch-prompt-layout.mjs` call needed on this path — the composer already made it). The orchestrator then delivers the composer's `--out` file bytes to the reviewer per the "Per-harness delivery" paragraph above. Hand-composing a prompt and calling `record-dispatch-prompt-layout.mjs` directly against it remains possible as the underlying primitive, but is no longer the sanctioned fan-out path.
+- is composed via the sanctioned composer (`GATE-EXEC-BRIEFING-PREFIX`'s "The composer" paragraph): the same step that runs `verify-fresh-review-context.mjs` (above) ALSO runs `scripts/github/compose-reviewer-prompt.mjs --repo <repo> --pr <n> --gate <gate> --head-sha <sha> --scope <same scope> --angle-suffix-file <path to the group's authored angle-specific prompt text>`, which inlines this round's invariant-prefix bytes as the leading bytes, appends the volatile tail and the angle suffix, writes the composed prompt, and records its dispatch-prompt layout ATOMICALLY (no separate `record-dispatch-prompt-layout.mjs` call needed on this path — the composer already made it). The orchestrator then delivers the composer's `--out` file bytes to the reviewer per the "Per-harness delivery" paragraph below. Hand-composing a prompt and calling `record-dispatch-prompt-layout.mjs` directly against it remains possible as the underlying primitive, but is no longer the sanctioned fan-out path.
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when a covered angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph. When it widens, it records in the findings artifact's optional `contextWidened` field ONLY the files that actually moved its judgment, never every file it opened. Absence of `contextWidened` (or an empty one) means "not consulted" — never "consulted and clean"; carry-forward and audit logic MUST NOT infer clean-ness from that omission.
 - is scoped to exactly one review angle (one angle per unit under `mode: per-angle`, which bypasses configured groups; every angle in its resolved group (grouped mode, the default — including `gate:full`, which dispatches grouped) — each angle keeps its own prompt, all appended after the one shared invariant prefix (`GATE-EXEC-BRIEFING-PREFIX`)
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -740,7 +740,17 @@ structured data (label + body pairs), never pre-joined into one string, so the r
 itself — not any one issue's body — owns emitting each `### <label>` heading, outside every
 fence. Every fence delimiter (`pickFence`) is sized one backtick longer than the longest
 backtick run already inside the text it wraps, so the wrapped content can never close the
-fence early and leak into a later section. The diff SHOULD be inlined up to a size cap
+fence early and leak into a later section. The diff is FILTERED before inlining (issue
+#1853, `filterDiffForInline` in `@dev-loops/core/loop/review-dispatch-plan`): lockfiles
+(`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `Gemfile.lock`,
+`composer.lock`, and `*-lock.y[a]ml` generally), generated/vendored trees (`dist/`, `lib/`,
+`coverage/`, `node_modules/`, `.claude/`), and any caller-configured `excludeGlobs` are
+dropped whole-file (`DEFAULT_DIFF_EXCLUDE_GLOBS`, always applied — a caller's own globs
+layer on top, never replace it) — high-churn/not-review-relevant hunks never dilute the
+shared per-head block. An excluded file's CHANGE still appears in the "Changed files"
+summary and stays fully readable on demand from the FULL, unfiltered `scope.diffPath`
+pointer file (never itself filtered) or `git diff` in the reviewed worktree; only the
+INLINED copy is narrowed. The (filtered) diff SHOULD then be inlined up to a size cap
 (`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`, a fixed constant), carried inside a fenced
 markdown block sized by the same `pickFence` rule — the fence and surrounding framing are
 part of the rendered prefix bytes, so "inline" means the diff content travels in the
@@ -1516,8 +1526,8 @@ If findings with a severity in the gate's `blockCleanOnFindingSeverities` list a
   is, like every non-high body-filed finding, deferred by construction at post time per
   `GATE-EXEC-DEFERRAL-RECORD` — the answered/never-deferred contract applies only to a locatable
   question's own resolvable thread, which is the only surface an answer reply can land on. A nit
-  is deferred immediately at round 1, with no fixer cycle on the severity axis (judge-acted
-  nits excepted). Two layers
+  is resolved-with-rationale immediately at round 1, never filed, with no fixer cycle on the
+  severity axis (judge-acted nits excepted). Two layers
   govern this, and they stay distinct: the LEDGER verdict is `clean` whenever
   no finding at a blocking severity remains, computed from `blockCleanOnFindingSeverities` alone
   and never from an open medium thread; an unresolved in-window locatable

--- a/packages/core/src/loop/review-dispatch-plan.mjs
+++ b/packages/core/src/loop/review-dispatch-plan.mjs
@@ -763,30 +763,6 @@ export function renderBriefingPointerLine(prefixPath) {
 }
 
 /**
- * Decide whether a dispatched reviewer prompt's LEADING bytes are
- * cache-aligned (GATE-EXEC-BRIEFING-PREFIX layout, issue #1841): either the
- * prompt's leading bytes are byte-identical to the round's invariant prefix
- * (inline mode), or the prompt leads with the byte-identical pointer line
- * naming the round's invariant-prefix path (pointer-seeding mode), with any
- * angle-specific text strictly AFTER it. An angle-first prompt (dynamic
- * per-unit prose ahead of the prefix/pointer) matches neither and is
- * REJECTED — this is the mechanical proof the prose-only rule lacked.
- *
- * Pure and offline: takes the already-captured leading bytes and the already-
- * read prefix bytes/path, never reads a file itself (the CLI wrapper owns
- * I/O), so this is directly unit-testable with in-memory strings.
- *
- * @param {object} input
- * @param {string} input.promptLeading — the captured leading bytes of the
- *   ACTUAL reviewer prompt (record-dispatch-prompt-layout.mjs's capture).
- * @param {string} input.prefixBytes — the round's recorded byte-identical
- *   invariant-prefix content (the `<gate>-<headSha>.briefing-prefix.txt`
- *   bytes).
- * @param {string} input.prefixPath — the path used to render this round's
- *   pointer line (must be the SAME path every reviewer was pointed at).
- * @returns {{ aligned: boolean, mode: "inline"|"pointer"|null, reason: string|null }}
- */
-/**
  * Deterministically compose a full reviewer prompt: the round's
  * byte-identical invariant prefix INLINED as the leading bytes, followed by
  * the (also round-invariant) volatile tail, followed by the per-group angle
@@ -829,6 +805,30 @@ export function composeReviewerPromptText({ prefixBytes, volatileBytes, angleSuf
   return prefixBytes + volatile + angleSuffix;
 }
 
+/**
+ * Decide whether a dispatched reviewer prompt's LEADING bytes are
+ * cache-aligned (GATE-EXEC-BRIEFING-PREFIX layout, issue #1841): either the
+ * prompt's leading bytes are byte-identical to the round's invariant prefix
+ * (inline mode), or the prompt leads with the byte-identical pointer line
+ * naming the round's invariant-prefix path (pointer-seeding mode), with any
+ * angle-specific text strictly AFTER it. An angle-first prompt (dynamic
+ * per-unit prose ahead of the prefix/pointer) matches neither and is
+ * REJECTED — this is the mechanical proof the prose-only rule lacked.
+ *
+ * Pure and offline: takes the already-captured leading bytes and the already-
+ * read prefix bytes/path, never reads a file itself (the CLI wrapper owns
+ * I/O), so this is directly unit-testable with in-memory strings.
+ *
+ * @param {object} input
+ * @param {string} input.promptLeading — the captured leading bytes of the
+ *   ACTUAL reviewer prompt (record-dispatch-prompt-layout.mjs's capture).
+ * @param {string} input.prefixBytes — the round's recorded byte-identical
+ *   invariant-prefix content (the `<gate>-<headSha>.briefing-prefix.txt`
+ *   bytes).
+ * @param {string} input.prefixPath — the path used to render this round's
+ *   pointer line (must be the SAME path every reviewer was pointed at).
+ * @returns {{ aligned: boolean, mode: "inline"|"pointer"|null, reason: string|null }}
+ */
 export function verifyPromptLeadingAlignment({ promptLeading, prefixBytes, prefixPath } = {}) {
   const leading = typeof promptLeading === "string" ? promptLeading : "";
   if (typeof prefixBytes === "string" && prefixBytes.length > 0 && leading.startsWith(prefixBytes)) {
@@ -845,4 +845,190 @@ export function verifyPromptLeadingAlignment({ promptLeading, prefixBytes, prefi
     mode: null,
     reason: "reviewer prompt does not LEAD with the round's byte-identical invariant prefix (inline mode) or its byte-identical pointer line (pointer-seeding mode) — an angle-first prompt (dynamic per-unit prose ahead of the prefix/pointer) defeats prefix matching (GATE-EXEC-BRIEFING-PREFIX)",
   };
+}
+
+/* ------------------------------------------------------------------ *
+ * 7. Diff filtering for the shared per-head block (issue #1853)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Default excluded path patterns for the diff INLINED into a reviewer
+ * prompt's shared per-head block: lockfiles (high-churn, not
+ * review-relevant — the file's CHANGE is still listed in the changed-files
+ * summary, only its hunk text is dropped from the inlined diff) and common
+ * generated/vendored trees. ALWAYS applied on top of any caller-supplied
+ * `excludeGlobs` in {@link filterDiffForInline} — never replaced by it, so a
+ * project-specific config gap can't silently un-exclude a lockfile. A file
+ * excluded here is not deleted from the repo or the diff on disk; it stays
+ * readable on demand (`git diff -- <path>` in the reviewed worktree, or the
+ * full unfiltered `.diff` pointer file), only not inlined by default.
+ *
+ * Glob subset: `**\/` matches zero-or-more whole path segments, a lone `**`
+ * matches any suffix, a single `*` matches within one path segment only —
+ * see {@link matchesDiffExcludeGlob}.
+ */
+export const DEFAULT_DIFF_EXCLUDE_GLOBS = Object.freeze([
+  // Lockfiles.
+  "package-lock.json", "**/package-lock.json",
+  "npm-shrinkwrap.json", "**/npm-shrinkwrap.json",
+  "yarn.lock", "**/yarn.lock",
+  "pnpm-lock.yaml", "**/pnpm-lock.yaml",
+  "*-lock.yaml", "**/*-lock.yaml",
+  "*-lock.yml", "**/*-lock.yml",
+  "Cargo.lock", "**/Cargo.lock",
+  "Gemfile.lock", "**/Gemfile.lock",
+  "composer.lock", "**/composer.lock",
+  // Generated/vendored trees.
+  "dist/**", "**/dist/**",
+  "lib/**", "**/lib/**",
+  "coverage/**", "**/coverage/**",
+  "node_modules/**", "**/node_modules/**",
+  ".claude/**", "**/.claude/**",
+]);
+
+function escapeDiffGlobLiteral(ch) {
+  return /[.*+?^${}()|[\]\\]/.test(ch) ? `\\${ch}` : ch;
+}
+
+const diffGlobPatternCache = new Map();
+
+/**
+ * Minimal shell-glob subset compiler (mirrors the established pattern used
+ * elsewhere in this repo for config-driven path patterns): `**\/` matches
+ * zero-or-more whole path segments, a lone `**` matches any suffix
+ * (including `/`), a single `*` matches within one path segment only,
+ * everything else is literal. No glob dependency is installed in this repo
+ * and none of the callers need more than this subset.
+ * @param {string} relPath — POSIX-normalized repo-relative path
+ * @param {string} pattern
+ * @returns {boolean}
+ */
+export function matchesDiffExcludeGlob(relPath, pattern) {
+  if (typeof relPath !== "string" || typeof pattern !== "string" || pattern.length === 0) return false;
+  let compiled = diffGlobPatternCache.get(pattern);
+  if (!compiled) {
+    let re = "";
+    for (let i = 0; i < pattern.length; i++) {
+      const ch = pattern[i];
+      if (ch === "*" && pattern[i + 1] === "*") {
+        if (pattern[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 2;
+        } else {
+          re += ".*";
+          i += 1;
+        }
+      } else if (ch === "*") {
+        re += "[^/]*";
+      } else {
+        re += escapeDiffGlobLiteral(ch);
+      }
+    }
+    compiled = new RegExp(`^${re}$`);
+    diffGlobPatternCache.set(pattern, compiled);
+  }
+  return compiled.test(relPath);
+}
+
+/**
+ * Classify why a diff file is excluded from inlining, or `null` when it
+ * should be inlined. Checks {@link DEFAULT_DIFF_EXCLUDE_GLOBS} first, then
+ * any caller-supplied `excludeGlobs` — the default set can never be
+ * disabled by a caller's config.
+ * @param {string} relPath
+ * @param {{ excludeGlobs?: string[] }} [opts]
+ * @returns {"default"|"configured"|null}
+ */
+export function classifyDiffFileExclusion(relPath, { excludeGlobs = [] } = {}) {
+  const posix = String(relPath).replace(/\\/g, "/");
+  for (const pattern of DEFAULT_DIFF_EXCLUDE_GLOBS) {
+    if (matchesDiffExcludeGlob(posix, pattern)) return "default";
+  }
+  for (const pattern of excludeGlobs) {
+    if (matchesDiffExcludeGlob(posix, pattern)) return "configured";
+  }
+  return null;
+}
+
+/**
+ * Extract a diff file-block's resulting path. Prefers the `+++ b/<path>`
+ * line (present for every non-deletion block), falls back to `--- a/<path>`
+ * (deletions), then to the `diff --git a/X b/Y` header's second token. This
+ * is a best-effort extraction for FILTERING purposes only (unlike a
+ * content-fidelity transform, a path this misses just fails open to
+ * "inlined" — never mis-drops a file), so it does not attempt full
+ * git-quoted-path decoding (rare: a path containing a quote/control
+ * byte/non-ASCII byte under core.quotePath) — see
+ * `scripts/github/write-gate-context.mjs`'s `decodeGitDiffPathToken` for
+ * that fuller decode if this ever needs it.
+ * @param {string[]} blockLines
+ * @returns {string|null}
+ */
+function extractDiffBlockPath(blockLines) {
+  for (const line of blockLines) {
+    if (line.startsWith("+++ ") && !line.includes("/dev/null")) {
+      return line.slice(4).trim().replace(/^[abiwco]\//, "");
+    }
+  }
+  for (const line of blockLines) {
+    if (line.startsWith("--- ") && !line.includes("/dev/null")) {
+      return line.slice(4).trim().replace(/^[abiwco]\//, "");
+    }
+  }
+  const header = blockLines[0] ?? "";
+  const m = /^diff --git \S+ (\S+)$/.exec(header);
+  return m ? m[1].replace(/^[abiwco]\//, "") : null;
+}
+
+/**
+ * Filter a unified diff (`git diff` output) down to the files that should be
+ * INLINED into a reviewer prompt's shared per-head block (issue #1853):
+ * lockfiles, generated/vendored trees, and any caller-configured
+ * `excludeGlobs` are dropped whole-file (header + all hunks), every other
+ * file's block passes through byte-for-byte unchanged. Excluding a file here
+ * only affects what this function returns — it never touches the diff on
+ * disk or in the reviewed worktree, so an excluded file stays readable on
+ * demand.
+ *
+ * Pure and offline: string in, string out, no I/O — the caller (currently
+ * `write-gate-context.mjs`, before rendering the invariant prefix) supplies
+ * already-captured diff text.
+ *
+ * @param {string} diffText — `git diff` output (or `""`/absent).
+ * @param {{ excludeGlobs?: string[] }} [opts] — additional exclude globs,
+ *   layered on top of {@link DEFAULT_DIFF_EXCLUDE_GLOBS} (never replacing it).
+ * @returns {{ filteredDiff: string, excludedFiles: Array<{path: string, reason: "default"|"configured"}>, includedFiles: string[] }}
+ */
+export function filterDiffForInline(diffText, { excludeGlobs = [] } = {}) {
+  if (typeof diffText !== "string" || diffText.length === 0) {
+    return { filteredDiff: typeof diffText === "string" ? diffText : "", excludedFiles: [], includedFiles: [] };
+  }
+  const lines = diffText.split("\n");
+  const blockStarts = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("diff --git ")) blockStarts.push(i);
+  }
+  // No recognizable `diff --git` file boundary — not a shape this filter
+  // understands; pass through unfiltered rather than guess.
+  if (blockStarts.length === 0) {
+    return { filteredDiff: diffText, excludedFiles: [], includedFiles: [] };
+  }
+  const keptChunks = [];
+  const excludedFiles = [];
+  const includedFiles = [];
+  if (blockStarts[0] > 0) keptChunks.push(lines.slice(0, blockStarts[0]).join("\n"));
+  for (let b = 0; b < blockStarts.length; b++) {
+    const start = blockStarts[b];
+    const end = b + 1 < blockStarts.length ? blockStarts[b + 1] : lines.length;
+    const blockLines = lines.slice(start, end);
+    const relPath = extractDiffBlockPath(blockLines);
+    const reason = relPath ? classifyDiffFileExclusion(relPath, { excludeGlobs }) : null;
+    if (reason) {
+      excludedFiles.push({ path: relPath, reason });
+    } else {
+      if (relPath) includedFiles.push(relPath);
+      keptChunks.push(blockLines.join("\n"));
+    }
+  }
+  return { filteredDiff: keptChunks.join("\n"), excludedFiles, includedFiles };
 }

--- a/packages/core/test/review-dispatch-plan.test.mjs
+++ b/packages/core/test/review-dispatch-plan.test.mjs
@@ -24,6 +24,10 @@ import {
   composeReviewerPromptText,
   renderBriefingPointerLine,
   verifyPromptLeadingAlignment,
+  DEFAULT_DIFF_EXCLUDE_GLOBS,
+  classifyDiffFileExclusion,
+  filterDiffForInline,
+  matchesDiffExcludeGlob,
 } from "../src/loop/review-dispatch-plan.mjs";
 
 describe("normalizeHarnessCapabilities — explicit capability model (Section D)", () => {
@@ -902,5 +906,139 @@ describe("verifyPromptLeadingAlignment — GATE-EXEC-BRIEFING-PREFIX layout chec
 
   test("DISPATCH_PROMPT_LEADING_CAP_BYTES is comfortably above the 200 KiB inline-diff cap", () => {
     assert.ok(DISPATCH_PROMPT_LEADING_CAP_BYTES > 200 * 1024);
+  });
+});
+
+describe("matchesDiffExcludeGlob / classifyDiffFileExclusion — diff-inline exclude patterns (issue #1853)", () => {
+  test("literal filename pattern matches only that exact path", () => {
+    assert.equal(matchesDiffExcludeGlob("package-lock.json", "package-lock.json"), true);
+    assert.equal(matchesDiffExcludeGlob("packages/app/package-lock.json", "package-lock.json"), false);
+  });
+
+  test("**/ prefix matches the same basename at any depth, including the root", () => {
+    assert.equal(matchesDiffExcludeGlob("package-lock.json", "**/package-lock.json"), true);
+    assert.equal(matchesDiffExcludeGlob("packages/app/package-lock.json", "**/package-lock.json"), true);
+  });
+
+  test("a single * matches within one path segment only", () => {
+    assert.equal(matchesDiffExcludeGlob("dist/foo.js", "dist/*.js"), true);
+    assert.equal(matchesDiffExcludeGlob("dist/nested/foo.js", "dist/*.js"), false);
+    assert.equal(matchesDiffExcludeGlob("dist/nested/foo.js", "dist/**"), true);
+  });
+
+  test("classifyDiffFileExclusion: DEFAULT_DIFF_EXCLUDE_GLOBS covers common lockfiles + generated trees", () => {
+    for (const p of ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "npm-shrinkwrap.json", "packages/core/package-lock.json"]) {
+      assert.equal(classifyDiffFileExclusion(p), "default", p);
+    }
+    for (const p of ["dist/index.js", "node_modules/x/index.js", ".claude/agents/foo.md"]) {
+      assert.equal(classifyDiffFileExclusion(p), "default", p);
+    }
+  });
+
+  test("classifyDiffFileExclusion: a review-relevant source file is never classified", () => {
+    assert.equal(classifyDiffFileExclusion("packages/core/src/loop/review-dispatch-plan.mjs"), null);
+  });
+
+  test("classifyDiffFileExclusion: a caller excludeGlobs entry is 'configured', layered on top of the default set (never replacing it)", () => {
+    assert.equal(classifyDiffFileExclusion("dist/index.js"), "default"); // still excluded even with no excludeGlobs
+    assert.equal(classifyDiffFileExclusion("vendor/generated.rb", { excludeGlobs: ["vendor/**"] }), "configured");
+    assert.equal(classifyDiffFileExclusion("package-lock.json", { excludeGlobs: [] }), "default");
+  });
+
+  test("DEFAULT_DIFF_EXCLUDE_GLOBS is frozen and non-empty", () => {
+    assert.ok(Object.isFrozen(DEFAULT_DIFF_EXCLUDE_GLOBS));
+    assert.ok(DEFAULT_DIFF_EXCLUDE_GLOBS.length > 0);
+  });
+});
+
+describe("filterDiffForInline — filtered diff for the shared per-head block (issue #1853)", () => {
+  const SRC_HUNK = [
+    "diff --git a/src/foo.mjs b/src/foo.mjs",
+    "index 1111111..2222222 100644",
+    "--- a/src/foo.mjs",
+    "+++ b/src/foo.mjs",
+    "@@ -1,2 +1,2 @@",
+    "-old line",
+    "+new line",
+    " context",
+  ].join("\n");
+  const LOCKFILE_HUNK = [
+    "diff --git a/package-lock.json b/package-lock.json",
+    "index 3333333..4444444 100644",
+    "--- a/package-lock.json",
+    "+++ b/package-lock.json",
+    "@@ -1,3 +1,3 @@",
+    '-  "version": "1.0.0",',
+    '+  "version": "1.0.1",',
+    " other",
+  ].join("\n");
+  const DIFF_WITH_LOCKFILE = `${SRC_HUNK}\n${LOCKFILE_HUNK}\n`;
+
+  test("AC1: strips a lockfile's hunk out of the diff entirely", () => {
+    const { filteredDiff, excludedFiles, includedFiles } = filterDiffForInline(DIFF_WITH_LOCKFILE);
+    assert.ok(!filteredDiff.includes("package-lock.json"));
+    assert.ok(!filteredDiff.includes('"version": "1.0.1"'));
+    assert.ok(filteredDiff.includes("src/foo.mjs"));
+    assert.ok(filteredDiff.includes("new line"));
+    assert.deepEqual(excludedFiles, [{ path: "package-lock.json", reason: "default" }]);
+    assert.deepEqual(includedFiles, ["src/foo.mjs"]);
+  });
+
+  test("a non-excluded file's block passes through byte-for-byte unchanged", () => {
+    const { filteredDiff } = filterDiffForInline(SRC_HUNK);
+    assert.equal(filteredDiff, SRC_HUNK);
+  });
+
+  test("a diff excluding every file collapses to an empty filteredDiff (no dangling separators)", () => {
+    const { filteredDiff, excludedFiles } = filterDiffForInline(LOCKFILE_HUNK);
+    assert.equal(filteredDiff, "");
+    assert.equal(excludedFiles.length, 1);
+  });
+
+  test("an absent/empty diff passes through as empty, never throws", () => {
+    assert.deepEqual(filterDiffForInline(null), { filteredDiff: "", excludedFiles: [], includedFiles: [] });
+    assert.deepEqual(filterDiffForInline(""), { filteredDiff: "", excludedFiles: [], includedFiles: [] });
+  });
+
+  test("configured excludeGlobs additionally excludes a project-specific path, on top of the defaults", () => {
+    const vendorHunk = [
+      "diff --git a/vendor/generated.rb b/vendor/generated.rb",
+      "--- a/vendor/generated.rb",
+      "+++ b/vendor/generated.rb",
+      "@@ -1 +1 @@",
+      "-a",
+      "+b",
+    ].join("\n");
+    const combined = `${SRC_HUNK}\n${vendorHunk}\n`;
+    const { filteredDiff, excludedFiles } = filterDiffForInline(combined, { excludeGlobs: ["vendor/**"] });
+    assert.ok(!filteredDiff.includes("vendor/generated.rb"));
+    assert.ok(filteredDiff.includes("src/foo.mjs"));
+    assert.deepEqual(excludedFiles, [{ path: "vendor/generated.rb", reason: "configured" }]);
+  });
+
+  test("AC4: the filtered diff, once inlined into a shared prefix, is byte-identical across the round's reviewers regardless of angle suffix", () => {
+    const { filteredDiff } = filterDiffForInline(DIFF_WITH_LOCKFILE);
+    const prefixBytes = `## Invariant prefix\nrepo: o/r\nhead: abc\n\n## Diff at reviewed head (abc)\n\n${filteredDiff}\n`;
+    const volatileBytes = "# volatile tail\n";
+    const coverage = composeReviewerPromptText({ prefixBytes, volatileBytes, angleSuffix: "## Angle: coverage" });
+    const security = composeReviewerPromptText({ prefixBytes, volatileBytes, angleSuffix: "## Angle: security, a longer suffix" });
+    const sharedSpan = prefixBytes + volatileBytes;
+    assert.equal(coverage.slice(0, sharedSpan.length), sharedSpan);
+    assert.equal(security.slice(0, sharedSpan.length), sharedSpan);
+    assert.ok(coverage.slice(0, sharedSpan.length).includes(filteredDiff));
+  });
+
+  test("AC4: ordering is static (prefix header) -> filtered-diff -> suffix in the composed prompt", () => {
+    const { filteredDiff } = filterDiffForInline(DIFF_WITH_LOCKFILE);
+    const staticHeader = "## Invariant prefix\nrepo: o/r\nhead: abc\n";
+    const prefixBytes = `${staticHeader}\n## Diff at reviewed head (abc)\n\n${filteredDiff}\n`;
+    const composed = composeReviewerPromptText({ prefixBytes, angleSuffix: "## Angle: coverage\nDo the thing." });
+    const staticIdx = composed.indexOf(staticHeader);
+    const diffIdx = composed.indexOf(filteredDiff);
+    const suffixIdx = composed.indexOf("## Angle: coverage");
+    assert.ok(staticIdx === 0);
+    assert.ok(diffIdx > staticIdx, "filtered diff must sit after the static leading span");
+    assert.ok(suffixIdx > diffIdx, "the per-group suffix must sit after the filtered diff");
+    assert.ok(!composed.includes("package-lock.json"), "an excluded file's hunk never reaches the composed prompt");
   });
 });

--- a/scripts/github/close-gate-findings.mjs
+++ b/scripts/github/close-gate-findings.mjs
@@ -152,7 +152,7 @@ function detectContractViolatingDeferredStamps(threads, login, round, mediumFixW
     const details = violations
       .map((v) => `thread ${v.threadId} (comment ${v.commentId}): severity=${v.severity} at round=${v.round} (mediumFixWindow=${v.mediumFixWindow}) carries disposition=deferred, reason=${v.reason}${v.issue ? ` (issue=${v.issue})` : ""}`)
       .join("; ");
-    throw new Error(`GATE-EXEC-THREAD-DISPOSITION violation: ${violations.length} gate-authored thread(s) carry a contract-violating disposition=deferred stamp (${details}). A question must be answered (never deferred), an in-window medium (round ≤ mediumFixWindow) must stay unresolved to force a fix round, and every disposition=deferred stamp must link a follow-up issue number. Refuse to proceed with the disposition pass.`);
+    throw new Error(`GATE-EXEC-THREAD-DISPOSITION violation: ${violations.length} gate-authored thread(s) carry a contract-violating disposition=deferred stamp (${details}). A question must be answered (never deferred), a nit must never be stamped deferred (resolved-with-rationale instead, never filed), a low must carry operatorVisible=true on its own marker before it may be stamped deferred (otherwise resolved-with-rationale, never filed), an in-window medium (round ≤ mediumFixWindow) must stay unresolved to force a fix round, and every disposition=deferred stamp must link a follow-up issue number. Refuse to proceed with the disposition pass.`);
   }
 }
 

--- a/scripts/github/compose-reviewer-prompt.mjs
+++ b/scripts/github/compose-reviewer-prompt.mjs
@@ -71,7 +71,7 @@ Output (stdout, JSON):
   { "ok": true, "composed": true, "recorded": true, "scope": "...", "headSha": "...", "gate": "...", "promptPath": "...", "prefixPath": "...", "promptLength": <n>, "truncated": false }
   { "ok": true, "composed": false, "reason": "..." }
   On error (stderr, JSON):
-  { "ok": false, "error": "...", "usage": "..." }
+  { "ok": false, "error": "...", "hint"?: "run with --help for usage" }
 ${JQ_OUTPUT_USAGE}
 Exit codes:
   0  Composed and recorded

--- a/scripts/github/record-dispatch-prompt-layout.mjs
+++ b/scripts/github/record-dispatch-prompt-layout.mjs
@@ -57,7 +57,7 @@ Output (stdout, JSON):
   { "ok": true, "recorded": true, "scope": "...", "headSha": "...", "prefixPath": "...", "truncated": false }
   { "ok": true, "recorded": false, "reason": "..." }
   On error (stderr, JSON):
-  { "ok": false, "error": "...", "usage": "..." }
+  { "ok": false, "error": "...", "hint"?: "run with --help for usage" }
 ${JQ_OUTPUT_USAGE}
 Exit codes:
   0  Recorded
@@ -200,6 +200,15 @@ export async function main(argv = process.argv.slice(2), { tmpRootDefault = path
   const jq = jqArg === null ? undefined : jqArg;
   const silent = argv.includes("--silent") || argv.includes("-s");
   const finish = (payload, ok) => emitResult(payload, { jq, silent, ok });
+
+  // Fail fast on a non-canonical --prefix-path BEFORE reading --prompt-file:
+  // recordDispatchPromptLayout would reject this exact input anyway, but
+  // only after the (possibly large) prompt-file read below — checking here
+  // first means a bad basename refuses instantly, no wasted I/O.
+  const pathCheck = validateBriefingPrefixPath(prefixPathArg, headSha);
+  if (!pathCheck.ok) {
+    return finish({ ok: true, recorded: false, scope, headSha, reason: pathCheck.reason }, false);
+  }
 
   let promptText;
   try {

--- a/scripts/github/write-gate-context.mjs
+++ b/scripts/github/write-gate-context.mjs
@@ -37,7 +37,7 @@ import { parseArgs } from "node:util";
 import { GATE_ANGLE_SCOPES, GATE_FULL_LABEL, loadDevLoopConfig, resolveFanoutGroups, resolveFanoutMaxConcurrent, resolveFanoutSequential, resolveFanoutEffectiveConcurrency, resolveGateAngleContract, resolveGateAngleScope, resolveGateAngles, resolveGateAnglesDynamic, resolveMaxAnglesPerGroup, resolveRoleModel } from "@dev-loops/core/config";
 import { angleReviewSurface } from "@dev-loops/core/loop/gate-carry-forward";
 import { baseAngleName, reviewerBudgetPreflight, scheduleFanoutWaves } from "@dev-loops/core/loop/gate-fanin";
-import { buildAngleRequestGroups, buildReviewDispatchPlan, normalizeHarnessCapabilities } from "@dev-loops/core/loop/review-dispatch-plan";
+import { buildAngleRequestGroups, buildReviewDispatchPlan, filterDiffForInline, normalizeHarnessCapabilities } from "@dev-loops/core/loop/review-dispatch-plan";
 import { classifyFile } from "@dev-loops/core/analysis/diff-analyzer";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { detectIssueRefinementArtifact } from "@dev-loops/core/loop/issue-refinement-artifact";
@@ -2200,6 +2200,17 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
     }
     prefixMode = "file";
   } else {
+    // Issue #1853: the diff INLINED into the invariant prefix (and its
+    // scoped "changed-files" variant below) is FILTERED — lockfiles,
+    // generated/vendored trees, and any --diff-exclude-glob configured here
+    // are dropped whole-file, so a lockfile-heavy diff no longer dominates
+    // the shared per-head block. The FULL, unfiltered diff stays persisted
+    // at options.diffPath (scope.diffPath) — an excluded file remains
+    // readable on demand from there, or via `git diff` in the reviewed
+    // worktree; only the INLINED copy is narrowed.
+    const inlineDiffOutput = typeof options.diffOutput === "string" && options.diffOutput.length > 0
+      ? filterDiffForInline(options.diffOutput, { excludeGlobs: options.diffExcludeGlobs ?? [] }).filteredDiff
+      : (options.diffOutput ?? null);
     const rendered = renderBriefingPrefix({
       repo: options.repo,
       pr: options.pr,
@@ -2212,7 +2223,7 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
       issueRef: options.acceptanceCriteria ?? null,
       issueBody: options.issueBody ?? null,
       issueSections: options.issueSections ?? null,
-      diffOutput: options.diffOutput ?? null,
+      diffOutput: inlineDiffOutput,
       diffPath: options.diffPath ?? null,
       changedFiles: options.changedFiles ?? [],
       adjacentCode: options.adjacentCode ?? null,
@@ -2247,7 +2258,7 @@ export async function writeGateContext(options, { repoRoot = process.cwd() } = {
           issueRef: options.acceptanceCriteria ?? null,
           issueBody: options.issueBody ?? null,
           issueSections: options.issueSections ?? null,
-          diffOutput: options.diffOutput ?? null,
+          diffOutput: inlineDiffOutput,
           diffPath: options.diffPath ?? null,
           validationResultsPath: options.validationResultsPath ?? null,
         });

--- a/scripts/github/write-gate-findings-log.mjs
+++ b/scripts/github/write-gate-findings-log.mjs
@@ -27,6 +27,7 @@ Required:
                                  explicit signal close-gate-findings.mjs's disposition pass requires before filing a "low"
                                  to the PR's tracked follow-up issue; absent/false is the conservative default (resolved
                                  in-thread, never filed). A "nit" is never filed regardless of operatorVisible.
+                                 operatorVisible on any OTHER severity fails closed (exit 2) — it has no meaning there.
   --findings-file <path>         Read the --findings JSON array from a file instead of an inline argument
                                  (mutually exclusive with --findings; identical validation)
 Optional:
@@ -135,6 +136,14 @@ function validateFindingsArray(parsed, flagLabel) {
     if ("operatorVisible" in f) {
       if (typeof f.operatorVisible !== "boolean") {
         throw parseError(`${flagLabel}[${i}].operatorVisible must be a boolean`);
+      }
+      // Fail closed rather than accept-and-ignore: operatorVisible only has
+      // meaning for a "low" finding (the net-reduction disposition policy's
+      // signal close-gate-findings.mjs requires before filing a low) — setting
+      // it on any other severity is a caller error the ledger must not
+      // silently swallow.
+      if (f.severity !== "low") {
+        throw parseError(`${flagLabel}[${i}].operatorVisible is only meaningful for a "low" finding (got severity ${JSON.stringify(f.severity)})`);
       }
       entry.operatorVisible = f.operatorVisible;
     }

--- a/skills/docs/gate-review-sub-loop-contract.md
+++ b/skills/docs/gate-review-sub-loop-contract.md
@@ -579,7 +579,7 @@ what left no per-angle evidence artifacts on disk for the fan-in. Concretely:
   operator decision per PR. Each reviewer:
 
 - starts in fresh context: run the mandatory `verify-fresh-review-context.mjs` invocation exactly as Phase 1 specifies. In the fan-out, `--scope` additionally keeps parallel reviewers in the same working directory from tripping false contamination on each other's sentinels, and `--context-path` (the Phase 1 artifact) fails a reviewer in the wrong/isolated checkout closed. A grouped reviewer runs this ONCE for the whole group, with `--scope <gate>-group-<name>` (below), not once per angle it covers. The sentinel is keyed per review ROUND by the current head SHA, so a retry at a new head naturally gets a fresh sentinel — see [Sentinel lifecycle](#sentinel-lifecycle). Here "fresh" means the reviewer's context is the neutral builder artifact + its angle(s), and explicitly NOT the main agent's conversation/state or a prior reviewer session's state: the injected neutral bundle is the intended seed (allowed), while main-agent / cross-session state bleed fails closed.
-- is composed via the sanctioned composer (`GATE-EXEC-BRIEFING-PREFIX`'s "The composer" paragraph): the same step that runs `verify-fresh-review-context.mjs` (above) ALSO runs `scripts/github/compose-reviewer-prompt.mjs --repo <repo> --pr <n> --gate <gate> --head-sha <sha> --scope <same scope> --angle-suffix-file <path to the group's authored angle-specific prompt text>`, which inlines this round's invariant-prefix bytes as the leading bytes, appends the volatile tail and the angle suffix, writes the composed prompt, and records its dispatch-prompt layout ATOMICALLY (no separate `record-dispatch-prompt-layout.mjs` call needed on this path — the composer already made it). The orchestrator then delivers the composer's `--out` file bytes to the reviewer per the "Per-harness delivery" paragraph above. Hand-composing a prompt and calling `record-dispatch-prompt-layout.mjs` directly against it remains possible as the underlying primitive, but is no longer the sanctioned fan-out path.
+- is composed via the sanctioned composer (`GATE-EXEC-BRIEFING-PREFIX`'s "The composer" paragraph): the same step that runs `verify-fresh-review-context.mjs` (above) ALSO runs `scripts/github/compose-reviewer-prompt.mjs --repo <repo> --pr <n> --gate <gate> --head-sha <sha> --scope <same scope> --angle-suffix-file <path to the group's authored angle-specific prompt text>`, which inlines this round's invariant-prefix bytes as the leading bytes, appends the volatile tail and the angle suffix, writes the composed prompt, and records its dispatch-prompt layout ATOMICALLY (no separate `record-dispatch-prompt-layout.mjs` call needed on this path — the composer already made it). The orchestrator then delivers the composer's `--out` file bytes to the reviewer per the "Per-harness delivery" paragraph below. Hand-composing a prompt and calling `record-dispatch-prompt-layout.mjs` directly against it remains possible as the underlying primitive, but is no longer the sanctioned fan-out path.
 - is seeded with the neutral context bundle verbatim (diff + `adjacentCode`) as its base, and widens (loads more files) only when a covered angle genuinely needs more — it does not re-derive the whole diff/adjacent-code graph. When it widens, it records in the findings artifact's optional `contextWidened` field ONLY the files that actually moved its judgment, never every file it opened. Absence of `contextWidened` (or an empty one) means "not consulted" — never "consulted and clean"; carry-forward and audit logic MUST NOT infer clean-ness from that omission.
 - is scoped to exactly one review angle (one angle per unit under `mode: per-angle`, which bypasses configured groups; every angle in its resolved group (grouped mode, the default — including `gate:full`, which dispatches grouped) — each angle keeps its own prompt, all appended after the one shared invariant prefix (`GATE-EXEC-BRIEFING-PREFIX`)
 - is **read-only**: inspects the diff and returns findings via output artifacts only; never edits files
@@ -740,7 +740,17 @@ structured data (label + body pairs), never pre-joined into one string, so the r
 itself — not any one issue's body — owns emitting each `### <label>` heading, outside every
 fence. Every fence delimiter (`pickFence`) is sized one backtick longer than the longest
 backtick run already inside the text it wraps, so the wrapped content can never close the
-fence early and leak into a later section. The diff SHOULD be inlined up to a size cap
+fence early and leak into a later section. The diff is FILTERED before inlining (issue
+#1853, `filterDiffForInline` in `@dev-loops/core/loop/review-dispatch-plan`): lockfiles
+(`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `Gemfile.lock`,
+`composer.lock`, and `*-lock.y[a]ml` generally), generated/vendored trees (`dist/`, `lib/`,
+`coverage/`, `node_modules/`, `.claude/`), and any caller-configured `excludeGlobs` are
+dropped whole-file (`DEFAULT_DIFF_EXCLUDE_GLOBS`, always applied — a caller's own globs
+layer on top, never replace it) — high-churn/not-review-relevant hunks never dilute the
+shared per-head block. An excluded file's CHANGE still appears in the "Changed files"
+summary and stays fully readable on demand from the FULL, unfiltered `scope.diffPath`
+pointer file (never itself filtered) or `git diff` in the reviewed worktree; only the
+INLINED copy is narrowed. The (filtered) diff SHOULD then be inlined up to a size cap
 (`BRIEFING_PREFIX_INLINE_DIFF_CAP_BYTES`, a fixed constant), carried inside a fenced
 markdown block sized by the same `pickFence` rule — the fence and surrounding framing are
 part of the rendered prefix bytes, so "inline" means the diff content travels in the
@@ -1516,8 +1526,8 @@ If findings with a severity in the gate's `blockCleanOnFindingSeverities` list a
   is, like every non-high body-filed finding, deferred by construction at post time per
   `GATE-EXEC-DEFERRAL-RECORD` — the answered/never-deferred contract applies only to a locatable
   question's own resolvable thread, which is the only surface an answer reply can land on. A nit
-  is deferred immediately at round 1, with no fixer cycle on the severity axis (judge-acted
-  nits excepted). Two layers
+  is resolved-with-rationale immediately at round 1, never filed, with no fixer cycle on the
+  severity axis (judge-acted nits excepted). Two layers
   govern this, and they stay distinct: the LEDGER verdict is `clean` whenever
   no finding at a blocking severity remains, computed from `blockCleanOnFindingSeverities` alone
   and never from an open medium thread; an unresolved in-window locatable

--- a/test/github/close-gate-findings.test.mjs
+++ b/test/github/close-gate-findings.test.mjs
@@ -1022,7 +1022,10 @@ test("#1846 guard: a disposition=deferred stamp on a nit thread is rejected (nit
     async ({ env, ghCommand, repoRoot }) => {
       await assert.rejects(
         () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
-        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=nit.*reason=out-of-window/s,
+        // #1853 hygiene: the error message itself names the nit rejection
+        // case (diagnosable without cross-referencing the code), in addition
+        // to the per-thread detail already asserted.
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=nit.*reason=out-of-window.*a nit must never be stamped deferred/s,
       );
     },
   ));
@@ -1040,7 +1043,9 @@ test("#1846 guard: a disposition=deferred stamp on a NON-operator-visible low th
     async ({ env, ghCommand, repoRoot }) => {
       await assert.rejects(
         () => closeGateFindings({ ledgerPath }, { env, ghCommand, repoRoot }),
-        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=low.*reason=out-of-window/s,
+        // #1853 hygiene: the error message names the low/operatorVisible
+        // rejection case explicitly, in addition to the per-thread detail.
+        /GATE-EXEC-THREAD-DISPOSITION violation.*severity=low.*reason=out-of-window.*a low must carry operatorVisible=true/s,
       );
     },
   ));

--- a/test/github/dispatch-prompt-layout.test.mjs
+++ b/test/github/dispatch-prompt-layout.test.mjs
@@ -206,6 +206,22 @@ test("record-dispatch-prompt-layout.mjs refuses (exit 1) a non-canonical --prefi
   });
 });
 
+test("record-dispatch-prompt-layout.mjs validates --prefix-path BEFORE reading --prompt-file (fail-fast: an unreadable --prompt-file never masks a bad --prefix-path)", () => {
+  const result = runRecordCli([
+    "--scope", "draft-gate-coverage", "--head-sha", HEAD_SHA,
+    "--prefix-path", "not-a-real-record.txt",
+    // A nonexistent --prompt-file: if the CLI read it BEFORE validating
+    // --prefix-path, the reason would report an unreadable prompt-file
+    // instead of the (earlier, real) prefix-path defect.
+    "--prompt-file", "/nonexistent/path/does-not-exist.txt",
+  ]);
+  assert.equal(result.status, 1);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.recorded, false);
+  assert.match(payload.reason, /canonical/);
+  assert.doesNotMatch(payload.reason, /unreadable/);
+});
+
 test("record-dispatch-prompt-layout.mjs requires --scope/--head-sha/--prefix-path/--prompt-file", () => {
   assert.equal(runRecordCli([]).status, 2);
   assert.equal(runRecordCli(["--scope", "a"]).status, 2);

--- a/test/github/write-gate-context.test.mjs
+++ b/test/github/write-gate-context.test.mjs
@@ -2615,6 +2615,92 @@ test("buildGateContext omits the Linked issue section for an issue-less PR (no c
 });
 
 // ---------------------------------------------------------------------------
+// Filtered-diff inlining into the shared per-head block (issue #1853)
+// ---------------------------------------------------------------------------
+
+test("buildGateContext: a lockfile's hunk is filtered out of the inlined diff, but the file still appears in the changed-files summary and stays fully readable at scope.diffPath", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-diff-filter-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const diff = {
+      nameStatusOutput: "M\tsrc/a.mjs\nM\tpackage-lock.json\n",
+      diffOutput: [
+        "diff --git a/src/a.mjs b/src/a.mjs",
+        "--- a/src/a.mjs",
+        "+++ b/src/a.mjs",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new line in a.mjs",
+        "diff --git a/package-lock.json b/package-lock.json",
+        "--- a/package-lock.json",
+        "+++ b/package-lock.json",
+        "@@ -1 +1 @@",
+        '-  "version": "1.0.0"',
+        '+  "version": "1.0.1"',
+        "",
+      ].join("\n"),
+    };
+    const result = await buildGateContext(
+      { config, gate: "draft_gate", diff, repo: "owner/repo", pr: 53, headSha: "1234567890abcdef" },
+      { repoRoot },
+    );
+    assert.equal(result.artifact.prefixMode, "inline");
+    const onDisk = await readFile(path.resolve(repoRoot, result.prefixPath), "utf8");
+
+    // AC1: the lockfile hunk is dropped from the inlined diff.
+    assert.ok(onDisk.includes("new line in a.mjs"), "the review-relevant hunk still inlines");
+    assert.ok(!onDisk.includes('"version": "1.0.1"'), "the lockfile hunk body is filtered out");
+    assert.ok(!onDisk.includes("diff --git a/package-lock.json"), "the lockfile's diff header is filtered out");
+
+    // AC3: the file's CHANGE is still disclosed (changed-files summary), and
+    // the FULL unfiltered diff (including the lockfile hunk) stays available
+    // on demand at scope.diffPath — filtering only narrows what's INLINED.
+    assert.ok(onDisk.includes("- package-lock.json"), "the changed-files summary still lists the lockfile");
+    const fullDiskDiff = await readFile(path.resolve(repoRoot, result.artifact.scope.diffPath), "utf8");
+    assert.ok(fullDiskDiff.includes('"version": "1.0.1"'), "the persisted .diff pointer target stays FULL/unfiltered");
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildGateContext: AC2 — the static-only leading span (before the diff section) is unchanged by a diff-content change", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "gate-context-diff-static-span-"));
+  try {
+    const config = draftConfig({ dynamicAngles: false });
+    const baseInput = {
+      config, gate: "draft_gate", repo: "owner/repo", pr: 54, headSha: "abcdef1234567890",
+      prBody: "Same PR body", acceptanceCriteria: "#7", issueBody: "Same issue body",
+    };
+    const diffA = { nameStatusOutput: "M\tsrc/a.mjs\n", diffOutput: "diff --git a/src/a.mjs b/src/a.mjs\n+first version\n" };
+    const diffB = {
+      nameStatusOutput: "M\tsrc/a.mjs\nM\tyarn.lock\n",
+      diffOutput: "diff --git a/src/a.mjs b/src/a.mjs\n+SECOND, DIFFERENT version\ndiff --git a/yarn.lock b/yarn.lock\n+lockfile churn\n",
+    };
+    const resultA = await buildGateContext({ ...baseInput, diff: diffA }, { repoRoot });
+    const onDiskA = await readFile(path.resolve(repoRoot, resultA.prefixPath), "utf8");
+    const resultB = await buildGateContext({ ...baseInput, diff: diffB }, { repoRoot });
+    const onDiskB = await readFile(path.resolve(repoRoot, resultB.prefixPath), "utf8");
+
+    const diffHeadingIdx = onDiskA.indexOf("## Diff at reviewed head");
+    assert.ok(diffHeadingIdx > 0);
+    assert.equal(onDiskB.indexOf("## Diff at reviewed head"), diffHeadingIdx, "the diff heading sits at the same offset regardless of diff content");
+    const staticSpanA = onDiskA.slice(0, diffHeadingIdx);
+    const staticSpanB = onDiskB.slice(0, diffHeadingIdx);
+    assert.equal(staticSpanA, staticSpanB, "the static-only leading span (header/PR-body/issue-body) is byte-identical across a diff content change");
+
+    // Ordering (AC2/AC4): the filtered diff sits strictly AFTER the static
+    // span and BEFORE the changed-files summary; the lockfile hunk in diffB
+    // never reaches the rendered prefix.
+    const summaryIdx = onDiskB.indexOf("## Changed files + adjacent-code summary");
+    const diffContentIdx = onDiskB.indexOf("SECOND, DIFFERENT version");
+    assert.ok(diffHeadingIdx < diffContentIdx && diffContentIdx < summaryIdx);
+    assert.ok(!onDiskB.includes("lockfile churn"));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Dogfood round-trip (#1220 AC4): real gate-pass shape — build via the CLI,
 // two reviewer sentinels via --prefix-file, fan-in verify — verified:true.
 // Reuses verify-fresh-review-context.mjs / verify-briefing-prefixes.mjs UNCHANGED.

--- a/test/github/write-gate-findings-log.test.mjs
+++ b/test/github/write-gate-findings-log.test.mjs
@@ -445,6 +445,32 @@ test("writeGateFindingsLog rejects a non-boolean operatorVisible", async () => {
   }, /operatorVisible must be a boolean/);
 });
 
+test("writeGateFindingsLog fails closed on operatorVisible set for a non-'low' severity (accepted-but-ignored is loose; #1853 hygiene)", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{ severity: "medium", angle: "naming", summary: "x", operatorVisible: true }]),
+    });
+  }, /operatorVisible is only meaningful for a "low" finding/);
+});
+
+test("writeGateFindingsLog fails closed on operatorVisible: false for a non-'low' severity too (the key's mere presence is the signal, not just true)", async () => {
+  await assert.rejects(async () => {
+    await writeGateFindingsLog({
+      repo: "a/b",
+      pr: 1,
+      gate: "draft_gate",
+      headSha: "abc1234500000000000000000000000000000000",
+      verdict: "findings_present",
+      findings: JSON.stringify([{ severity: "nit", angle: "naming", summary: "x", operatorVisible: false }]),
+    });
+  }, /operatorVisible is only meaningful for a "low" finding/);
+});
+
 test("writeGateFindingsLog rejects malformed repo format in buildLogPath", async () => {
   await assert.rejects(async () => {
     await writeGateFindingsLog({


### PR DESCRIPTION
Closes #1853

Direct follow-up to the composer (#1852): inline a FILTERED diff into the shared per-head block so reviewers no longer re-ingest the full diff as a separate per-agent file, and it can share the round's prompt-prefix span. Framed as per-reviewer read-size reduction (in a code-driven harness it also feeds cross-reviewer reuse).

## What

- `filterDiffForInline` (pure, in `review-dispatch-plan.mjs`): strips whole file blocks for lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `*-lock.y[a]ml`, `Cargo.lock`, `Gemfile.lock`, `composer.lock`), generated dirs (`dist/`, `lib/`, `coverage/`, `node_modules/`, `.claude/`), plus caller `excludeGlobs`. Applied in `write-gate-context.mjs` at the existing diff-inlining insertion point.
- Placement: static-only leading span (header/PR-body/issue-body) → `## Diff at reviewed head` (now filtered) → changed-files summary → composer volatile + per-group suffix. The static leading span is byte-identical regardless of diff content (pinned), and [static + filtered-diff] is byte-identical across the round's reviewers.
- On-demand preserved: the FULL unfiltered diff stays at `scope.diffPath`, and the changed-files summary still names excluded files, so a reviewer that needs one reads it on demand. Only the inlined copy is narrowed.

## Folded-in hygiene sweep (tracked on the issue)

usage-envelope text fix (compose-reviewer-prompt), detached `verifyPromptLeadingAlignment` JSDoc, `record-dispatch-prompt-layout` validate-prefix-before-read (fail-fast), `gate-review-sub-loop-contract.md:1519` nit-contract line + one inverted directional reference, `write-gate-findings-log` fail-closed on `operatorVisible` for a non-`low`, and `close-gate-findings`'s contract-violation error message now names the nit/low-without-ov cases.

## Acceptance criteria

- [x] The composer inlines a FILTERED diff (lockfiles/generated/configured-exclude paths removed) into the shared per-head block of every reviewer prompt; the filter set is explicit and documented.
- [x] The filtered diff sits AFTER the static invariant contract span and BEFORE the per-group suffix; the static span remains byte-identical across rounds (cross-round cache preserved) and [static + filtered-diff] is byte-identical across the round's reviewers.
- [x] On the canonical path reviewers no longer read the diff as a separate per-agent file; an excluded file remains readable on demand.
- [x] Tests pin: the filter removes lockfiles; the inlined diff is byte-identical across a round's reviewers; the static-only leading span is unchanged by a diff change (cross-round span stable); ordering is static → filtered-diff → suffix.

## Definition of done

- [x] All AC checked.
- [x] `npm run verify` green (core 2873, scripts 4326, all suites).
- [x] `npm run assets:check` clean.
- [x] Docs link validation green.

## Non-goals

- Not changing which files the review ANGLES analyze — only what is inlined by default vs read on demand.
- Not the composer itself (#1852) — this extends it to the diff tier.

## Verification

- `npm run verify` green (core 2873, scripts 4326, all suites); `npm run assets:check` clean.
- Tests pin: the filter removes lockfiles; the static leading span is unchanged across a diff-content change; [static+filtered-diff] byte-identical across a round's reviewers; ordering static → filtered-diff → suffix at both the pure composer and the write-gate-context integration level.

