### PR TITLE
docs(release): document release-commit staging and dirty-cut recovery

### DIFF
--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -20,6 +20,16 @@ manual step.** Everything after the tag is hands-off.
    DEVLOOPS_ALLOW_MAIN=1 git commit -m "chore(release): v<version>"
    DEVLOOPS_ALLOW_MAIN=1 git push origin main
    ```
+
+   **Staging the release commit.** Stage the exact release files explicitly
+   (the version bump, `CHANGELOG.md`, and any regenerated assets) — never
+   `git add -A` or `git add .`. The release commit runs with
+   `DEVLOOPS_ALLOW_MAIN=1`, which intentionally turns the default-branch guard
+   off, so a broad add sweeps accumulated main-checkout scratch straight into
+   the release commit (this has already cost a cancelled publish run and a tag
+   re-cut). Before committing, run `git status --porcelain` and verify every
+   staged path is an intended release file; abort the commit if anything
+   unexpected is staged.
 2. Tag the release commit and push the tag:
 
    ```bash
@@ -53,6 +63,16 @@ the workflow does it (and is idempotent if you already created one).
 
 ## Failure modes
 
+- Release commit contains unintended content: cancel the publish run
+  **first** (the run is the irreversible step — it publishes from the tag),
+  then clean up `main`, then delete and re-cut the tag:
+
+  ```bash
+  gh run cancel <publish-run-id>          # 1. stop the publish run first
+  # 2. fix/remove the unintended commit on main (guard override as above)
+  git tag -d v<version> && git push origin :refs/tags/v<version>
+  git tag v<version> && git push origin v<version>   # 3. re-cut the tag
+  ```
 - Tag not on `main`: the release workflow fails the on-main guard — re-tag the
   correct commit.
 - Missing CHANGELOG section: the extraction step exits non-zero and no Release is

--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -82,7 +82,8 @@ the workflow does it (and is idempotent if you already created one).
   and re-push:
 
   ```bash
-  DEVLOOPS_ALLOW_MAIN=1 git commit -am "docs: add v<version> CHANGELOG section"
+  DEVLOOPS_ALLOW_MAIN=1 git add CHANGELOG.md
+  DEVLOOPS_ALLOW_MAIN=1 git commit -m "docs: add v<version> CHANGELOG section"
   DEVLOOPS_ALLOW_MAIN=1 git push origin main
   git tag -f v<version>
   git push --force origin v<version>

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -20,6 +20,16 @@ manual step.** Everything after the tag is hands-off.
    DEVLOOPS_ALLOW_MAIN=1 git commit -m "chore(release): v<version>"
    DEVLOOPS_ALLOW_MAIN=1 git push origin main
    ```
+
+   **Staging the release commit.** Stage the exact release files explicitly
+   (the version bump, `CHANGELOG.md`, and any regenerated assets) — never
+   `git add -A` or `git add .`. The release commit runs with
+   `DEVLOOPS_ALLOW_MAIN=1`, which intentionally turns the default-branch guard
+   off, so a broad add sweeps accumulated main-checkout scratch straight into
+   the release commit (this has already cost a cancelled publish run and a tag
+   re-cut). Before committing, run `git status --porcelain` and verify every
+   staged path is an intended release file; abort the commit if anything
+   unexpected is staged.
 2. Tag the release commit and push the tag:
 
    ```bash
@@ -53,6 +63,16 @@ the workflow does it (and is idempotent if you already created one).
 
 ## Failure modes
 
+- Release commit contains unintended content: cancel the publish run
+  **first** (the run is the irreversible step — it publishes from the tag),
+  then clean up `main`, then delete and re-cut the tag:
+
+  ```bash
+  gh run cancel <publish-run-id>          # 1. stop the publish run first
+  # 2. fix/remove the unintended commit on main (guard override as above)
+  git tag -d v<version> && git push origin :refs/tags/v<version>
+  git tag v<version> && git push origin v<version>   # 3. re-cut the tag
+  ```
 - Tag not on `main`: the release workflow fails the on-main guard — re-tag the
   correct commit.
 - Missing CHANGELOG section: the extraction step exits non-zero and no Release is

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -82,7 +82,8 @@ the workflow does it (and is idempotent if you already created one).
   and re-push:
 
   ```bash
-  DEVLOOPS_ALLOW_MAIN=1 git commit -am "docs: add v<version> CHANGELOG section"
+  DEVLOOPS_ALLOW_MAIN=1 git add CHANGELOG.md
+  DEVLOOPS_ALLOW_MAIN=1 git commit -m "docs: add v<version> CHANGELOG section"
   DEVLOOPS_ALLOW_MAIN=1 git push origin main
   git tag -f v<version>
   git push --force origin v<version>


### PR DESCRIPTION
## Summary
Persist release-commit staging + dirty-cut recovery guidance into the release runbook (`skills/docs/release-runbook.md`, mirrored to `.claude/skills/docs/`).

- **Staging:** stage the exact release files explicitly (version bump, CHANGELOG, regenerated assets); never `git add -A`/`git add .`. Check `git status --porcelain` before committing and abort if anything unexpected is staged — the release commit runs with `DEVLOOPS_ALLOW_MAIN=1` (guard intentionally off), so a broad add sweeps main-checkout scratch into the release commit (already cost a cancelled publish run + tag re-cut).
- **Dirty-cut recovery order (irreversible step first):** cancel the publish run first, then clean main, then delete + re-cut the tag.

## Scope and context
Docs-only change to the release procedure's system of record. Guidance is woven into the existing Procedure step 1 (staging) and Failure modes (dirty-cut recovery) so it sits where the release procedure is defined, not as a detached note. Tracker-backed local session: the tracker issue is the canonical spec-of-record; no duplicate phase doc.

## Acceptance criteria / Definition of done / Non-goals matrix

| Acceptance criterion (#1873) | Definition-of-done item | Non-goals respected |
|---|---|---|
| Explicit-file staging (never `git add -A`) + `git status --porcelain` pre-commit check documented for the release/reconcile commit | `skills/docs/release-runbook.md` updated; verify + assets:check green | No release-script changes; no re-documentation of tag/publish mechanics |
| Dirty-cut recovery order documented: cancel publish run → clean main → re-cut tag | Same DoD item; docs-only diff (source + generated mirror) | Same |
| Guidance placed where the release procedure is defined, not a detached note | Same DoD item; guidance woven into Procedure step 1 + Failure modes | Same |

## Acceptance criteria
- [x] The runbook documents explicit-file staging (never `git add -A`) and the `git status --porcelain` pre-commit check for the release/reconcile commit.
- [x] The runbook documents the dirty-cut recovery order: cancel publish run first, then clean main, then re-cut the tag.
- [x] The guidance is placed where the release procedure is defined, not a detached note.

## Definition of done
- [x] `skills/docs/release-runbook.md` updated; `npm run verify` + `assets:check` green (docs-only, no code change expected).

## Non-goals
- No change to the release scripts themselves.
- Not re-documenting tag/publish mechanics already in the runbook.

## Validation
- `npm run test:doc-guard` green (286/286 after regenerating the mirrored `.claude` asset)
- `npm run assets:check` green (90 checked)
- `npm run verify` green (all suites, 0 failures)
- Docs-only diff across 2 files (source + generated mirror)

Closes #1873
