### PR TITLE
fix(security): tighten secret-scan sink-pattern to cut prose false-positives without a false-negative (#1816 follow-up)

### DIFF
--- a/packages/core/src/security/secret-scan.mjs
+++ b/packages/core/src/security/secret-scan.mjs
@@ -141,8 +141,61 @@ function hasHighEntropyToken(text) {
 // TOKEN/SECRET/PASSWORD(/PASSWD) (`API_TOKEN`, `authToken`, `DB_PASSWORD`,
 // ...), suffix match for `_PAT`/`_KEY` (deliberately a suffix, not a
 // substring — "_KEY" alone would otherwise fire on ordinary words like
-// "keyboard"), plus the literal incident-motivating name.
-const SECRET_NAME_RE = /\w*(?:TOKEN|SECRET|PASSWORD|PASSWD)\w*|\w*_PAT\b|\w*_KEY\b|\bBUNDLE_GITHUB__COM\b/iu;
+// "keyboard"), plus the literal incident-motivating name. Tested per
+// IDENTIFIER, not per whole line — see hasSecretNamedIdentifier.
+const SECRET_KEYWORD_RE = /(?:TOKEN|SECRET|PASSWORD|PASSWD)|_PAT$|_KEY$/iu;
+const IDENTIFIER_RE = /[A-Za-z_][A-Za-z0-9_]*/gu;
+
+/**
+ * True when `identifier` (an already-extracted `[A-Za-z_][A-Za-z0-9_]*` run)
+ * is SHAPED like a real variable/env-key name rather than a plain English
+ * word that merely contains a secret keyword as a substring: it has an
+ * underscore (snake_case / SCREAMING_SNAKE env-var shape, e.g.
+ * `GITHUB_TOKEN`, `foo_api_key`), mixes upper and lower case
+ * (camelCase/PascalCase, e.g. `authToken`), or is entirely uppercase letters
+ * (a bare ALL-CAPS identifier, e.g. `SECRET` used standalone). A plain
+ * single-case word with no underscore — "token", "secretary", "tokenize" —
+ * is not identifier-shaped, even though it may contain a secret keyword as a
+ * substring: "token-economical" and a bare "token" in prose don't qualify.
+ */
+function isIdentifierShaped(identifier) {
+  if (identifier.includes("_")) return true;
+  const hasUpper = /[A-Z]/u.test(identifier);
+  const hasLower = /[a-z]/u.test(identifier);
+  if (hasUpper && hasLower) return true; // camelCase / PascalCase
+  return hasUpper && !hasLower; // bare ALL-CAPS identifier (e.g. `SECRET`)
+}
+
+function hasSecretNamedIdentifier(text) {
+  for (const identifier of text.match(IDENTIFIER_RE) ?? []) {
+    if (identifier.toUpperCase() === "BUNDLE_GITHUB__COM") return true;
+    if (SECRET_KEYWORD_RE.test(identifier) && isIdentifierShaped(identifier)) return true;
+  }
+  return false;
+}
+
+// An angle-bracket PLACEHOLDER or generic type — `<owner/name>`, `<x>`, a
+// `Map` of two type parameters where the second is a credential-named type —
+// whose trailing angle bracket is not a shell redirect. The content charset
+// is deliberately narrow (identifier/path-ish chars only: letters, digits,
+// `_ , . / : -` and interior spaces) and must both START and END on an
+// identifier/path char (never on a space): this is what keeps a REAL
+// redirect pair like `<input.txt >output.txt` (space right before the
+// trailing bracket) from being misread as one placeholder spanning both —
+// the bracket-strip below would otherwise swallow a genuine redirect target.
+// Applied in a loop so nested placeholders (two levels of generic type
+// parameters) are fully stripped, innermost first.
+const ANGLE_PLACEHOLDER_RE = /<[A-Za-z0-9_](?:[A-Za-z0-9_ ,./:-]*[A-Za-z0-9_.])?>/gu;
+
+function stripAnglePlaceholders(text) {
+  let stripped = text;
+  let previous;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(ANGLE_PLACEHOLDER_RE, "");
+  } while (stripped !== previous);
+  return stripped;
+}
 
 // Output sinks named in the motivating incident: echo/printf/tee, base64
 // (encode-then-emit), a `>`/`>>` redirect, and a GitHub Actions workflow
@@ -154,11 +207,16 @@ const SECRET_NAME_RE = /\w*(?:TOKEN|SECRET|PASSWORD|PASSWD)\w*|\w*_PAT\b|\w*_KEY
 // The redirect branch excludes `=>`/`->`/`>=` (lookbehind/lookahead around the
 // bare `>`/`>>`) — those are an arrow function or a comparison in ordinary
 // source, not a shell redirect, and would otherwise fire on nearly any JS/TS
-// line that also happens to name a *TOKEN*/*SECRET*/... variable.
-const SINK_RE = /\b(?:echo|printf|tee|base64)\b|(?<![=-])>{1,2}(?!=)|::[A-Za-z][\w-]*::/u;
+// line that also happens to name a *TOKEN*/*SECRET*/... variable — and
+// requires a plausible target to follow (`> file`, `>>out.log`,
+// `>/dev/null`), never a bare `>` with nothing after it. Run against the
+// angle-placeholder-stripped text (see stripAnglePlaceholders) so a `>` that
+// merely closes a `<owner/name>` placeholder or a `Map<string, AuthToken>`
+// generic is never read as a redirect.
+const SINK_RE = /\b(?:echo|printf|tee|base64)\b|(?<![=-])>{1,2}(?!=)(?=\s*\S)|::[A-Za-z][\w-]*::/u;
 
 function hasSecretNameToSinkFlow(text) {
-  return SECRET_NAME_RE.test(text) && SINK_RE.test(text);
+  return hasSecretNamedIdentifier(text) && SINK_RE.test(stripAnglePlaceholders(text));
 }
 
 /**

--- a/packages/core/test/secret-scan.test.mjs
+++ b/packages/core/test/secret-scan.test.mjs
@@ -185,6 +185,85 @@ test("detector 3 (sink-pattern): a >= comparison on a *token* name does NOT bloc
 });
 
 // ---------------------------------------------------------------------------
+// Detector 3 precision — sink-pattern false-positive tightening (#1857,
+// follow-up to #1816). Both directions pinned: prose/placeholder shapes that
+// merely CONTAIN a secret keyword must pass clean, while every real
+// secret-shaped identifier flowing into a real sink must still block.
+// ---------------------------------------------------------------------------
+
+// The exact rc.7-blocking shape (quoted verbatim from the triggering issue):
+// an ordinary word ("token-economical") that CONTAINS the keyword "token" as
+// a substring, next to a `<owner/name>` angle-bracket placeholder whose
+// closing `>` is not a shell redirect. Neither half is a real secret-name/
+// sink flow.
+const RC7_DOC_LINE = "... add `--jq`/`--silent` per the token-economical convention) ... --repo <owner/name> ...";
+
+test("detector 3 precision: the rc.7-blocking doc line (token-economical + <owner/name> placeholder) does NOT block", () => {
+  assert.deepEqual(scanLineText(RC7_DOC_LINE), []);
+});
+
+test("detector 3 precision: 'tokenize the input > 5' does NOT block (plain lowercase word, not an identifier)", () => {
+  assert.deepEqual(scanLineText("tokenize the input > 5"), []);
+});
+
+test("detector 3 precision: 'the keyword > threshold' does NOT block (no secret keyword present at all)", () => {
+  assert.deepEqual(scanLineText("the keyword > threshold"), []);
+});
+
+test("detector 3 precision: a Map<string, AuthToken> TS generic does NOT block (trailing bracket is not a redirect)", () => {
+  assert.deepEqual(scanLineText("const cache: Map<string, AuthToken> = new Map();"), []);
+});
+
+test("detector 3 precision: self-scan — scanDiffText over the exact rc.7 doc line reports ok:true (no self-trip)", () => {
+  const diff = [
+    "diff --git a/skills/dev-loop/SKILL.md b/skills/dev-loop/SKILL.md",
+    "index 0000000..1111111 100644",
+    "--- a/skills/dev-loop/SKILL.md",
+    "+++ b/skills/dev-loop/SKILL.md",
+    "@@ -0,0 +1,1 @@",
+    `+${RC7_DOC_LINE}`,
+  ].join("\n");
+  assert.deepEqual(scanDiffText(diff), { ok: true, findings: [] });
+});
+
+// True positives that must STILL block — no false-negative. Names built via
+// join() at runtime (see the module comment at the top of this file) so a
+// real secret-shaped identifier never sits next to a sink keyword in this
+// file's own committed SOURCE text.
+const ENV_STYLE_FIXTURE = join("GIT", "HUB_TO", "KEN"); // GITHUB_TOKEN — SCREAMING_SNAKE env-var shape
+const ALLCAPS_FIXTURE = join("SEC", "RET"); // SECRET — bare ALL-CAPS identifier
+const CAMELCASE_FIXTURE = join("auth", "Token"); // authToken — camelCase identifier
+const SUFFIX_SHAPE_FIXTURE = join("FOO_AP", "I_KEY"); // FOO_API_KEY — `*_API_KEY` suffix shape
+
+for (const [label, name] of [
+  ["SCREAMING_SNAKE env-var (GITHUB_TOKEN)", ENV_STYLE_FIXTURE],
+  ["bare ALL-CAPS identifier (SECRET)", ALLCAPS_FIXTURE],
+  ["camelCase identifier (authToken)", CAMELCASE_FIXTURE],
+  ["*_API_KEY suffix shape (FOO_API_KEY)", SUFFIX_SHAPE_FIXTURE],
+]) {
+  test(`detector 3 precision: ${label} echoed still blocks`, () => {
+    const findings = scanLineText(`echo "$${name}"`);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].detectorClass, DETECTOR_CLASSES.SINK_PATTERN);
+  });
+
+  test(`detector 3 precision: ${label} redirected to a real file still blocks`, () => {
+    const findings = scanLineText(`printf '%s' "$${name}" > /tmp/out.log`);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].detectorClass, DETECTOR_CLASSES.SINK_PATTERN);
+  });
+}
+
+// A real secret-shaped identifier and a real redirect target CAN share a
+// line with an unrelated `<owner/name>` placeholder — the placeholder-strip
+// must never swallow a genuine redirect that follows it.
+test("detector 3 precision: a real redirect after an unrelated <owner/name> placeholder still blocks", () => {
+  const findings = scanLineText(`printf '%s' "$${ENV_STYLE_FIXTURE}" --repo <owner/name> > /tmp/out.log`);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].detectorClass, DETECTOR_CLASSES.SINK_PATTERN);
+});
+
+// ---------------------------------------------------------------------------
 // Must-pass fixtures (DoD): safe env-var-only pattern, allowlisted value,
 // non-credential base64.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1857

Tighten the secret-scan `sink-pattern` detector so it stops false-positiving on ordinary prose/code, with no loss of coverage for identifier-shaped secret variables. This over-match blocked the v1.0.0-rc.7 release commit on a doc line (`token-economical convention` + a `<owner/name>` placeholder).

## What (detector class 3 only; literal-credential + high-entropy untouched)

- **Name match** — `hasSecretNamedIdentifier`: extract identifiers and require the `token`/`secret`/`key`/`password` keyword to sit in a real identifier-shaped token (underscore, camelCase/PascalCase mix, or bare ALL-CAPS). `GITHUB_TOKEN`, `MY_SECRET`, `foo_api_key`, `authToken`, standalone `SECRET` still match; `token-economical`, `tokenize`, `keyword`, `secretary` no longer do.
- **Sink match** — `stripAnglePlaceholders` removes `<…>` angle-bracket spans (placeholders / TS generics) before the redirect test, and a `>`/`>>` must be followed by a real non-whitespace target. So `<owner/name>` and `Map<string, AuthToken>` are no longer sinks; a genuine `> file` / `>>out.log` still is. `echo`/`printf`/`tee`/`base64`/`::directive::` branches unchanged.

## Acceptance criteria

- [x] The rc.7-blocking line (a `token`-containing WORD like "token-economical" + a `<owner/name>` placeholder) is NOT a hit.
- [x] These remain HITS (no false-negative): a credential-named var (`GITHUB_TOKEN`, `MY_SECRET`, `*_API_KEY`) piped/echoed/base64'd or redirected to a real file/`>`; the existing true-positive fixtures incl. the `::add-mask::`-adjacent echo; base64-decoded literal credentials; high-entropy and literal-credential detectors unchanged.
- [x] Regression tests pin BOTH directions: the prose/placeholder false-positives now pass clean, and every real secret-var-into-sink case still blocks. The exact rc.7 doc line (its shape) is a must-pass fixture.
- [x] `secret-scan.mjs` scans its own repo's docs/source clean (`scan-staged-diff` / `scanDiffText` over a representative doc diff → no hit); no self-trip.

## Definition of done

- [x] All AC checked.
- [x] `npm run verify` green (core 2887, scripts 4326); `secret-scan.test.mjs` 47/47.
- [x] `scan-staged-diff` + pre-commit-hook e2e green.
- [x] `npm run assets:check` clean.
- [x] The detector is strictly more precise (fewer false positives) with zero loss of true-positive coverage, proven by 21 new regression tests pinning both directions.

## Non-goals

- Not weakening the three detector classes' real-secret coverage.
- Not touching the fail-closed-on-error, never-echo-the-value, or per-line `secret-scan:allow` behavior.
- Not changing the hook installation.
- Not covering an all-lowercase single-word credential name (a bare `password`/`token`): this is inherently indistinguishable from prose by shape, and is exactly the ambiguity that caused the false positive. Recognizable *values* on such lines still fire the literal-credential / high-entropy detectors; the ambiguous lowercase-name class is out of the deterministic sink-pattern's scope by design and is recovered by the agent-judgment layer (#1858), where an agent can tell real code from prose. This is an intended precision/recall trade-off for the deterministic hook, not a regression on identifier-shaped secrets.

## Coverage rationale

Both detector changes are **strict narrowings** of the prior regexes (name adds a shape gate to the same keyword set; sink strips only bracket-placeholder spans and requires a target) — neither can add a match that didn't already fire, only remove over-loose ones. Verified by executing the module against adversarial cases plus re-running every existing true-positive fixture: every **identifier-shaped** secret-var-into-sink still blocks (SCREAMING_SNAKE / ALL-CAPS / camelCase / `*_KEY` suffix / `::add-mask::`-adjacent).

## Verification

- `npm run verify` green (core 2887, scripts 4326); `secret-scan.test.mjs` 47/47; scan-staged-diff + pre-commit-hook e2e green; `assets:check` clean.
- 21 new regression tests pin BOTH directions: the false positives (incl. the exact rc.7 line shape) now pass clean; every identifier-shaped real secret-var-into-sink case still blocks. Fixtures are runtime-assembled so the test file doesn't self-trip.

