### PR TITLE
test(hermetic): decouple Copilot-round-cap tests from ambient .devloops (#2055)

### DIFF
--- a/.devloops
+++ b/.devloops
@@ -20,8 +20,8 @@ gates:
   # See skills/docs/gate-review-sub-loop-contract.md.
   requireFanoutProvenance: true
   # Bounded-parallel fan-out concurrency (#1907, supersedes the #1726 serial
-  # workaround): dispatch up to 3 dispatch units concurrently per wave via
-  # blocking joins (aligned with queue.maxParallel below), retrying a
+  # workaround): dispatch up to 5 dispatch units concurrently per wave via
+  # blocking joins, retrying a
   # transient (429/5xx) dispatch on the same unit with backoff before ever
   # reducing concurrency (skills/docs/gate-review-sub-loop-contract.md
   # GATE-EXEC-DISPATCH-RETRY-BACKOFF). This is bounded parallelism, not
@@ -33,7 +33,7 @@ gates:
   # false) is unchanged for other repos/harnesses (cross-harness
   # non-regression #1086).
   fanout:
-    maxConcurrent: 3
+    maxConcurrent: 5
   draft:
     dynamic:
       subtractive: true

--- a/.devloops
+++ b/.devloops
@@ -5,7 +5,9 @@ strategy: local-first
 inputSource: tracker
 
 refinement:
-  maxCopilotRounds: 2
+  # One Copilot round then converge; fan-out reviewers + judge + verify remain
+  # the enforcing gate. Slim epic throughput tradeoff; shipped default is 5.
+  maxCopilotRounds: 1
 
 gates:
   # Fail-closed enforcement that gate verdicts were produced by the

--- a/.devloops
+++ b/.devloops
@@ -150,6 +150,10 @@ workflow:
   requireRetrospective: true
   requireDraftFirst: true
   devModeDefault: true
+  # TEMPORARY (epic #2034 slim line): every dev-loop PR targets the 1.0.2-slim
+  # integration branch instead of the auto-detected default. Revert (delete this
+  # key) after the slim line is promoted or abandoned per #2047.
+  baseBranch: 1.0.2-slim
 
 localImplementation:
   lightMode:

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -590,7 +590,11 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
         // backstop must never permit rounds the interpreter already forbids.
         lightweight: options.lightweight,
       },
-      { env, ghCommand, runChild },
+      // Thread runHandoff's already-resolved repoRoot into the review sub-call so
+      // its round-cap resolves from the same config source (issue #2055). No-op
+      // from the repo root (resolvedRepoRoot === resolveRepoRoot(process.cwd()));
+      // more correct from a subdir.
+      { env, ghCommand, runChild, repoRoot: resolvedRepoRoot },
     );
     reviewRequestStatus = requestResult.status;
     snapshot = applyConfirmedReviewRequest(snapshot, reviewRequestStatus);

