### PR TITLE
feat(loop): commit-msg guard hook enforcing the commit-message contract

### DIFF
--- a/.claude/skills/docs/worktree-guidance.md
+++ b/.claude/skills/docs/worktree-guidance.md
@@ -199,12 +199,16 @@ contract at commit time instead of leaving it to agent discipline:
   `Claude-Session:` trailer.
 - A bare non-issue `#<digits>` enumeration is rejected — GitHub auto-links it
   to an unrelated issue/PR when rendered. A genuine `Closes #N` / `Fixes #N`
-  / `Refs #N` reference is allowed.
+  / `Refs #N` reference is allowed, including its trailer colon form
+  (`Closes: #N`).
 - The subject must be conventional-commit form `type(scope): summary` (type
-  one of `feat`/`fix`/`chore`/`docs`/`test`).
+  one of `feat`/`fix`/`chore`/`docs`/`test`/`refactor`/`revert`/`perf`/
+  `style`/`ci`/`build`).
 - A default, unedited merge message (`Merge branch '...'`, `Merge pull
-  request #...`, `Merge tag '...'`) is exempt — it is git-generated, not
-  operator-authored prose.
+  request #...`, `Merge tag '...'`), a default `git revert` message
+  (`Revert "..."`), or a `git commit --fixup`/`--squash` autosquash subject
+  (`fixup! ...` / `squash! ...`) is exempt — each is git/tooling-generated,
+  not operator-authored prose.
 - A per-commit waiver line (`dev-loops:commit-msg-guard:allow`) skips every
   check above for a deliberate exception.
 

--- a/.claude/skills/docs/worktree-guidance.md
+++ b/.claude/skills/docs/worktree-guidance.md
@@ -184,6 +184,35 @@ best-effort measure, not a substitute for `WORKTREE-CREATE-PROVISION` and
 `WORKTREE-DEFAULT-USE`'s own mandate to address git operations explicitly
 (below).
 
+### Commit-message contract guard
+
+<!-- rule: WORKTREE-COMMIT-MSG-GUARD -->
+`WORKTREE-COMMIT-MSG-GUARD`: `ensure-worktree.mjs` also best-effort installs a
+`commit-msg` hook into the same common hook directory as the default-branch
+guard above (reported separately, as `commitMsgGuard` in the result, since it
+guards message CONTENT rather than a branch). It enforces the commit-message
+contract at commit time instead of leaving it to agent discipline:
+
+- An agent-authored commit (`CLAUDECODE=1` in the environment — a plain
+  human commit is exempt, since it is never "Claude") must carry both
+  `Co-Authored-By: Claude <model> <noreply@anthropic.com>` and a
+  `Claude-Session:` trailer.
+- A bare non-issue `#<digits>` enumeration is rejected — GitHub auto-links it
+  to an unrelated issue/PR when rendered. A genuine `Closes #N` / `Fixes #N`
+  / `Refs #N` reference is allowed.
+- The subject must be conventional-commit form `type(scope): summary` (type
+  one of `feat`/`fix`/`chore`/`docs`/`test`).
+- A default, unedited merge message (`Merge branch '...'`, `Merge pull
+  request #...`, `Merge tag '...'`) is exempt — it is git-generated, not
+  operator-authored prose.
+- A per-commit waiver line (`dev-loops:commit-msg-guard:allow`) skips every
+  check above for a deliberate exception.
+
+Same refusal/degraded-coverage shape as the default-branch guard (a
+pre-existing `commit-msg` hook is never clobbered; `core.hooksPath` pointing
+elsewhere refuses the install) — see `installCommitMsgGuard` in
+`packages/core/src/loop/commit-msg-guard.mjs`.
+
 ### Post-merge cleanup
 
 <!-- rule: WORKTREE-CLEANUP -->

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "./loop/refinement-grill-state": "./src/loop/refinement-grill-state.mjs",
     "./loop/queue-board-ordering": "./src/loop/queue-board-ordering.mjs",
     "./loop/default-branch-guard": "./src/loop/default-branch-guard.mjs",
+    "./loop/commit-msg-guard": "./src/loop/commit-msg-guard.mjs",
     "./loop/queue-board-sync": "./src/loop/queue-board-sync.mjs",
     "./loop/queue-driver": "./src/loop/queue-driver.mjs",
     "./loop/queue-membership": "./src/loop/queue-membership.mjs",

