### PR TITLE
test(review-exemption): behavioral pin of review ownership exemption on a foreign-owned PR

### DIFF
--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -9,6 +9,108 @@ import {
   USER_FACING_AGENT_SURFACE,
 } from "../imported-assets-helpers.mjs";
 import { assertRuleOwned } from "./_rule-helpers.mjs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { makeGhMock, resolverTestEnv, runNode, writeGhStub } from "../_helpers.mjs";
+
+// Behavioral pin for the standalone review ownership exemption (issue #1893,
+// fixing the AC over-claim PR 1851 shipped: its "tests pin review on a
+// foreign-owned PR proceeds (no gate block); a fix/merge route on the same
+// foreign PR is still blocked" AC was backed only by the doc-grep test
+// "standalone review route stays structurally decoupled..." below). This test
+// drives the REAL routing/exemption logic with one foreign-owned PR fixture,
+// both halves in one test so the DIFFERENTIAL itself is the pinned contract:
+//
+//   half A — the review pipeline entrypoint (write-gate-context.mjs --gate
+//   review, the first stage every /loop-review run executes) PROCEEDS on a
+//   foreign-owned PR and never resolves a viewer identity: makeGhMock answers
+//   ONLY the spec-of-record PR read and fails closed (exit 97) on any extra gh
+//   call, so wiring `gh api user` (or any viewer-identity read) into the review
+//   pipeline fails this test loudly.
+//
+//   half B — the write/merge startup route (resolve-dev-loop-startup.mjs
+//   --pr, the single-contributor ownership gate) on the SAME foreign-owned
+//   fixture fails closed naming the foreign assignee.
+test("behavioral pin: review proceeds on a foreign-owned PR while the write/merge startup route is blocked (issue #1893, AC for PR 1851)", async () => {
+  const REPO = "mfittko/dev-loops";
+  const PR = 740;
+  const HEAD_SHA = "e0f1c2d3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9";
+  const FOREIGN_ASSIGNEE = "foreign-dev";
+
+  // ---- Half A: the review pipeline proceeds on the foreign-owned PR ----
+  const { main, readGateContext } = await import("../../scripts/github/write-gate-context.mjs");
+  const reviewHalfRoot = mkdtempSync(path.join(os.tmpdir(), "review-pin-1893-a-"));
+  try {
+    const gh = makeGhMock([
+      {
+        assertArgs: ["pr", "view", String(PR), "--json", "body,closingIssuesReferences"],
+        stdout: JSON.stringify({
+          body: "Foreign-owned fixture PR (assigned to foreign-dev, not the current viewer).",
+          closingIssuesReferences: [],
+        }),
+      },
+    ]);
+
+    const savedExitCode = process.exitCode;
+    try {
+      await main([
+        "--repo", REPO,
+        "--pr", String(PR),
+        "--gate", "review",
+        "--head-sha", HEAD_SHA,
+        "--silent",
+      ], { repoRoot: reviewHalfRoot, run: gh.runChild });
+    } finally {
+      process.exitCode = savedExitCode;
+    }
+
+    // The review gate-context artifact exists: the review route proceeded all
+    // the way through Phase 1 on a PR the viewer does not own.
+    const artifact = await readGateContext(
+      { repo: REPO, pr: PR, gate: "review", headSha: HEAD_SHA, tmpRoot: "tmp" },
+      { repoRoot: reviewHalfRoot },
+    );
+    assert.ok(artifact, "review gate-context artifact written for the foreign-owned PR (the review route proceeded past ownership)");
+
+    // No viewer-identity resolution ever happened: the review half made exactly
+    // one gh call, the spec-of-record PR read — never `gh api user` (the
+    // ownership gate's mechanism). makeGhMock would have failed the run closed
+    // on any second call; this assertion pins that fact against the recorded
+    // calls so a future mock change cannot silently weaken the pin.
+    assert.equal(gh.calls.length, 1, `the review half must make exactly one gh call (the spec-of-record PR read), got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`);
+    assert.ok(gh.calls.every((call) => !call.args.includes("user") && call.args[0] !== "api"), `no gh api user call may occur in the review pipeline, got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`);
+  } finally {
+    rmSync(reviewHalfRoot, { recursive: true, force: true });
+  }
+
+  // ---- Half B: the write/merge startup route blocks on the SAME fixture ----
+  const resolverHalfRoot = mkdtempSync(path.join(os.tmpdir(), "review-pin-1893-b-"));
+  try {
+    execFileSync("git", ["init"], { cwd: resolverHalfRoot, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", `git@github.com:${REPO}.git`], { cwd: resolverHalfRoot, stdio: "ignore" });
+    const ghStub = await writeGhStub(resolverHalfRoot, [
+      {
+        assertArgs: ["pr", "view", String(PR)],
+        stdout: JSON.stringify({ state: "OPEN", mergedAt: null, assignees: [{ login: FOREIGN_ASSIGNEE }], closingIssuesReferences: [], body: "" }),
+      },
+      { assertArgs: ["api", "user"], stdout: JSON.stringify({ login: "test-viewer" }) },
+    ], { matchMode: "claims" });
+
+    const result = await runNode(path.resolve("scripts/loop/resolve-dev-loop-startup.mjs"), ["--pr", String(PR)], {
+      cwd: resolverHalfRoot,
+      env: { ...ghStub.env, ...resolverTestEnv({ DEVLOOPS_OWNERSHIP_BYPASS: undefined }) },
+    });
+
+    assert.equal(result.code, 1, `the write/merge startup route must exit 1 on the foreign-owned PR (got exit ${result.code}; stdout: ${result.stdout})`);
+    assert.equal(result.stdout, "", "no readiness bundle may be emitted for a foreign-owned PR");
+    assert.match(result.stderr, new RegExp(`PR #${PR} is assigned to ${FOREIGN_ASSIGNEE}, not the current viewer`));
+    assert.match(result.stderr, /fail closed/);
+  } finally {
+    rmSync(resolverHalfRoot, { recursive: true, force: true });
+  }
+});
 
 test("copilot skill does not contain known imported blocker phrases", async () => {
   const content = await readRepo("skills/copilot-pr-followup/SKILL.md");

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -287,6 +287,12 @@ test("CI gates the Playwright WebKit smoke behind inspect-run viewer change dete
 });
 
 test("standalone review route stays structurally decoupled from the single-contributor ownership gate (issue #1850)", async () => {
+  // Prose/structure companion to the behavioral pin above ("behavioral pin:
+  // review proceeds on a foreign-owned PR...", issue #1893): that test drives
+  // the actual routing/exemption logic on a foreign-owned PR fixture — the
+  // differential AC PR 1851 originally claimed — while THIS test pins the
+  // decoupling's doc/structure surface so the exemption's mechanism stays
+  // documented and structurally unreachable from the review pipeline.
   const [devLoopSkill, reviewSkill, publicContract, writeGateContextSrc, consolidateFaninSrc, upsertVerdictSrc] = await Promise.all([
     readRepo("skills/dev-loop/SKILL.md"),
     readRepo("skills/review/SKILL.md"),

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -22,13 +22,15 @@ import { makeGhMock, resolverTestEnv, runNode, writeGhStub, initGitFixture } fro
 // drives the REAL routing/exemption logic with one foreign-owned PR fixture,
 // both halves in one test so the DIFFERENTIAL itself is the pinned contract:
 //
-//   half A — the review pipeline entrypoint (write-gate-context.mjs --gate
-//   review, the first stage every /loop-review run executes) PROCEEDS on a
-//   foreign-owned PR and never resolves a viewer identity: makeGhMock answers
-//   the spec-of-record PR read (plus any legitimate closing-issue reads) and
-//   fails closed (exit 97) on any extra unstubbed gh call, so wiring `gh api
-//   user` (or any viewer-identity read) into the review pipeline fails this
-//   test loudly.
+//   half A — the review pipeline's Phase-1 entrypoint (write-gate-context.mjs
+//   --gate review, the first stage every /loop-review run executes) PROCEEDS
+//   on a foreign-owned PR and never resolves a viewer identity: makeGhMock
+//   answers the spec-of-record PR read (plus any legitimate closing-issue
+//   reads) and fails closed (exit 97) on any extra unstubbed gh call, so
+//   wiring `gh api user` (or any viewer-identity read) into write-gate-context
+//   fails this test loudly. (Phase 3 of the review pipeline — the verdict
+//   poster — DOES read `gh api user` for marker provenance; that is a
+//   different, exempt mechanism, NOT the ownership gate's.)
 //
 //   half B — the write/merge startup route (resolve-dev-loop-startup.mjs
 //   --pr, the single-contributor ownership gate) on the SAME foreign-owned
@@ -74,17 +76,19 @@ test("behavioral pin: review proceeds on a foreign-owned PR while the write/merg
     );
     assert.ok(artifact, "review gate-context artifact written for the foreign-owned PR (the review route proceeded past ownership)");
 
-    // No viewer-identity resolution ever happened: the review pipeline never
-    // calls `gh api user` — the ownership gate's mechanism — regardless of the
-    // PR's spec shape (a closing-issue fixture legitimately makes additional
-    // gh calls, e.g. viewIssue in resolvePrSpecContext, so the pin is on the
+    // No viewer-identity resolution ever happened in the pinned Phase-1
+    // surface: write-gate-context --gate review never calls `gh api user` —
+    // the ownership gate's mechanism — regardless of the PR's spec shape (a
+    // closing-issue fixture legitimately makes additional stubbed gh calls,
+    // e.g. viewIssue in resolvePrSpecContext, so the pin is on the
     // viewer-identity read specifically, never on an exact call count; the
     // coverage angle's round-3 finding). makeGhMock still fails closed on any
     // UNSTUBBED gh call, so a wired-in ownership read would fail loudly even
-    // before this assertion.
+    // before this assertion. (Phase 3's marker-provenance `api user` read in
+    // the verdict poster is a different, exempt mechanism, not pinned here.)
     assert.ok(
       gh.calls.every((call) => !(call.args[0] === "api" && call.args[1] === "user")),
-      `no gh api user (viewer-identity) call may occur in the review pipeline, got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`,
+      `no gh api user (viewer-identity) call may occur in write-gate-context --gate review, got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`,
     );
   } finally {
     rmSync(reviewHalfRoot, { recursive: true, force: true });

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -9,11 +9,10 @@ import {
   USER_FACING_AGENT_SURFACE,
 } from "../imported-assets-helpers.mjs";
 import { assertRuleOwned } from "./_rule-helpers.mjs";
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { makeGhMock, resolverTestEnv, runNode, writeGhStub } from "../_helpers.mjs";
+import { makeGhMock, resolverTestEnv, runNode, writeGhStub, initGitFixture } from "../_helpers.mjs";
 
 // Behavioral pin for the standalone review ownership exemption (issue #1893,
 // fixing the AC over-claim PR 1851 shipped: its "tests pin review on a
@@ -88,8 +87,11 @@ test("behavioral pin: review proceeds on a foreign-owned PR while the write/merg
   // ---- Half B: the write/merge startup route blocks on the SAME fixture ----
   const resolverHalfRoot = mkdtempSync(path.join(os.tmpdir(), "review-pin-1893-b-"));
   try {
-    execFileSync("git", ["init"], { cwd: resolverHalfRoot, stdio: "ignore" });
-    execFileSync("git", ["remote", "add", "origin", `git@github.com:${REPO}.git`], { cwd: resolverHalfRoot, stdio: "ignore" });
+    // initGitFixture (not a bare execFileSync git init): it hardens the git
+    // calls against an ambient GIT_DIR/GIT_WORK_TREE redirect (the hazard its
+    // own JSDoc documents) and persists a repo-local identity — the
+    // determinism angle's finding (draft_gate round 2).
+    initGitFixture(resolverHalfRoot, { remote: `git@github.com:${REPO}.git`, commit: null });
     const ghStub = await writeGhStub(resolverHalfRoot, [
       {
         assertArgs: ["pr", "view", String(PR)],

--- a/test/contracts/review-doc-contracts.test.mjs
+++ b/test/contracts/review-doc-contracts.test.mjs
@@ -25,9 +25,10 @@ import { makeGhMock, resolverTestEnv, runNode, writeGhStub, initGitFixture } fro
 //   half A — the review pipeline entrypoint (write-gate-context.mjs --gate
 //   review, the first stage every /loop-review run executes) PROCEEDS on a
 //   foreign-owned PR and never resolves a viewer identity: makeGhMock answers
-//   ONLY the spec-of-record PR read and fails closed (exit 97) on any extra gh
-//   call, so wiring `gh api user` (or any viewer-identity read) into the review
-//   pipeline fails this test loudly.
+//   the spec-of-record PR read (plus any legitimate closing-issue reads) and
+//   fails closed (exit 97) on any extra unstubbed gh call, so wiring `gh api
+//   user` (or any viewer-identity read) into the review pipeline fails this
+//   test loudly.
 //
 //   half B — the write/merge startup route (resolve-dev-loop-startup.mjs
 //   --pr, the single-contributor ownership gate) on the SAME foreign-owned
@@ -73,13 +74,18 @@ test("behavioral pin: review proceeds on a foreign-owned PR while the write/merg
     );
     assert.ok(artifact, "review gate-context artifact written for the foreign-owned PR (the review route proceeded past ownership)");
 
-    // No viewer-identity resolution ever happened: the review half made exactly
-    // one gh call, the spec-of-record PR read — never `gh api user` (the
-    // ownership gate's mechanism). makeGhMock would have failed the run closed
-    // on any second call; this assertion pins that fact against the recorded
-    // calls so a future mock change cannot silently weaken the pin.
-    assert.equal(gh.calls.length, 1, `the review half must make exactly one gh call (the spec-of-record PR read), got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`);
-    assert.ok(gh.calls.every((call) => !call.args.includes("user") && call.args[0] !== "api"), `no gh api user call may occur in the review pipeline, got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`);
+    // No viewer-identity resolution ever happened: the review pipeline never
+    // calls `gh api user` — the ownership gate's mechanism — regardless of the
+    // PR's spec shape (a closing-issue fixture legitimately makes additional
+    // gh calls, e.g. viewIssue in resolvePrSpecContext, so the pin is on the
+    // viewer-identity read specifically, never on an exact call count; the
+    // coverage angle's round-3 finding). makeGhMock still fails closed on any
+    // UNSTUBBED gh call, so a wired-in ownership read would fail loudly even
+    // before this assertion.
+    assert.ok(
+      gh.calls.every((call) => !(call.args[0] === "api" && call.args[1] === "user")),
+      `no gh api user (viewer-identity) call may occur in the review pipeline, got: ${JSON.stringify(gh.calls.map((c) => c.args.join(" ")))}`,
+    );
   } finally {
     rmSync(reviewHalfRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Summary

PR 1851's AC over-claim: adds the missing behavioral pin of the review-gate
ownership exemption. Test-only change — one file, 120 added lines, zero
product-code changes (`test/contracts/review-doc-contracts.test.mjs`).

Fixes #1893

## Problem

Issue #1893 (rc.7 fresh-context retro triage, #1874) found that PR 1851
marked the acceptance criterion *"Tests pin: review on a foreign-owned PR
proceeds (no gate block); a fix/merge route on the same foreign PR is
still blocked by the gate"* as satisfied, but the shipped test
(`test/contracts/review-doc-contracts.test.mjs`, "standalone review route
stays structurally decoupled…") proves neither behavior: it greps
SKILL/contract prose for router-short-circuit strings and asserts three
pipeline scripts do not reference `resolve-dev-loop-startup`. The
exemption was enforced only by agent discipline; the AC-required
behavioral proof did not exist.

## Scope and context

- In scope: add the differential behavioral test the AC claimed; retain
  the doc-grep test as the prose/structure companion with a pointer
  comment.
- Out of scope: changing the standalone review ownership exemption itself
  (landed correctly in PR 1851's prose and code); any product-code change
  (`resolve-dev-loop-startup.mjs`, `write-gate-context.mjs`, and all other
  scripts are untouched).

## Change

- **New behavioral pin** — `behavioral pin: review proceeds on a
  foreign-owned PR while the write/merge startup route is blocked
  (issue #1893, AC for PR 1851)`. One foreign-owned PR fixture (PR #740
  assigned to `foreign-dev`, viewer `test-viewer`) drives both real code
  paths so the **differential itself** is the pinned contract:
  - **Half A — review proceeds:** `write-gate-context.mjs --gate review`
    (the review pipeline's Phase-1 entrypoint, the first stage every
    `/loop-review` run executes) completes and writes its gate-context
    artifact. The pin is on the viewer-identity read specifically: no
    recorded gh call may be `gh api user` (the ownership gate's
    mechanism), never an exact call count — a closing-issue fixture
    legitimately makes additional stubbed gh calls (e.g. `viewIssue` in
    `resolvePrSpecContext`). `makeGhMock` fails closed on any extra
    UNSTUBBED gh call, so wiring a viewer-identity read into the review
    pipeline fails this test loudly.
  - **Half B — write/merge route blocks:** the same foreign-owned fixture
    driven through `resolve-dev-loop-startup.mjs --pr` (the
    single-contributor ownership gate) exits 1, names the foreign
    assignee, and emits no readiness bundle.
- **Doc-grep test retained as the prose/structure companion**, with a
  new comment pointing at the behavioral pin as the AC's real evidence
  (issue #1893's "replacing or superseding" satisfied by superseding the
  AC's evidentiary basis).

## Acceptance criteria

Linked issue #1893's acceptance criteria, with evidence:

- [x] No [x] on a behavioral-test AC that only a doc-grep backs; AC text
  and evidence match — the behavioral pin test
  (`test/contracts/review-doc-contracts.test.mjs`, first test after the
  imports) drives the actual routing/exemption logic on a foreign-owned
  PR fixture; the doc-grep test's header comment now names it as the
  AC's real evidence.

## Definition of done

- [x] `npm run verify` green including the new behavioral test (exit 0,
  all suites: assets/core/scripts/extension/dev-loop/pack/docs/workflows).
- [x] Only the test file changed (`git diff --stat origin/main...HEAD`:
  1 file, 120 insertions); no product-code changes.
- [x] Doc-grep test retained as the prose/structure companion with a
  pointer comment to the behavioral pin.
- [x] New test run in isolation passes; resolver startup suite re-run
  green (120/120).

## Validation

- `npm run verify` — exit 0, all suites green (test:assets 306 incl. the
  new behavioral test; core 2973, scripts 4475, extension, dev-loop,
  pack, docs, workflows legs; 0 failures, 0 cancelled).
  The new behavioral test runs in `test:assets` and `test:doc-guard`
  (`test/contracts/*.test.mjs`), not `test:scripts`.
- New test run in isolation: `node --test --test-name-pattern "issue
  #1893" test/contracts/review-doc-contracts.test.mjs` — pass.
- `test:doc-guard` (all `test/contracts/*.test.mjs` + workflow handoff
  contract) — 300/300 pass.
- Resolver startup suite re-run (`test/loop/resolve-dev-loop-startup.test.mjs`)
  — 120/120 pass (half B agrees with that suite's ownership-gate contract).

## Non-goals

- Not changing the standalone review ownership exemption itself (it
  landed correctly in PR 1851's prose and code) — this PR only adds the
  missing behavioral evidence the AC claimed.
- No product-code changes: `resolve-dev-loop-startup.mjs`,
  `write-gate-context.mjs`, and all other scripts are untouched.

## Size

1 file changed, 120 insertions(+), 0 deletions(-). Test-only pack-in
(no tracked-file product changes; the only tracked-file change is this
test file).