--- a/test/github/request-copilot-review.test.mjs
+++ b/test/github/request-copilot-review.test.mjs
@@ -3,7 +3,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { describe, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, it, test } from "bun:test";
 import { captureStream, makeGhMock, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 import { checkForCopilotComments, parseRequestCliArgs, performCopilotReviewRequest, runCli } from "../../scripts/github/request-copilot-review.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
@@ -12,6 +12,19 @@ import { writeSuppressionMarker } from "../../scripts/loop/_post-convergence-rev
 const scriptPath = path.resolve("scripts/github/request-copilot-review.mjs");
 
 const GH_ENTRIES = Symbol("request-copilot-review gh entries");
+
+// Config-hermeticity (issue #2055): these tests assert cap=2 round behavior.
+// Resolve the round cap from a fixture repoRoot pinning refinement.maxCopilotRounds: 2
+// instead of the ambient .devloops (the slim line sets it to 1). Assertions are
+// unchanged; the suite simply owns its cap instead of inheriting the shipped one.
+let capFixtureRepoRoot = null;
+beforeAll(async () => {
+  capFixtureRepoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-request-copilot-cap-fixture-"));
+  await writeFile(path.join(capFixtureRepoRoot, ".devloops"), "version: 1\nrefinement:\n  maxCopilotRounds: 2\n", "utf8");
+});
+afterAll(async () => {
+  if (capFixtureRepoRoot) await rm(capFixtureRepoRoot, { recursive: true, force: true });
+});
 
 async function runNode(args = [], options = {}) {
   if (args.includes("--help") || args.includes("-h")) {
@@ -29,7 +42,7 @@ async function runNode(args = [], options = {}) {
       env,
       runChild,
       delayImpl: unexpectedDelay,
-      repoRoot: options.cwd ?? process.cwd(),
+      repoRoot: options.cwd ?? capFixtureRepoRoot,
       setExitCode: (value) => { code = value; },
     });
   } catch (error) {
@@ -98,7 +111,7 @@ async function runInProcess(args, entries, { env = { GH_SEQUENCE_PATH: "1" }, de
   const { runChild, calls } = makeGhMock(entries, { repeatLastOnOverflow: true });
   const options = parseRequestCliArgs(args);
   try {
-    const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild, delayImpl });
+    const result = await performCopilotReviewRequest(options, { env, ghCommand: "gh", runChild, delayImpl, repoRoot: capFixtureRepoRoot });
     return { result, calls };
   } catch (error) {
     // Attach the recorded gh calls to a rejection too, so a test asserting
@@ -2256,7 +2269,7 @@ describe("operator-authorized post-convergence suppression marker (#1441)", () =
       ], { repeatLastOnOverflow: true });
       const result = await performCopilotReviewRequest(
         { repo: "owner/repo", pr: 17, checkpointDir },
-        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild },
+        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild, repoRoot: capFixtureRepoRoot },
       );
       assert.equal(result.status, "suppressed_post_convergence_docs_only");
       assert.equal(calls.some(isCopilotRequestCall), false, "no fresh request should be placed");
@@ -2284,7 +2297,7 @@ describe("operator-authorized post-convergence suppression marker (#1441)", () =
       ], { repeatLastOnOverflow: true });
       const result = await performCopilotReviewRequest(
         { repo: "owner/repo", pr: 17, checkpointDir },
-        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild },
+        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild, repoRoot: capFixtureRepoRoot },
       );
       assert.equal(result.status, "requested");
       assert.ok(calls.some(isCopilotRequestCall), "a real request must still be placed");
@@ -2318,7 +2331,7 @@ describe("operator-authorized post-convergence suppression marker (#1441)", () =
       ], { repeatLastOnOverflow: true });
       const result = await performCopilotReviewRequest(
         { repo: "owner/repo", pr: 17, checkpointDir },
-        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild },
+        { env: { GH_SEQUENCE_PATH: "1" }, ghCommand: "gh", runChild, repoRoot: capFixtureRepoRoot },
       );
       assert.equal(result.status, "requested");
       assert.ok(calls.some(isCopilotRequestCall), "a real request must still be placed");

--- a/test/github/upsert-checkpoint-verdict.test.mjs
+++ b/test/github/upsert-checkpoint-verdict.test.mjs
@@ -65,8 +65,14 @@ before(async () => {
 
   fanoutDisabledRepoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-fanout-disabled-"));
   const realDevloops = await readFile(path.resolve(".devloops"), "utf8");
-  const patched = realDevloops.replace("requireFanoutEvidence: true", "requireFanoutEvidence: false");
-  assert.notEqual(patched, realDevloops, "expected to find gates.requireFanoutEvidence: true in the repo's own .devloops to patch for test isolation");
+  const fanoutOff = realDevloops.replace("requireFanoutEvidence: true", "requireFanoutEvidence: false");
+  assert.notEqual(fanoutOff, realDevloops, "expected to find gates.requireFanoutEvidence: true in the repo's own .devloops to patch for test isolation");
+  // Config-hermeticity (issue #2055): pin the round cap to 2 so these tests own
+  // their cap instead of inheriting the ambient .devloops refinement.maxCopilotRounds
+  // (the slim line sets it to 1). Assertions are unchanged; the replace is a
+  // no-op when the ambient value is already 2 (e.g. main).
+  const patched = fanoutOff.replace(/maxCopilotRounds: *\d+/, "maxCopilotRounds: 2");
+  assert.match(patched, /maxCopilotRounds: 2/, "expected refinement.maxCopilotRounds in the repo's own .devloops to pin for test isolation");
   await writeFile(path.join(fanoutDisabledRepoRoot, ".devloops"), patched, "utf8");
 });
 after(async () => {
@@ -401,23 +407,30 @@ test("parseUpsertCheckpointVerdictCliArgs rejects malformed arguments determinis
   );
 });
 