--- a/packages/core/src/loop/commit-msg-guard.mjs
+++ b/packages/core/src/loop/commit-msg-guard.mjs
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Enforces the commit-message contract AT COMMIT TIME (issue #1869): the
+ * attribution trailers, the no-bare-#N rule, and the conventional-commit
+ * subject form were previously prose-only — nothing checked them, so a
+ * non-compliant commit landed silently. Installed alongside the
+ * default-branch guard (see default-branch-guard.mjs), through the same
+ * ensure-worktree provisioning path, so it rides into every worktree too.
+ *
+ * The rendered hook is a single self-contained Node script (ESM: this repo's
+ * root package.json is `"type": "module"`, and Node resolves an
+ * extensionless direct-run script's module type by walking up for the
+ * nearest package.json — verified empirically, not merely assumed). Keeping
+ * the ENTIRE check inline in the rendered script (rather than requiring a
+ * sibling file back into the checkout) means the installed hook keeps
+ * working even if the checkout that installed it is later removed or moved
+ * — the same self-containment default-branch-guard's hooks rely on.
+ */
+export const COMMIT_MSG_GUARD_MARKER = "dev-loops:commit-msg-guard";
+export const COMMIT_MSG_WAIVER_MARKER = `${COMMIT_MSG_GUARD_MARKER}:allow`;
+
+// Ownership check mirrors default-branch-guard's: the marker must be its own
+// line (a `//` comment, since the rendered hook is JS), not merely mentioned,
+// so a foreign hook that references us in prose is still left untouched.
+const GUARD_MARKER_LINE = new RegExp(`^// ${COMMIT_MSG_GUARD_MARKER}$`, "mu");
+
+/**
+ * Renders the commit-msg hook as a standalone, runnable Node script. The
+ * validation logic below is the ONLY copy of it — there is no separate JS
+ * implementation this must stay in sync with, exactly like renderGuardHook's
+ * shell body has none either. Tests exercise it by actually running it (see
+ * commit-msg-guard.test.mjs), the same way default-branch-guard.test.mjs
+ * drives real git rather than asserting on rendered text.
+ *
+ * String.raw, not a plain template literal: the generated script is full of
+ * regex backslash escapes (\s, \d, \b, \.) that a normal template literal
+ * would silently strip (an unrecognized string escape drops its backslash),
+ * corrupting every regex in the installed hook. String.raw keeps every
+ * backslash literal while still substituting the ${...} marker constants.
+ * The generated script deliberately uses NO template literals of its own
+ * (string concatenation instead) — a literal backtick would otherwise close
+ * THIS OUTER template early.
+ */
+export function renderCommitMsgGuardHook() {
+  return String.raw`#!/usr/bin/env node
+// ${COMMIT_MSG_GUARD_MARKER}
+// Enforces the commit-message contract (issue #1869): attribution trailers,
+// no bare non-issue #<digits>, and a conventional-commit subject. A
+// per-commit waiver line (${COMMIT_MSG_WAIVER_MARKER}) skips every check
+// below for a deliberate exception.
+import { readFileSync } from "node:fs";
+
+// git invokes commit-msg with ONLY the message-file path (unlike
+// prepare-commit-msg, which also gets a source/sha) — no signal distinguishes
+// an ordinary commit from a merge/squash at this hook. A default, unedited
+// merge message ("Merge branch '...'", "Merge pull request #...", "Merge tag
+// '...'") is git-generated, not operator-authored prose, so it is exempt by
+// its own recognizable shape rather than forced through a conventional-commit
+// subject and trailers it was never meant to carry.
+const [, , msgPath] = process.argv;
+const message = readFileSync(msgPath, "utf8");
+const subjectLine = message.split("\n", 1)[0] || "";
+if (/^Merge (branch|tag|remote-tracking branch|pull request) /u.test(subjectLine)) process.exit(0);
+
+if (/^${COMMIT_MSG_GUARD_MARKER}:allow\b/mu.test(message)) process.exit(0);
+
+const errors = [];
+
+// Trailers are required only for an AGENT-authored commit: Claude Code sets
+// CLAUDECODE=1 in every shell it spawns (the same harness-detection signal
+// packages/core/src/loop/run-context.mjs's isClaudeHarness checks) — a plain
+// human commit (CLAUDECODE unset) is never "Claude", so requiring a Claude
+// co-author trailer on it would misattribute the commit, not enforce honesty.
+if (process.env.CLAUDECODE === "1") {
+  if (!/^Co-Authored-By:\s*Claude\s+.+\s+<noreply@anthropic\.com>\s*$/imu.test(message)) {
+    errors.push("missing required trailer: Co-Authored-By: Claude <model> <noreply@anthropic.com>");
+  }
+  if (!/^Claude-Session:\s*\S+/imu.test(message)) {
+    errors.push("missing required trailer: Claude-Session: <url>");
+  }
+}
+
+// A genuine "Closes #N" / "Fixes #N" / "Refs #N" reference (optionally a
+// comma/and-joined list) is allowed and stripped first; any #<digits> left
+// over is a bare non-issue enumeration, which GitHub auto-links to an
+// unrelated issue/PR when rendered.
+const withoutAllowedRefs = message.replace(
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?)\s+#\d+(?:\s*(?:,|and)\s*#\d+)*/giu,
+  "",
+);
+if (/#\d+/u.test(withoutAllowedRefs)) {
+  errors.push('bare #<digits> reference found; use "Closes #N" / "Fixes #N" / "Refs #N" for a genuine issue reference, or reword a non-issue enumeration (e.g. "defect N")');
+}
+
+if (!/^(feat|fix|chore|docs|test)\([^()\n]+\): .+\S/u.test(subjectLine)) {
+  errors.push("subject must be conventional-commit form \"type(scope): summary\" (type one of feat/fix/chore/docs/test)");
+}
+
+if (errors.length > 0) {
+  console.error("dev-loops: WORKTREE-COMMIT-MSG-GUARD refuses this commit — contract violation(s):");
+  for (const error of errors) console.error("  - " + error);
+  console.error("  Waiver: add a \"${COMMIT_MSG_WAIVER_MARKER}\" line to the commit message for a deliberate exception.");
+  process.exit(1);
+}
+process.exit(0);
+`;
+}
+
+/**
+ * Install the commit-msg guard into a repository's hook directory. Mirrors
+ * default-branch-guard's install-refusal checks (a caller with an unsafe
+ * `core.hooksPath`, a non-absolute/non-git `gitDir`, or a linked worktree's
+ * OWN gitdir must never report success for a hook that can never fire) and
+ * its atomic write + foreign-hook preservation — duplicated rather than
+ * shared, since it is one hook, not a family; see default-branch-guard.mjs
+ * for the family version if a third hook installer ever needs the same
+ * shape factored out.
+ *
+ * @param {{ gitDir: string, hooksPathOverride?: string|null }} target
+ */
+export function installCommitMsgGuard({ gitDir, hooksPathOverride = null }) {
+  const refuse = (reason) => ({ ok: false, installed: false, refreshed: false, skipped: true, reason });
+
+  if (typeof hooksPathOverride === "string") {
+    const configured = hooksPathOverride.trim();
+    return configured.length > 0
+      ? refuse(`core.hooksPath is set to ${JSON.stringify(configured)} — install the guard there, or unset it`)
+      : refuse("core.hooksPath is set to an empty string — git runs no hooks at all");
+  }
+  if (typeof gitDir !== "string" || !path.isAbsolute(gitDir)) {
+    return refuse(`gitDir must be an absolute path; got ${JSON.stringify(gitDir)}`);
+  }
+  if (!fs.existsSync(path.join(gitDir, "HEAD"))) {
+    return refuse(`gitDir ${JSON.stringify(gitDir)} does not look like a git directory (no HEAD file)`);
+  }
+  if (fs.existsSync(path.join(gitDir, "commondir"))) {
+    return refuse(`gitDir ${JSON.stringify(gitDir)} is a linked worktree's own git directory, not the common one — hooks installed there never run`);
+  }
+
+  const hooksDir = path.join(gitDir, "hooks");
+  fs.mkdirSync(hooksDir, { recursive: true });
+  const hookPath = path.join(hooksDir, "commit-msg");
+
+  const existing = fs.existsSync(hookPath) ? fs.readFileSync(hookPath, "utf8") : null;
+  const ours = existing === null || GUARD_MARKER_LINE.test(existing);
+  if (!ours) {
+    return { ok: true, installed: false, refreshed: false, skipped: true, reason: "a pre-existing hook is present and was left untouched" };
+  }
+
+  // Same atomic tmp-write + rename as default-branch-guard: the hooks dir is
+  // shared across worktrees, so a direct writeFileSync would be visible
+  // mid-write to a concurrent install or a real commit racing this one.
+  const tmpPath = path.join(hooksDir, `.commit-msg.tmp-${process.pid}-${Date.now()}`);
+  fs.writeFileSync(tmpPath, renderCommitMsgGuardHook(), { mode: 0o755 });
+  fs.chmodSync(tmpPath, 0o755);
+  fs.renameSync(tmpPath, hookPath);
+
+  return { ok: true, installed: existing === null, refreshed: existing !== null, skipped: false };
+}

--- a/packages/core/src/loop/commit-msg-guard.mjs
+++ b/packages/core/src/loop/commit-msg-guard.mjs
@@ -56,13 +56,19 @@ import { readFileSync } from "node:fs";
 // prepare-commit-msg, which also gets a source/sha) — no signal distinguishes
 // an ordinary commit from a merge/squash at this hook. A default, unedited
 // merge message ("Merge branch '...'", "Merge pull request #...", "Merge tag
-// '...'") is git-generated, not operator-authored prose, so it is exempt by
+// '...'"), a default git-revert message (Revert "..."), or a
+// git commit --fixup/--squash autosquash subject (fixup! ... / squash! ...)
+// is git/tooling-generated, not operator-authored prose, so each is exempt by
 // its own recognizable shape rather than forced through a conventional-commit
 // subject and trailers it was never meant to carry.
 const [, , msgPath] = process.argv;
 const message = readFileSync(msgPath, "utf8");
 const subjectLine = message.split("\n", 1)[0] || "";
-if (/^Merge (branch|tag|remote-tracking branch|pull request) /u.test(subjectLine)) process.exit(0);
+if (
+  /^Merge (branch|tag|remote-tracking branch|pull request) /u.test(subjectLine) ||
+  /^Revert "/u.test(subjectLine) ||
+  /^(fixup|squash)! /u.test(subjectLine)
+) process.exit(0);
 
 if (/^${COMMIT_MSG_GUARD_MARKER}:allow\b/mu.test(message)) process.exit(0);
 
@@ -83,19 +89,20 @@ if (process.env.CLAUDECODE === "1") {
 }
 
 // A genuine "Closes #N" / "Fixes #N" / "Refs #N" reference (optionally a
-// comma/and-joined list) is allowed and stripped first; any #<digits> left
-// over is a bare non-issue enumeration, which GitHub auto-links to an
-// unrelated issue/PR when rendered.
+// comma/and-joined list, and optionally the trailer colon form "Closes: #N")
+// is allowed and stripped first; any #<digits> left over is a bare non-issue
+// enumeration, which GitHub auto-links to an unrelated issue/PR when
+// rendered.
 const withoutAllowedRefs = message.replace(
-  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?)\s+#\d+(?:\s*(?:,|and)\s*#\d+)*/giu,
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?):?\s+#\d+(?:\s*(?:,|and)\s*#\d+)*/giu,
   "",
 );
 if (/#\d+/u.test(withoutAllowedRefs)) {
   errors.push('bare #<digits> reference found; use "Closes #N" / "Fixes #N" / "Refs #N" for a genuine issue reference, or reword a non-issue enumeration (e.g. "defect N")');
 }
 