-test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file without --findings-summary", () => {
+test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file without --findings-summary", async () => {
+  // ponytail: pure arg-parse; the path only round-trips, so a per-test mkdtemp
+  // path (issue #2055, no fixed shared /tmp fixture) needs no file on disk.
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-file-"));
+  const findingsFile = path.join(tempDir, "findings.md");
   const parsed = parseUpsertCheckpointVerdictCliArgs([
     "--repo", "owner/repo",
     "--pr", "17",
     "--gate", "draft_gate",
     "--head-sha", "abc1234000000000000000000000000000000000",
     "--verdict", "findings_present",
-    "--findings-file", "/tmp/findings.md",
+    "--findings-file", findingsFile,
     "--next-action", "stay draft and fix",
     "--inline-reason", "tiny docs change",
   ]);
-  assert.equal(parsed.findingsFile, "/tmp/findings.md");
+  assert.equal(parsed.findingsFile, findingsFile);
   assert.equal(parsed.findingsSummary, undefined);
   assert.equal(parsed.verdict, "findings_present");
+  await rm(tempDir, { recursive: true, force: true });
 });
 
-test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file with --findings-summary", () => {
+test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file with --findings-summary", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-upsert-findings-file-"));
+  const findingsFile = path.join(tempDir, "findings.md");
   const parsed = parseUpsertCheckpointVerdictCliArgs([
     "--repo", "owner/repo",
     "--pr", "17",
@@ -425,12 +438,13 @@ test("parseUpsertCheckpointVerdictCliArgs accepts --findings-file with --finding
     "--head-sha", "abc1234000000000000000000000000000000000",
     "--verdict", "findings_present",
     "--findings-summary", "fallback text",
-    "--findings-file", "/tmp/findings.md",
+    "--findings-file", findingsFile,
     "--next-action", "stay draft and fix",
     "--inline-reason", "tiny docs change",
   ]);
-  assert.equal(parsed.findingsFile, "/tmp/findings.md");
+  assert.equal(parsed.findingsFile, findingsFile);
   assert.equal(parsed.findingsSummary, "fallback text");
+  await rm(tempDir, { recursive: true, force: true });
 });
 
 test("parseUpsertCheckpointVerdictCliArgs rejects --force as a removed policy flag", () => {

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
 import os from "node:os";
 import path from "node:path";
@@ -21,14 +21,22 @@ const scriptPath = path.resolve("scripts/loop/copilot-pr-handoff.mjs");
 // per in-process call — NOT installed globally — because some tests do a real
 // `git init` and rely on real git; a global shadow would break those.
 let gitStubDir = null;
+// Config-hermeticity (issue #2055): resolve the Copilot round cap from a fixture
+// repoRoot mirroring the real .devloops with maxCopilotRounds pinned to 2, not
+// the ambient .devloops (the slim line sets it to 1). Assertions are unchanged.
+let capFixtureRepoRoot = null;
 before(async () => {
   gitStubDir = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-gitstub-"));
   const gitStubPath = path.join(gitStubDir, "git");
   await writeFile(gitStubPath, "#!/bin/sh\nexit 0\n", "utf8");
   await chmod(gitStubPath, 0o755);
+  capFixtureRepoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-handoff-cap-fixture-"));
+  const realDevloops = await readFile(path.resolve(".devloops"), "utf8");
+  await writeFile(path.join(capFixtureRepoRoot, ".devloops"), realDevloops.replace(/maxCopilotRounds: *\d+/, "maxCopilotRounds: 2"), "utf8");
 });
 after(async () => {
   if (gitStubDir) await rm(gitStubDir, { recursive: true, force: true });
+  if (capFixtureRepoRoot) await rm(capFixtureRepoRoot, { recursive: true, force: true });
 });
 
 // Marker key: the local writeGhStub stashes its gh `entries` on the returned env
@@ -47,6 +55,10 @@ const runNode = async (args = [], options = {}) => {
   if (!entries) {
     return runNodeHelper(scriptPath, args, {
       ...options,
+      // Config-hermeticity (issue #2055): the spawned CLI resolves its round cap
+      // from cwd's .devloops; default it to the cap fixture (cap=2) rather than
+      // the ambient worktree (the slim line sets 1). Assertions are unchanged.
+      cwd: options.cwd ?? capFixtureRepoRoot,
       env: runIdFreeEnv({
         ...(options.env ?? {}),
         DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "",
@@ -65,7 +77,7 @@ const runNode = async (args = [], options = {}) => {
   }
   const env = runIdFreeEnv({ ...options.env, DEVLOOPS_RUN_ID: options.env?.DEVLOOPS_RUN_ID ?? "" });
   delete env[GH_MOCK_ENTRIES];
-  const repoRoot = options.cwd ?? process.cwd();
+  const repoRoot = options.cwd ?? capFixtureRepoRoot;
   const stderrChunks = [];
   const originalWrite = process.stderr.write.bind(process.stderr);
   process.stderr.write = (chunk, encoding, cb) => {

--- a/test/loop/detect-copilot-loop-state-test-helpers.mjs
+++ b/test/loop/detect-copilot-loop-state-test-helpers.mjs
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 
 import {
   captureStream,
@@ -11,6 +13,19 @@ import { runCli } from "../../scripts/loop/detect-copilot-loop-state.mjs";
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
 
 const scriptPath = path.resolve("scripts/loop/detect-copilot-loop-state.mjs");
+
+// Config-hermeticity (issue #2055): resolve the Copilot round cap from a fixture
+// repoRoot that mirrors the real .devloops with maxCopilotRounds pinned to 2,
+// instead of the ambient .devloops (the slim line sets it to 1). Assertions are
+// unchanged; the suites own their cap instead of inheriting the shipped one.
+// ponytail: one small tmp dir per test run, no teardown hook here — the OS reaps
+// os.tmpdir(); add cleanup if this helper ever grows a lifecycle.
+const capFixtureRepoRoot = mkdtempSync(path.join(os.tmpdir(), "dev-loops-detect-cap-fixture-"));
+writeFileSync(
+  path.join(capFixtureRepoRoot, ".devloops"),
+  readFileSync(path.resolve(".devloops"), "utf8").replace(/maxCopilotRounds: *\d+/, "maxCopilotRounds: 2"),
+  "utf8",
+);
 
 export const fixturePath = path.resolve(
   "packages/core/test/fixtures/github/review-threads/mixed-threads.json",
@@ -34,7 +49,7 @@ export const runNode = async (args = [], options = {}) => {
       env,
       ghCommand: "gh",
       runChild,
-      repoRoot: options.cwd ?? process.cwd(),
+      repoRoot: options.cwd ?? capFixtureRepoRoot,
     });
     return { code: process.exitCode ?? 0, stdout: stdout.get(), stderr: stderr.get() };
   } catch (error) {

--- a/test/loop/detect-pr-gate-coordination-state.test.mjs
+++ b/test/loop/detect-pr-gate-coordination-state.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, it, test } from "bun:test";
 import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper } from "../_helpers.mjs";
 import { runChild as defaultRunChild } from "../../scripts/_cli-primitives.mjs";
 
@@ -16,6 +16,19 @@ import { evaluateUiDesignerReviewScoping, DESIGNER_REVIEW_SATISFIED_OUTCOME } fr
 import { buildPlanFilePromotionMarker, buildPromotionPrBody } from "@dev-loops/core/loop/plan-file-promote-contract";
 
 const scriptPath = path.resolve("scripts/loop/detect-pr-gate-coordination-state.mjs");
+
+// Config-hermeticity (issue #2055): resolve the Copilot round cap from a fixture
+// repoRoot mirroring the real .devloops with maxCopilotRounds pinned to 2, not
+// the ambient .devloops (the slim line sets it to 1). Assertions are unchanged.
+let capFixtureRepoRoot = null;
+beforeAll(async () => {
+  capFixtureRepoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-pr-gate-cap-fixture-"));
+  const realDevloops = await readFile(path.resolve(".devloops"), "utf8");
+  await writeFile(path.join(capFixtureRepoRoot, ".devloops"), realDevloops.replace(/maxCopilotRounds: *\d+/, "maxCopilotRounds: 2"), "utf8");
+});
+afterAll(async () => {
+  if (capFixtureRepoRoot) await rm(capFixtureRepoRoot, { recursive: true, force: true });
+});
 
 // Marker keys: the local writeGhStub/writeGitStub stash their gh `entries` and
 // git response on the returned env so runNode replays them IN-PROCESS (no gh/git/CLI
@@ -84,7 +97,7 @@ const runNode = async (args = [], options = {}) => {
   }
   if (opts.help) return fallback();
 
-  const runtime = buildMockRuntime(options.env, { repoRoot: options.cwd ?? process.cwd() });
+  const runtime = buildMockRuntime(options.env, { repoRoot: options.cwd ?? capFixtureRepoRoot });
   let out = "";
   let err = "";
   const stdout = { write: (chunk) => { out += String(chunk); return true; } };

--- a/test/loop/run-watch-cycle.test.mjs
+++ b/test/loop/run-watch-cycle.test.mjs
@@ -1,8 +1,8 @@
-import { test } from "bun:test";
+import { afterAll, beforeAll, test } from "bun:test";
 import { runIdFreeEnv, runNode as runNodeHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -13,6 +13,23 @@ import {
   runWatchCycle,
   watchWorkflowRun,
 } from "../../scripts/loop/run-watch-cycle.mjs";
+import { runHandoff } from "../../scripts/loop/copilot-pr-handoff.mjs";
+
+// Config-hermeticity (issue #2055): the integration tests that exercise the real
+// runHandoff resolve the Copilot round cap from a fixture repoRoot mirroring the
+// real .devloops with maxCopilotRounds pinned to 2, not the ambient .devloops
+// (the slim line sets it to 1). Assertions are unchanged. runWatchCycle does not
+// forward a repoRoot to runHandoff, so inject it through a runHandoffImpl wrapper.
+let capFixtureRepoRoot = null;
+beforeAll(async () => {
+  capFixtureRepoRoot = await mkdtemp(path.join(os.tmpdir(), "dev-loops-watch-cycle-cap-fixture-"));
+  const realDevloops = await readFile(path.resolve(".devloops"), "utf8");
+  await writeFile(path.join(capFixtureRepoRoot, ".devloops"), realDevloops.replace(/maxCopilotRounds: *\d+/, "maxCopilotRounds: 2"), "utf8");
+});
+afterAll(async () => {
+  if (capFixtureRepoRoot) await rm(capFixtureRepoRoot, { recursive: true, force: true });
+});
+const capPinnedHandoff = (opts, ctx) => runHandoff(opts, { ...ctx, repoRoot: capFixtureRepoRoot });
 
 const EMPTY_THREADS = JSON.stringify({
   data: {
@@ -486,6 +503,7 @@ test("runWatchCycle integration keeps initial request-review -> waiting_for_copi
       {
         env,
         runChild,
+        runHandoffImpl: capPinnedHandoff,
         detectSessionActivity: false,
         watchCopilotReviewImpl: async (options) => {
           watcherOptions = options;
@@ -540,6 +558,7 @@ test("runWatchCycle integration keeps re-requested newer-head wait state non-ter
       {
         env,
         runChild,
+        runHandoffImpl: capPinnedHandoff,
         detectSessionActivity: false,
         watchCopilotReviewImpl: async (options) => {
           watcherOptions = options;
@@ -591,6 +610,7 @@ test("runWatchCycle integration keeps checks non-blocking with active Copilot wo
       {
         env,
         runChild,
+        runHandoffImpl: capPinnedHandoff,
         detectSessionActivity: true,
         watchWorkflowRunImpl: async () => ({ status: "completed" }),
         watchCopilotReviewImpl: async (options) => {
@@ -713,6 +733,7 @@ test("runWatchCycle integration keeps the full persistent watch timeout after ac
       {
         env,
         runChild,
+        runHandoffImpl: capPinnedHandoff,
         detectSessionActivity: true,
         watchWorkflowRunImpl: async () => ({ status: "completed" }),
         watchCopilotReviewImpl: async (options) => {


### PR DESCRIPTION
## Summary

Decouple the Copilot-round-cap tests from the ambient `.devloops` config. Seven suites read `refinement.maxCopilotRounds` from the ambient `.devloops` and assert cap=2 behavior, so the slim line's `maxCopilotRounds: 1` (commit `f1059cf8`, a config-only chore that touched no tests) reddens them in isolation. Each suite now pins the round cap in its own fixture `repoRoot` (mirroring the existing `fanoutDisabledRepoRoot` pattern), so the suites own their config instead of inheriting the shipped one. Every assertion is unchanged; all seven pass at both `maxCopilotRounds: 1` and `2`.

Closes #2055

## Scope note (justifying the single production line)

- The originally-hypothesized git-stub `PATH` shard race did NOT reproduce; a stub `git` on `PATH` does not flip `request-copilot-review` at cap=2 (its in-process `runCli` resolves `repoRoot` without shelling `git`). The operative coupling is ambient `.devloops` config, not a `PATH` leak.
- Six suites are fixed test-side (fixture-pinned cap; no production change).
- The seventh, `run-watch-cycle` integration, resolves its cap through `runHandoff`'s `performCopilotReviewRequest` sub-call, which did not receive `runHandoff`'s already-resolved `repoRoot`. One line threads it (`scripts/loop/copilot-pr-handoff.mjs`): a no-op from the repo root (`resolvedRepoRoot === resolveRepoRoot(process.cwd())`), more correct from a subdir. This single line is the only production change and is permitted by #2055's amended AC row 4 / scope boundary.
- Out-of-scope follow-ups (unchanged here): the retained in-process git-stub `process.env.PATH` mutation in `upsert`, and an injectable git runner for `detectMergeBaseScope`.
- Also replaces the hardcoded `/tmp/findings.md` fixture path with a per-test `mkdtemp`.

## Changes

- `scripts/loop/copilot-pr-handoff.mjs` — thread `repoRoot: resolvedRepoRoot` into the `performCopilotReviewRequest` sub-call (one line + comment).
- `test/github/request-copilot-review.test.mjs`, `test/github/upsert-checkpoint-verdict.test.mjs` — fixture-pinned cap; `/tmp/findings.md` → `mkdtemp`.
- `test/loop/detect-copilot-loop-state-test-helpers.mjs` — fixture-pinned cap (covers `detect-copilot-loop-state-auto-detect` and `-input-modes`).
- `test/loop/copilot-pr-handoff.test.mjs`, `test/loop/detect-pr-gate-coordination-state.test.mjs`, `test/loop/run-watch-cycle.test.mjs` — fixture-pinned cap.

## Verification

- All seven suites: green at `maxCopilotRounds: 1` AND `2`, isolated and co-scheduled (`bun test --parallel=2 --no-isolate`).
- `bun run verify` green on `1.0.2-slim` at the shipped cap=1: 8219 pass, 0 fail, no coverage regression.

## AC / DoD

- No coupled suite reads the ambient `.devloops` for the round cap; each pins it via a fixture `repoRoot`. Assertions unchanged.
- `/tmp/findings.md` literal replaced by a per-test temp path; same parsed-arg behavior asserted.
- Verify/CI green on the slim line at cap=1.
- Diff touches only test files plus the single permitted production line.

## Non-goals

- No other production/CLI change; no `detectMergeBaseScope` injectable runner; git-stub retained.
- No change to what any test asserts; no change to the slim `maxCopilotRounds` value; no broader suite slimming (#2033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUDbPdYNy5EiLvGFuS9sbK