-if (!/^(feat|fix|chore|docs|test)\([^()\n]+\): .+\S/u.test(subjectLine)) {
-  errors.push("subject must be conventional-commit form \"type(scope): summary\" (type one of feat/fix/chore/docs/test)");
+if (!/^(feat|fix|chore|docs|test|refactor|revert|perf|style|ci|build)\([^()\n]+\): .+\S/u.test(subjectLine)) {
+  errors.push("subject must be conventional-commit form \"type(scope): summary\" (type one of feat/fix/chore/docs/test/refactor/revert/perf/style/ci/build)");
 }
 
 if (errors.length > 0) {

--- a/packages/core/test/commit-msg-guard.test.mjs
+++ b/packages/core/test/commit-msg-guard.test.mjs
@@ -130,6 +130,23 @@ test("allows a genuine Closes/Fixes/Refs #N reference", async () => {
   }
 });
 
+test("allows the colon-form Closes:/Fixes:/Refs: #N trailer, same as the non-colon form", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    for (const message of [
+      `fix(gate): patch the thing\n\nCloses: #42${AGENT_TRAILERS}`,
+      `fix(gate): patch the thing\n\nFixes: #42${AGENT_TRAILERS}`,
+      `fix(gate): patch the thing\n\nRefs: #42${AGENT_TRAILERS}`,
+    ]) {
+      const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+      assert.equal(result.blocked, false, `expected ${JSON.stringify(message)} to pass: ${result.stderr}`);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("rejects a subject not in conventional-commit type(scope): summary form", async () => {
   const { dir, gitDir } = await repoFixture();
   try {
@@ -138,6 +155,39 @@ test("rejects a subject not in conventional-commit type(scope): summary form", a
     const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
     assert.equal(result.blocked, true);
     assert.match(result.stderr, /conventional-commit form/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("accepts every conventional-commit type in the full allowlist, including refactor/revert/perf/style/ci/build", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    for (const type of ["feat", "fix", "chore", "docs", "test", "refactor", "revert", "perf", "style", "ci", "build"]) {
+      const message = `${type}(gate): do the thing${AGENT_TRAILERS}`;
+      const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+      assert.equal(result.blocked, false, `expected type "${type}" to pass: ${result.stderr}`);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a default git-revert/fixup!/squash! subject is exempt from the conventional-commit subject check", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    for (const subject of [
+      'Revert "fix(gate): do the thing"',
+      "fixup! fix(gate): do the thing",
+      "squash! fix(gate): do the thing",
+    ]) {
+      // No trailers, no conventional form of its own — the git/tooling-authored
+      // shape must exempt it regardless.
+      const result = commitAttempt(dir, subject, { CLAUDECODE: "1" });
+      assert.equal(result.blocked, false, `expected ${JSON.stringify(subject)} to pass: ${result.stderr}`);
+    }
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/commit-msg-guard.test.mjs
+++ b/packages/core/test/commit-msg-guard.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  COMMIT_MSG_GUARD_MARKER,
+  COMMIT_MSG_WAIVER_MARKER,
+  installCommitMsgGuard,
+} from "../src/loop/commit-msg-guard.mjs";
+
+// The hook is a real Node script that runs inside real git — asserting on
+// rendered text would pass while the guard silently never ran, the same
+// reasoning default-branch-guard.test.mjs documents for its own shell hooks.
+//
+// CLAUDECODE is scrubbed from the base env (this suite runs under Claude
+// Code itself) and set explicitly per test, since the attribution-trailer
+// requirement is gated on it (issue #1869: a plain human commit is never
+// "Claude", so it must not be forced to carry a Claude co-author trailer).
+const BASE_GIT_ENV = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+delete BASE_GIT_ENV.CLAUDECODE;
+
+const AGENT_TRAILERS = "\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>\nClaude-Session: https://claude.ai/code/session_test\n";
+
+function git(cwd, args, env = {}) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...BASE_GIT_ENV, ...env },
+  });
+}
+
+async function repoFixture() {
+  const dir = await mkdtemp(path.join(tmpdir(), "commit-msg-guard-"));
+  git(dir, ["init", "--quiet", "--initial-branch=main"]);
+  git(dir, ["config", "user.email", "t@example.test"]);
+  git(dir, ["config", "user.name", "Guard Test"]);
+  fs.writeFileSync(path.join(dir, "seed.txt"), "seed\n");
+  git(dir, ["add", "seed.txt"]);
+  // --no-verify: seed the history before the guard exists.
+  git(dir, ["commit", "--quiet", "--no-verify", "-m", "seed"]);
+  const gitDir = git(dir, ["rev-parse", "--absolute-git-dir"]).trim();
+  return { dir, gitDir };
+}
+
+let fileCounter = 0;
+function commitAttempt(dir, message, env = {}) {
+  const file = `change-${fileCounter++}.txt`;
+  fs.writeFileSync(path.join(dir, file), `${file}\n`);
+  git(dir, ["add", file]);
+  try {
+    git(dir, ["commit", "--quiet", "-m", message], env);
+    return { blocked: false, stderr: "" };
+  } catch (err) {
+    return { blocked: true, stderr: String(err.stderr ?? "") };
+  }
+}
+
+test("installs the commit-msg hook into an empty hooks dir, executable and marked", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    const result = installCommitMsgGuard({ gitDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.installed, true);
+    assert.equal(result.refreshed, false);
+    const hookPath = path.join(gitDir, "hooks", "commit-msg");
+    const contents = fs.readFileSync(hookPath, "utf8");
+    assert.match(contents, new RegExp(`^// ${COMMIT_MSG_GUARD_MARKER}$`, "mu"));
+    assert.ok(fs.statSync(hookPath).mode & 0o111, "hook must be executable, or git ignores it entirely");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("rejects an agent-authored commit missing the attribution trailers", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    const result = commitAttempt(dir, "fix(gate): do the thing", { CLAUDECODE: "1" });
+    assert.equal(result.blocked, true);
+    assert.match(result.stderr, /missing required trailer: Co-Authored-By/);
+    assert.match(result.stderr, /missing required trailer: Claude-Session/);
+    assert.equal(git(dir, ["rev-list", "--count", "HEAD"]).trim(), "1", "the refusal must be the only effect");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a non-agent commit (CLAUDECODE unset) is not forced to carry a Claude trailer", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    const result = commitAttempt(dir, "fix(gate): do the thing", {});
+    assert.equal(result.blocked, false, `expected a human commit to pass without trailers: ${result.stderr}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("rejects a bare non-issue #<digits> enumeration", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    const message = `fix(gate): renumber item #42${AGENT_TRAILERS}`;
+    const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+    assert.equal(result.blocked, true);
+    assert.match(result.stderr, /bare #<digits> reference found/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("allows a genuine Closes/Fixes/Refs #N reference", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    for (const message of [
+      `fix(gate): patch the thing (Closes #42)${AGENT_TRAILERS}`,
+      `fix(gate): patch the thing (Fixes #42)${AGENT_TRAILERS}`,
+      `fix(gate): patch the thing (Refs #42)${AGENT_TRAILERS}`,
+    ]) {
+      const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+      assert.equal(result.blocked, false, `expected ${JSON.stringify(message)} to pass: ${result.stderr}`);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("rejects a subject not in conventional-commit type(scope): summary form", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    const message = `did a thing${AGENT_TRAILERS}`;
+    const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+    assert.equal(result.blocked, true);
+    assert.match(result.stderr, /conventional-commit form/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a per-commit waiver marker allows a deliberate exception", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    // No trailers, a bare #99, and a non-conventional subject — every check
+    // would independently reject this — yet the waiver line lets it through.
+    const message = `did a thing #99\n\n${COMMIT_MSG_WAIVER_MARKER}\n`;
+    const result = commitAttempt(dir, message, { CLAUDECODE: "1" });
+    assert.equal(result.blocked, false, `expected the waiver to allow it: ${result.stderr}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a pre-existing foreign commit-msg hook is preserved, never clobbered", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    const hooksDir = path.join(gitDir, "hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    const foreign = "#!/bin/sh\n# someone else's commit-msg hook\nexit 0\n";
+    fs.writeFileSync(path.join(hooksDir, "commit-msg"), foreign, { mode: 0o755 });
+
+    const result = installCommitMsgGuard({ gitDir });
+    assert.equal(result.ok, true);
+    assert.equal(result.installed, false);
+    assert.equal(result.skipped, true);
+    assert.equal(fs.readFileSync(path.join(hooksDir, "commit-msg"), "utf8"), foreign, "left byte-identical");
+
+    // And the contract is NOT enforced — the foreign hook owns the slot.
+    const message = "not conventional at all";
+    const commitResult = commitAttempt(dir, message, { CLAUDECODE: "1" });
+    assert.equal(commitResult.blocked, false, "the foreign hook's exit 0 must be what runs");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("install is idempotent — a re-run refreshes its own hook rather than duplicating it", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    const first = installCommitMsgGuard({ gitDir });
+    assert.equal(first.installed, true);
+    assert.equal(first.refreshed, false);
+
+    const second = installCommitMsgGuard({ gitDir });
+    assert.equal(second.installed, false);
+    assert.equal(second.refreshed, true);
+
+    const contents = fs.readFileSync(path.join(gitDir, "hooks", "commit-msg"), "utf8");
+    const markerLineMatches = contents.match(new RegExp(`^// ${COMMIT_MSG_GUARD_MARKER}$`, "mgu")) ?? [];
+    assert.equal(markerLineMatches.length, 1, "the ownership marker line must appear exactly once, not stacked");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a merge commit's message is exempt from the conventional-commit subject check", async () => {
+  const { dir, gitDir } = await repoFixture();
+  try {
+    installCommitMsgGuard({ gitDir });
+    git(dir, ["checkout", "--quiet", "-b", "feature"]);
+    fs.writeFileSync(path.join(dir, "feature.txt"), "feature\n");
+    git(dir, ["add", "feature.txt"]);
+    git(dir, ["commit", "--quiet", "--no-verify", "-m", "fix(gate): feature work"]);
+    git(dir, ["checkout", "--quiet", "main"]);
+    // The default merge message ("Merge branch 'feature'") is not
+    // conventional-commit form and carries no trailers — it must still pass.
+    git(dir, ["merge", "--no-ff", "feature"], { CLAUDECODE: "1" });
+    assert.equal(git(dir, ["rev-list", "--count", "HEAD"]).trim(), "3");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("refuses to install into a linked worktree's own gitdir, not the common one", async () => {
+  const { dir, gitDir } = await repoFixture();
+  const linked = path.join(dir, "..", `${path.basename(dir)}-linked`);
+  try {
+    git(dir, ["checkout", "--quiet", "-b", "primary-holder"]);
+    git(dir, ["worktree", "add", "--quiet", linked, "main"]);
+    const linkedGitDir = git(linked, ["rev-parse", "--absolute-git-dir"]).trim();
+    assert.notEqual(linkedGitDir, gitDir);
+
+    const result = installCommitMsgGuard({ gitDir: linkedGitDir });
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /own git directory/);
+    assert.equal(fs.existsSync(path.join(linkedGitDir, "hooks", "commit-msg")), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(linked, { recursive: true, force: true });
+  }
+});

--- a/scripts/loop/ensure-worktree.mjs
+++ b/scripts/loop/ensure-worktree.mjs
@@ -43,7 +43,9 @@
  * whatever was already fetched. `provision` is the full provisionWorktree()
  * result, not just its summary. `guard` is the default-branch guard's
  * install result — best-effort: a failure there never fails the worktree,
- * see installGuard below.)
+ * see installGuard below. `commitMsgGuard` is the commit-message contract
+ * guard's install result (issue #1869) — same best-effort contract, see
+ * installCommitMsgGuardForRoot below.)
  * A git create failure is a hard error (exit 1); provisioning is fail-soft.
  */
 import { execFileSync } from "node:child_process";
@@ -55,6 +57,7 @@ import { resolveWorktreePath } from "@dev-loops/core/loop/handoff-envelope";
 import { normalizeToBareBranch, resolveBaseBranch } from "@dev-loops/core/config";
 import { provisionWorktree } from "./provision-worktree.mjs";
 import { GUARDED_HOOKS, installDefaultBranchGuard } from "@dev-loops/core/loop/default-branch-guard";
+import { installCommitMsgGuard } from "@dev-loops/core/loop/commit-msg-guard";
 import { canonicalize } from "./_worktree-path.mjs";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 
@@ -110,6 +113,12 @@ Output (stdout, JSON):
                // install result (best-effort; see installDefaultBranchGuard) —
                // always present, on both the create and reuse paths. Guards the
                // repo's own default AND, when it differs, an explicit --base.
+    "commitMsgGuard": { "ok": bool, "installed": bool, "refreshed": bool,
+               "skipped": bool, "reason"? }              // commit-message
+               // contract guard's install result (best-effort; see
+               // installCommitMsgGuard) — always present, on both the create
+               // and reuse paths. Enforces the attribution trailers, the
+               // no-bare-#N rule, and the conventional-commit subject form.
   }
 
 ${JQ_OUTPUT_USAGE}`.trim();
@@ -469,34 +478,41 @@ function guardedBranches(gitCommand, root, explicitBase) {
   return { repoDefault, explicitBase: explicitCandidate };
 }
 
+// The COMMON git dir, not the per-worktree one: `--absolute-git-dir` in a
+// linked worktree resolves to `.git/worktrees/<name>`, a hooks directory git
+// never executes for anything — installing there reports guard.ok: true for
+// a hook that can never fire. `--git-common-dir` is identical for the main
+// checkout and every linked worktree, which is what every hook install must
+// target since hooks are resolved from the common directory. Shared by
+// installGuard (default-branch) and installCommitMsgGuardForRoot
+// (commit-msg): both hooks install into the same directory the same way.
+function resolveHooksInstallTarget(gitCommand, root) {
+  // --path-format=absolute needs git >= 2.31; fall back to resolving the
+  // (possibly relative) --git-common-dir against the invocation root so an
+  // older git still targets the right directory instead of failing the guard.
+  let gitDir;
+  try {
+    gitDir = runGit(gitCommand, ["rev-parse", "--path-format=absolute", "--git-common-dir"], root).trim();
+  } catch {
+    gitDir = path.resolve(root, runGit(gitCommand, ["rev-parse", "--git-common-dir"], root).trim());
+  }
+  let hooksPathOverride = null;
+  try {
+    // Exit 0 means SET (even to ""), exit 1 means unset — `.trim() || null`
+    // collapsed both to the same null, so `core.hooksPath=""` (git runs NO
+    // hooks at all in that case) read as "unset" and installed hooks git
+    // would never execute while reporting guard.ok: true.
+    hooksPathOverride = runGit(gitCommand, ["config", "--get", "core.hooksPath"], root).trim();
+  } catch {
+    hooksPathOverride = null; // unset — `git config --get` exits 1, which is the normal case
+  }
+  return { gitDir, hooksPathOverride };
+}
+
 function installGuard(gitCommand, root, explicitBase) {
   try {
-    // The COMMON git dir, not the per-worktree one: `--absolute-git-dir` in a
-    // linked worktree resolves to `.git/worktrees/<name>`, a hooks directory git
-    // never executes for anything — installing there reports guard.ok: true for
-    // a hook that can never fire. `--git-common-dir` is identical for the main
-    // checkout and every linked worktree, which is what the hook install must
-    // target since hooks are resolved from the common directory.
-    // --path-format=absolute needs git >= 2.31; fall back to resolving the
-    // (possibly relative) --git-common-dir against the invocation root so an
-    // older git still targets the right directory instead of failing the guard.
-    let gitDir;
-    try {
-      gitDir = runGit(gitCommand, ["rev-parse", "--path-format=absolute", "--git-common-dir"], root).trim();
-    } catch {
-      gitDir = path.resolve(root, runGit(gitCommand, ["rev-parse", "--git-common-dir"], root).trim());
-    }
+    const { gitDir, hooksPathOverride } = resolveHooksInstallTarget(gitCommand, root);
     const { repoDefault, explicitBase: explicitBranch } = guardedBranches(gitCommand, root, explicitBase);
-    let hooksPathOverride = null;
-    try {
-      // Exit 0 means SET (even to ""), exit 1 means unset — `.trim() || null`
-      // collapsed both to the same null, so `core.hooksPath=""` (git runs NO
-      // hooks at all in that case) read as "unset" and installed hooks git
-      // would never execute while reporting guard.ok: true.
-      hooksPathOverride = runGit(gitCommand, ["config", "--get", "core.hooksPath"], root).trim();
-    } catch {
-      hooksPathOverride = null; // unset — `git config --get` exits 1, which is the normal case
-    }
     const result = installDefaultBranchGuard({
       gitDir,
       defaultBranches: repoDefault,
@@ -530,6 +546,25 @@ function installGuard(gitCommand, root, explicitBase) {
       skipped: GUARDED_HOOKS.map((hook) => ({ hook, reason: detail })),
       reason: detail,
     };
+  }
+}
+
+// Installs the commit-msg contract guard (issue #1869) alongside the
+// default-branch guard above — same resolveHooksInstallTarget, same common
+// hooks directory, so it rides into every worktree the same way. Best-effort,
+// like installGuard: a failure here never fails the worktree.
+function installCommitMsgGuardForRoot(gitCommand, root) {
+  try {
+    const { gitDir, hooksPathOverride } = resolveHooksInstallTarget(gitCommand, root);
+    const result = installCommitMsgGuard({ gitDir, hooksPathOverride });
+    if (!result.ok) {
+      process.stderr.write(`[ensure-worktree] WARN commit-msg guard not installed: ${result.reason}\n`);
+    }
+    return result;
+  } catch (err) {
+    const detail = (err?.stderr ?? err?.message ?? "").toString().trim();
+    process.stderr.write(`[ensure-worktree] WARN commit-msg guard not installed: ${detail}\n`);
+    return { ok: false, installed: false, refreshed: false, skipped: true, reason: detail };
   }
 }
 
@@ -617,6 +652,7 @@ export async function ensureWorktree(
         branchOrigin: "reused-detached",
         provision: summary,
         guard: installGuard(gitCommand, root, base),
+        commitMsgGuard: installCommitMsgGuardForRoot(gitCommand, root),
       };
     }
     // Fetch before the divergence check (mirroring the create path below) so
@@ -635,6 +671,7 @@ export async function ensureWorktree(
       ...(fetchDegraded ? { fetchDegraded: true } : {}),
       provision: summary,
       guard: installGuard(gitCommand, root, base),
+      commitMsgGuard: installCommitMsgGuardForRoot(gitCommand, root),
     };
   }
 
@@ -697,6 +734,7 @@ export async function ensureWorktree(
     ...(fetchDegraded ? { fetchDegraded: true } : {}),
     provision: summary,
     guard: installGuard(gitCommand, root, base),
+    commitMsgGuard: installCommitMsgGuardForRoot(gitCommand, root),
   };
 }
 

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -671,6 +671,10 @@
       "id": "WORKTREE-CLEANUP"
     },
     {
+      "id": "WORKTREE-COMMIT-MSG-GUARD",
+      "enforcement": "runtime"
+    },
+    {
       "id": "WORKTREE-CREATE-PROVISION"
     },
     {

--- a/skills/docs/worktree-guidance.md
+++ b/skills/docs/worktree-guidance.md
@@ -199,12 +199,16 @@ contract at commit time instead of leaving it to agent discipline:
   `Claude-Session:` trailer.
 - A bare non-issue `#<digits>` enumeration is rejected — GitHub auto-links it
   to an unrelated issue/PR when rendered. A genuine `Closes #N` / `Fixes #N`
-  / `Refs #N` reference is allowed.
+  / `Refs #N` reference is allowed, including its trailer colon form
+  (`Closes: #N`).
 - The subject must be conventional-commit form `type(scope): summary` (type
-  one of `feat`/`fix`/`chore`/`docs`/`test`).
+  one of `feat`/`fix`/`chore`/`docs`/`test`/`refactor`/`revert`/`perf`/
+  `style`/`ci`/`build`).
 - A default, unedited merge message (`Merge branch '...'`, `Merge pull
-  request #...`, `Merge tag '...'`) is exempt — it is git-generated, not
-  operator-authored prose.
+  request #...`, `Merge tag '...'`), a default `git revert` message
+  (`Revert "..."`), or a `git commit --fixup`/`--squash` autosquash subject
+  (`fixup! ...` / `squash! ...`) is exempt — each is git/tooling-generated,
+  not operator-authored prose.
 - A per-commit waiver line (`dev-loops:commit-msg-guard:allow`) skips every
   check above for a deliberate exception.
 

--- a/skills/docs/worktree-guidance.md
+++ b/skills/docs/worktree-guidance.md
@@ -184,6 +184,35 @@ best-effort measure, not a substitute for `WORKTREE-CREATE-PROVISION` and
 `WORKTREE-DEFAULT-USE`'s own mandate to address git operations explicitly
 (below).
 
+### Commit-message contract guard
+
+<!-- rule: WORKTREE-COMMIT-MSG-GUARD -->
+`WORKTREE-COMMIT-MSG-GUARD`: `ensure-worktree.mjs` also best-effort installs a
+`commit-msg` hook into the same common hook directory as the default-branch
+guard above (reported separately, as `commitMsgGuard` in the result, since it
+guards message CONTENT rather than a branch). It enforces the commit-message
+contract at commit time instead of leaving it to agent discipline:
+
+- An agent-authored commit (`CLAUDECODE=1` in the environment — a plain
+  human commit is exempt, since it is never "Claude") must carry both
+  `Co-Authored-By: Claude <model> <noreply@anthropic.com>` and a
+  `Claude-Session:` trailer.
+- A bare non-issue `#<digits>` enumeration is rejected — GitHub auto-links it
+  to an unrelated issue/PR when rendered. A genuine `Closes #N` / `Fixes #N`
+  / `Refs #N` reference is allowed.
+- The subject must be conventional-commit form `type(scope): summary` (type
+  one of `feat`/`fix`/`chore`/`docs`/`test`).
+- A default, unedited merge message (`Merge branch '...'`, `Merge pull
+  request #...`, `Merge tag '...'`) is exempt — it is git-generated, not
+  operator-authored prose.
+- A per-commit waiver line (`dev-loops:commit-msg-guard:allow`) skips every
+  check above for a deliberate exception.
+
+Same refusal/degraded-coverage shape as the default-branch guard (a
+pre-existing `commit-msg` hook is never clobbered; `core.hooksPath` pointing
+elsewhere refuses the install) — see `installCommitMsgGuard` in
+`packages/core/src/loop/commit-msg-guard.mjs`.
+
 ### Post-merge cleanup
 
 <!-- rule: WORKTREE-CLEANUP -->

--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -234,6 +234,15 @@ test("ensure: reuse is idempotent (second call reuses, no error)", async () => {
     // this whole suite green while breaking that contract.
     assert.equal(second.guard.ok, true);
     assert.deepEqual(second.guard.refreshed, ["pre-commit", "pre-merge-commit", "pre-push"]);
+    // MUST-FIX regression (issue #1869): commitMsgGuard is documented as
+    // always present on BOTH the create and reuse paths — deleting
+    // installCommitMsgGuardForRoot's call on either return site would leave
+    // this whole suite green while silently dropping the commit-message
+    // contract guard from every reused worktree.
+    assert.equal(first.commitMsgGuard.ok, true);
+    assert.equal(first.commitMsgGuard.installed, true);
+    assert.equal(second.commitMsgGuard.ok, true);
+    assert.equal(second.commitMsgGuard.refreshed, true);
   } finally {
     repo.cleanup();
   }
@@ -288,6 +297,9 @@ test("ensure: a DETACHED-HEAD worktree at the path is reused as-is, never fabric
     assert.equal(res.branchOrigin, "reused-detached");
     assert.equal(res.diverged, undefined);
     assert.equal(res.base, undefined, "base is only reported on create");
+    // MUST-FIX regression (issue #1869): commitMsgGuard must be present on
+    // the reused-detached return site too, not just create/reused-local.
+    assert.equal(res.commitMsgGuard.ok, true);
   } finally {
     repo.cleanup();
   }

--- a/test/loop/ensure-worktree.test.mjs
+++ b/test/loop/ensure-worktree.test.mjs
@@ -30,9 +30,14 @@ after(() => {
 
 // Scrubbed, not inherited: an ambient DEVLOOPS_ALLOW_MAIN (the guard's own
 // documented release/reconcile override) would make the guard-refusal
-// assertions below pass for the wrong reason.
+// assertions below pass for the wrong reason. CLAUDECODE is scrubbed for the
+// same reason — this suite runs under Claude Code itself, so it would
+// otherwise leak in and make the commit-msg guard's (issue #1869)
+// agent-authored trailer requirement fire for a reason that has nothing to
+// do with what any test here actually exercises.
 const REPO_GIT_ENV = { ...process.env };
 delete REPO_GIT_ENV.DEVLOOPS_ALLOW_MAIN;
+delete REPO_GIT_ENV.CLAUDECODE;
 
 // A git command runner bound to `cwd`, with test identity pre-configured —
 // the "define a git() lambda, then set user.email/user.name" pattern
@@ -250,7 +255,9 @@ test("ensure: an already-existing worktree being reused reports a divergence on 
     const remoteSha = publishBranch(origin.originGit, "issue-4001", "remote-side rewrite", "HEAD");
 
     // Advance the LOCAL branch too, so it is a genuine, mutually-unreachable fork.
-    execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "local-side work"], { cwd: first.path, encoding: "utf8", env: REPO_GIT_ENV });
+    // --no-verify: this commit exercises divergence detection, not the
+    // commit-msg guard ensureWorktree also installed here (issue #1869).
+    execFileSync("git", ["commit", "-q", "--no-verify", "--allow-empty", "-m", "local-side work"], { cwd: first.path, encoding: "utf8", env: REPO_GIT_ENV });
     const localSha = git("-C", first.path, "rev-parse", "HEAD").trim();
 
     const second = await ensureWorktree({ repoRoot: root, issue: 4001 }); // hits the REUSE path
@@ -1132,8 +1139,9 @@ test("ensure: stacking --base on a live worktree branch does not permanently gua
     assert.ok(!freed.guard.defaultBranches.includes("issue-100"), "the stacked explicit base must be dropped once nothing requests it");
     assert.ok(freed.guard.defaultBranches.includes("main"), "the real default must still be guarded");
 
-    // issue-100's own commits now pass.
-    execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "own work after drop"], { cwd: owner.path, encoding: "utf8", env: REPO_GIT_ENV });
+    // issue-100's own commits now pass. --no-verify: this exercises the
+    // dropped explicit-base slot, not the commit-msg guard (issue #1869).
+    execFileSync("git", ["commit", "-q", "--no-verify", "--allow-empty", "-m", "own work after drop"], { cwd: owner.path, encoding: "utf8", env: REPO_GIT_ENV });
   } finally {
     repo.cleanup();
   }
@@ -1154,8 +1162,10 @@ test("ensure: with every guarded hook slot foreign, guard reports nothing enforc
     assert.equal(res.guard.ok, true);
     assert.deepEqual(res.guard.installed, []);
     assert.deepEqual(res.guard.defaultBranches, [], "nothing was written, so nothing may read as enforced");
-    // And the commit actually passes — the report matches reality.
-    repo.git("commit", "-q", "--allow-empty", "-m", "on main, unguarded by foreign hooks");
+    // And the commit actually passes — the report matches reality. --no-verify:
+    // this exercises the foreign-pre-commit-slot report, not the commit-msg
+    // guard (issue #1869), whose OWN slot is free and installs regardless.
+    repo.git("commit", "-q", "--no-verify", "--allow-empty", "-m", "on main, unguarded by foreign hooks");
   } finally {
     repo.cleanup();
   }


### PR DESCRIPTION
Closes #1869

## Objective

Enforce the commit-message contract at commit time via a `commit-msg` git hook installed through the same worktree-provision path as the secret-scan/default-branch guard. Closes the commit-seam analogue of the PR-description hole: attribution trailers, no-bare-`#N`, and conventional subject form were rule-but-unenforced, so a non-compliant commit landed silently (the retro found a real rc.7 merge commit missing both trailers).

## In scope

A `commit-msg` hook installed through the existing worktree-provision path that fail-closed validates the attribution trailers, the conventional subject form (full conventional type set: `feat|fix|chore|docs|test|refactor|revert|perf|style|ci|build`), and bare-`#N` usage, with a per-commit waiver and git/tooling-authored exemptions. Out of scope: rewriting history, body-prose quality, and new dependencies.

## What

- `packages/core/src/loop/commit-msg-guard.mjs` (new): `renderCommitMsgGuardHook()` renders a self-contained ESM `commit-msg` hook (marker `dev-loops:commit-msg-guard`); `installCommitMsgGuard()` mirrors the default-branch-guard's atomic-write + foreign-hook-preservation pattern.
- `scripts/loop/ensure-worktree.mjs`: shares `resolveHooksInstallTarget` and installs the commit-msg guard alongside the branch guard at every `ensureWorktree()` return site (reported as `commitMsgGuard`).
- The hook validates fail-closed: requires the `Co-Authored-By: Claude …` + `Claude-Session:` trailers on an agent-authored commit (`CLAUDECODE=1`, the existing `isClaudeHarness` signal); rejects a bare non-issue `#N` (allows `Closes/Fixes/Refs #N`); requires conventional subject form; merge commits exempt; a per-commit waiver marker bypasses.
- Docs: `skills/docs/worktree-guidance.md` (+ mirror) rule `WORKTREE-COMMIT-MSG-GUARD`; registered in `required-rules.json`.

## Acceptance criteria

- [x] A commit missing the required attribution trailers is rejected by the `commit-msg` hook, pinned by a test.
- [x] A commit with a bare non-issue `#N` is rejected; a genuine `Closes/Fixes/Refs #N` is allowed. Pinned.
- [x] A commit subject not in `type(scope): summary` form is rejected, pinned.
- [x] The hook installs through the existing worktree/guard provision path, in every worktree.
- [x] A per-commit waiver marker allows a deliberate exception, pinned.

## Definition of done

- [x] `npm run verify` green (core 2898, scripts 4326, all suites) and `assets:check` ok (90).
- [x] Tests pin each reject path, the allowed-reference path, and the waiver path (11 e2e tests against real git).
- [x] Hook wired into worktree provisioning; contract doc + required-rules registered.

## Non-goals

- No rewrite of historical commit messages.
- No body-prose quality enforcement beyond subject form + trailers + no-bare-#N.
- No new dependency (self-contained offline hook).

## Verification

- `npm run verify` green; `assets:check` `{"ok":true,"checked":90}`.
- The conventional type set is the full `feat|fix|chore|docs|test|refactor|revert|perf|style|ci|build`, pinned by a positive test over all 11 types (resolves the gate's round-1 blocking finding that the original `feat|fix|chore|docs|test`-only set rejected real `refactor`/`revert`/`perf`/`ci` commits).
- Git/tooling-authored subjects (`Merge …`, `Revert "…"`, `fixup! …`, `squash! …`) and colon-form `Closes:/Fixes:/Refs: #N` are exempted/accepted, pinned.
- `commitMsgGuard` wiring asserted at all three `ensureWorktree()` return sites (create, reused-local, reused-detached).
- 11 e2e tests: install; reject-missing-trailers; human commit not forced; reject bare `#N`; allow `Closes #N`; reject non-conventional subject; waiver bypass; foreign-hook preserved; idempotent reinstall; merge-commit exemption; linked-worktree-gitdir refusal.
