### PR TITLE
refactor(github): consolidate the identical read-command execution shell (#2037)

### DIFF
--- a/scripts/github/list-issues.mjs
+++ b/scripts/github/list-issues.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, isDirectCliRun } from "../_core-helpers.mjs";
 import { requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { listIssues as coreListIssues } from "@dev-loops/core/github/issue-ops";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, matchJqOutputToken, runReadCommandCli } from "../lib/jq-output.mjs";
 
 const STATES = new Set(["open", "closed", "all"]);
 
@@ -112,29 +112,8 @@ export async function listIssues(options, { env = process.env, ghCommand = "gh",
   return coreListIssues(options, { env, ghCommand, run });
 }
 
-export async function runCli(
-  argv = process.argv.slice(2),
-  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run = runChild } = {},
-) {
-  let options;
-  try {
-    options = parseListIssuesCliArgs(argv);
-  } catch (error) {
-    stderr.write(`${formatCliError(error)}\n`);
-    return 1;
-  }
-  if (options.help) {
-    stdout.write(`${USAGE}\n`);
-    return 0;
-  }
-  let result;
-  try {
-    result = await listIssues(options, { env, ghCommand, run });
-  } catch (error) {
-    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
-    return 1;
-  }
-  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+export async function runCli(argv = process.argv.slice(2), io = {}) {
+  return runReadCommandCli({ parse: parseListIssuesCliArgs, operate: listIssues, usage: USAGE }, argv, io);
 }
 
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/github/view-issue.mjs
+++ b/scripts/github/view-issue.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun } from "../_core-helpers.mjs";
+import { buildParseError, isDirectCliRun } from "../_core-helpers.mjs";
 import { parseIssueNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { viewIssue as coreViewIssue, VIEW_ISSUE_DEFAULT_FIELDS } from "@dev-loops/core/github/issue-ops";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, matchJqOutputToken, runReadCommandCli } from "../lib/jq-output.mjs";
 
 // Default issue facts a follow-up run reads: body + identity/state for AC
 // checkbox sync and gate angles that need the linked issue. Callers needing a
@@ -108,29 +108,8 @@ export async function viewIssue(options, { env = process.env, ghCommand = "gh", 
   return coreViewIssue(options, { env, ghCommand, run });
 }
 
-export async function runCli(
-  argv = process.argv.slice(2),
-  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run = runChild } = {},
-) {
-  let options;
-  try {
-    options = parseViewIssueCliArgs(argv);
-  } catch (error) {
-    stderr.write(`${formatCliError(error)}\n`);
-    return 1;
-  }
-  if (options.help) {
-    stdout.write(`${USAGE}\n`);
-    return 0;
-  }
-  let result;
-  try {
-    result = await viewIssue(options, { env, ghCommand, run });
-  } catch (error) {
-    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
-    return 1;
-  }
-  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+export async function runCli(argv = process.argv.slice(2), io = {}) {
+  return runReadCommandCli({ parse: parseViewIssueCliArgs, operate: viewIssue, usage: USAGE }, argv, io);
 }
 
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/github/view-pr.mjs
+++ b/scripts/github/view-pr.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { buildParseError, formatCliError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
+import { buildParseError, isDirectCliRun, parseJsonText } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild } from "../_cli-primitives.mjs";
 import { parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { parseArgs } from "node:util";
-import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
+import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, matchJqOutputToken, runReadCommandCli } from "../lib/jq-output.mjs";
 
 // Default PR facts a follow-up run reads: the fields loop info surfaces plus the
 // head SHA. Callers needing a different set pass --json <fields> (a comma list,
@@ -120,29 +120,8 @@ export async function viewPr(options, { env = process.env, ghCommand = "gh", run
   return { ok: true, pr };
 }
 
-export async function runCli(
-  argv = process.argv.slice(2),
-  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run = runChild } = {},
-) {
-  let options;
-  try {
-    options = parseViewPrCliArgs(argv);
-  } catch (error) {
-    stderr.write(`${formatCliError(error)}\n`);
-    return 1;
-  }
-  if (options.help) {
-    stdout.write(`${USAGE}\n`);
-    return 0;
-  }
-  let result;
-  try {
-    result = await viewPr(options, { env, ghCommand, run });
-  } catch (error) {
-    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
-    return 1;
-  }
-  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
+export async function runCli(argv = process.argv.slice(2), io = {}) {
+  return runReadCommandCli({ parse: parseViewPrCliArgs, operate: viewPr, usage: USAGE }, argv, io);
 }
 
 if (isDirectCliRun(import.meta.url)) {

--- a/scripts/lib/jq-output.mjs
+++ b/scripts/lib/jq-output.mjs
@@ -26,6 +26,8 @@
 //                  (truthy test). <lit> is a JSON string/number/true/false/null.
 // Anything else -> JqFilterError (fail closed).
 
+import { formatCliError } from "../_core-helpers.mjs";
+
 export class JqFilterError extends Error {
   constructor(message) {
     super(message);
@@ -420,4 +422,44 @@ export function emitResult(
   }
   stdout.write(`${JSON.stringify(result)}\n`);
   return ok ? 0 : 1;
+}
+
+// Shared execution shell for the identical GitHub read-command CLIs
+// (view-issue, view-pr, list-issues; issue #2037). Those three commands had a
+// byte-identical runCli that differs only in its parser, domain operation, and
+// usage text — this hosts that one shell in the existing output-helper seam so
+// each command keeps its own parser/operation/usage and passes them in, rather
+// than re-copying the parse -> help -> operate -> emit boilerplate three times.
+//
+// The two catch arms are kept deliberately distinct: a parse error routes
+// through the canonical `formatCliError` (which carries the usage/retry hint the
+// buildParseError seam attaches), while a runtime/operation error emits the
+// plain `{ ok:false, error }` envelope. Collapsing them would let the top-level
+// launcher treat a runtime failure as a retryable parse error. `run` is threaded
+// through when injected (tests) and otherwise left undefined so each operation's
+// own `runChild` default applies — unchanged from the per-command shells.
+export async function runReadCommandCli(
+  { parse, operate, usage },
+  argv,
+  { stdout = process.stdout, stderr = process.stderr, env = process.env, ghCommand = "gh", run } = {},
+) {
+  let options;
+  try {
+    options = parse(argv);
+  } catch (error) {
+    stderr.write(`${formatCliError(error)}\n`);
+    return 1;
+  }
+  if (options.help) {
+    stdout.write(`${usage}\n`);
+    return 0;
+  }
+  let result;
+  try {
+    result = await operate(options, { env, ghCommand, run });
+  } catch (error) {
+    stderr.write(`${JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) })}\n`);
+    return 1;
+  }
+  return emitResult(result, { jq: options.jq, silent: options.silent, stdout, stderr });
 }

--- a/test/contracts/jq-output-base-guarantee-contract.test.mjs
+++ b/test/contracts/jq-output-base-guarantee-contract.test.mjs
@@ -55,6 +55,17 @@ const DIRECT_RUN_GUARD_RE =
 // the real risk (a regression sailing through silently), so this stays loose.
 const JSON_STRINGIFY_RE = /JSON\.stringify/;
 
+// A file is ALSO JSON-emitting if it delegates its whole CLI to the shared
+// read-command execution shell (issue #2037): view-issue/view-pr/list-issues
+// moved their parse -> help -> operate -> emit boilerplate (including the
+// `JSON.stringify` runtime-error envelope) into `runReadCommandCli` in
+// scripts/lib/jq-output.mjs, so the migrated files no longer literally contain
+// `JSON.stringify` themselves. Without this signal the extraction would make
+// them silently disappear from discovery — the exact vacuous-pass this guard
+// exists to prevent. The shell still emits their JSON, so they remain
+// JSON-emitting direct-CLI commands and must stay discovered.
+const RUN_READ_COMMAND_SHELL_RE = /runReadCommandCli/;
+
 // Accepted "routes through the shared emit path" evidence: a direct import of
 // jq-output.mjs (emitResult), or the refine checkers' shared
 // _refine-helpers.mjs wrapper (which itself imports jq-output.mjs — verified
@@ -124,7 +135,10 @@ async function discoverJsonEmittingCliScripts() {
   const candidates = [];
   for (const absPath of files) {
     const source = await readFile(absPath, "utf8");
-    if (DIRECT_RUN_GUARD_RE.test(source) && JSON_STRINGIFY_RE.test(source)) {
+    if (
+      DIRECT_RUN_GUARD_RE.test(source) &&
+      (JSON_STRINGIFY_RE.test(source) || RUN_READ_COMMAND_SHELL_RE.test(source))
+    ) {
       candidates.push({ absPath, relPath: path.relative(scriptsRoot, absPath), source });
     }
   }
@@ -179,6 +193,19 @@ test("every JSON-emitting direct-CLI script routes through the shared jq-output 
       `Fix: wire --jq/--silent via emitResult (see scripts/projects/list-queue-items.mjs), or add a` +
       ` reasoned EXCLUDED entry if this script is genuinely out of scope.`,
   );
+});
+
+test("the shared read-command shell keeps the migrated commands discovered (#2037: extraction cannot pass vacuously)", async () => {
+  // view-issue/view-pr/list-issues delegate to runReadCommandCli and no longer
+  // contain a literal JSON.stringify. This asserts the discovery signal above
+  // still finds all three AND that each routes through the shared emit path —
+  // so the consolidation cannot silently drop them from the base-guarantee set.
+  const candidates = await discoverJsonEmittingCliScripts();
+  const discovered = new Map(candidates.map((c) => [c.relPath, c.source]));
+  for (const relPath of ["github/view-issue.mjs", "github/view-pr.mjs", "github/list-issues.mjs"]) {
+    assert.ok(discovered.has(relPath), `${relPath} must still be discovered as a JSON-emitting direct-CLI command after the shared-shell extraction`);
+    assert.ok(routesThroughSharedEmitPath(discovered.get(relPath)), `${relPath} must still route through the shared jq-output emit path`);
+  }
 });
 
 test("every EXCLUDED entry is still a real, currently-discovered file (no stale allowlist entries)", async () => {

--- a/test/github/list-issues.test.mjs
+++ b/test/github/list-issues.test.mjs
@@ -76,24 +76,14 @@ test("listIssues: throws when gh fails", async () => {
   await assert.rejects(() => listIssues({ repo: "o/n", state: "open", labels: [], limit: 30 }, { run }), /gh issue list failed: rate limited/);
 });
 
-test("runCli: --jq extracts a single issue number", async () => {
+// Wiring: this command's parser + listIssues operation compose through the shared
+// runReadCommandCli shell to produce the `.issues[]` result shape. The generic
+// shell matrix (--silent, invalid-filter refusal, parse-vs-runtime errors) is
+// covered once in test/lib/run-read-command-cli.test.mjs (#2037).
+test("runCli: parser + listIssues wire through the shared shell (--jq extracts a single issue number)", async () => {
   const { run } = stubGh(ISSUES);
   const stdout = captureStream();
   const code = await runCli(["--repo", "o/n", "--jq", ".issues[0].number"], { run, stdout });
   assert.equal(code, 0);
   assert.equal(stdout.get().trim(), "10");
-});
-
-test("runCli: invalid --jq filter fails closed with exit 2", async () => {
-  const { run } = stubGh(ISSUES);
-  const code = await runCli(["--repo", "o/n", "--jq", "bogus!!"], { run, stdout: captureStream(), stderr: captureStream() });
-  assert.equal(code, 2);
-});
-
-test("runCli: --silent + --jq predicate maps to exit code only", async () => {
-  const { run } = stubGh(ISSUES);
-  const stdout = captureStream();
-  const code = await runCli(["--repo", "o/n", "--jq", ".issues | length", "--silent"], { run, stdout });
-  assert.equal(code, 0);
-  assert.equal(stdout.get(), "");
 });

--- a/test/github/view-issue.test.mjs
+++ b/test/github/view-issue.test.mjs
@@ -55,24 +55,14 @@ test("viewIssue: throws when gh returns a non-object", async () => {
   await assert.rejects(() => viewIssue({ repo: "o/n", issue: 1354, fields: "state" }, { run }), /did not return a JSON object/);
 });
 
-test("runCli: --jq extracts the issue body", async () => {
+// Wiring: this command's parser + viewIssue operation compose through the shared
+// runReadCommandCli shell to produce the `.issue.*` result shape. The generic
+// shell matrix (--silent, invalid-filter refusal, parse-vs-runtime errors) is
+// covered once in test/lib/run-read-command-cli.test.mjs (#2037).
+test("runCli: parser + viewIssue wire through the shared shell (--jq extracts the issue body)", async () => {
   const { run } = stubGh(ISSUE);
   const stdout = captureStream();
   const code = await runCli(["--repo", "o/n", "--issue", "1354", "--jq", ".issue.body"], { run, stdout });
   assert.equal(code, 0);
   assert.equal(stdout.get().trim(), "## Summary\nApply the grounding pass to the intro deck.");
-});
-
-test("runCli: --silent + --jq predicate maps to exit code only", async () => {
-  const { run } = stubGh(ISSUE);
-  const stdout = captureStream();
-  const code = await runCli(["--repo", "o/n", "--issue", "1354", "--jq", ".issue.number==1354", "--silent"], { run, stdout });
-  assert.equal(code, 0);
-  assert.equal(stdout.get(), "");
-});
-
-test("runCli: invalid --jq fails closed with exit 2", async () => {
-  const { run } = stubGh(ISSUE);
-  const code = await runCli(["--repo", "o/n", "--issue", "1354", "--jq", "bogus!!"], { run, stdout: captureStream(), stderr: captureStream() });
-  assert.equal(code, 2);
 });

--- a/test/github/view-pr.test.mjs
+++ b/test/github/view-pr.test.mjs
@@ -57,24 +57,14 @@ test("viewPr: throws when gh returns a non-object", async () => {
   await assert.rejects(() => viewPr({ repo: "o/n", pr: 88, fields: "state" }, { run }), /did not return a JSON object/);
 });
 
-test("runCli: --jq extracts mergeStateStatus", async () => {
+// Wiring: this command's parser + viewPr operation compose through the shared
+// runReadCommandCli shell to produce the `.pr.*` result shape. The generic shell
+// matrix (--silent, invalid-filter refusal, parse-vs-runtime errors) is covered
+// once in test/lib/run-read-command-cli.test.mjs (#2037).
+test("runCli: parser + viewPr wire through the shared shell (--jq extracts mergeStateStatus)", async () => {
   const { run } = stubGh(PR);
   const stdout = captureStream();
   const code = await runCli(["--repo", "o/n", "--pr", "88", "--jq", ".pr.mergeStateStatus"], { run, stdout });
   assert.equal(code, 0);
   assert.equal(stdout.get().trim(), "CLEAN");
-});
-
-test("runCli: --silent + --jq predicate maps to exit code only", async () => {
-  const { run } = stubGh(PR);
-  const stdout = captureStream();
-  const code = await runCli(["--repo", "o/n", "--pr", "88", "--jq", ".pr.isDraft", "--silent"], { run, stdout });
-  assert.equal(code, 0);
-  assert.equal(stdout.get(), "");
-});
-
-test("runCli: invalid --jq fails closed with exit 2", async () => {
-  const { run } = stubGh(PR);
-  const code = await runCli(["--repo", "o/n", "--pr", "88", "--jq", "bogus!!"], { run, stdout: captureStream(), stderr: captureStream() });
-  assert.equal(code, 2);
 });

--- a/test/lib/run-read-command-cli.test.mjs
+++ b/test/lib/run-read-command-cli.test.mjs
@@ -1,0 +1,133 @@
+// Authoritative test for the shared GitHub read-command execution shell
+// (issue #2037). view-issue/view-pr/list-issues delegate their entire runCli to
+// runReadCommandCli; this covers the shell's behavior once — parse/help,
+// success + filtering, runtime failure, invalid-filter refusal, and the
+// parse-error-vs-runtime-error distinction — so the per-command tests do not
+// repeat the same matrix three times. Command-specific parser/payload/wiring
+// behavior stays in each command's own test.
+
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+
+import { runReadCommandCli } from "../../scripts/lib/jq-output.mjs";
+import { captureStream } from "../_helpers.mjs";
+
+const USAGE = "Usage: fake-command --flag <v>";
+
+// A minimal parser mirroring the migrated commands' options shape: it produces
+// { help, jq, silent } plus a marker the operation echoes back. A thrown parse
+// error carries the usage/retry hint via the same buildParseError seam the real
+// commands use; here we simulate that with an Error whose message the canonical
+// formatCliError renders.
+function makeParse({ help = false, jq, silent = false, throwOn } = {}) {
+  return (argv) => {
+    if (throwOn && argv.includes(throwOn)) {
+      // buildParseError attaches `usage`; formatCliError turns that into the
+      // `hint: "run with --help for usage"` retry hint (the parse-error signal).
+      const error = new Error("bad argument");
+      error.usage = USAGE;
+      throw error;
+    }
+    return { help, jq, silent, marker: argv[0] ?? null };
+  };
+}
+
+test("help precedence: prints usage and returns 0 before any operation runs", async () => {
+  const stdout = captureStream();
+  let operated = false;
+  const code = await runReadCommandCli(
+    { parse: makeParse({ help: true }), operate: async () => { operated = true; return { ok: true }; }, usage: USAGE },
+    [],
+    { stdout },
+  );
+  assert.equal(code, 0);
+  assert.equal(stdout.get(), `${USAGE}\n`);
+  assert.equal(operated, false);
+});
+
+test("success: threads env/ghCommand/run into the operation and emits the verbatim result", async () => {
+  const stdout = captureStream();
+  const seen = {};
+  const code = await runReadCommandCli(
+    {
+      parse: makeParse(),
+      operate: async (options, ctx) => { Object.assign(seen, { options, ctx }); return { ok: true, value: 42 }; },
+      usage: USAGE,
+    },
+    ["hello"],
+    { stdout, env: { A: "1" }, ghCommand: "gh-x", run: "RUN" },
+  );
+  assert.equal(code, 0);
+  assert.deepEqual(JSON.parse(stdout.get().trim()), { ok: true, value: 42 });
+  assert.equal(seen.options.marker, "hello");
+  assert.deepEqual(seen.ctx, { env: { A: "1" }, ghCommand: "gh-x", run: "RUN" });
+});
+
+test("--jq filters the result and exits 0", async () => {
+  const stdout = captureStream();
+  const code = await runReadCommandCli(
+    { parse: makeParse({ jq: ".value" }), operate: async () => ({ ok: true, value: 7 }), usage: USAGE },
+    [],
+    { stdout },
+  );
+  assert.equal(code, 0);
+  assert.equal(stdout.get().trim(), "7");
+});
+
+test("--silent + --jq predicate maps to exit code only, no stdout", async () => {
+  const stdout = captureStream();
+  const code = await runReadCommandCli(
+    { parse: makeParse({ jq: ".ok", silent: true }), operate: async () => ({ ok: true }), usage: USAGE },
+    [],
+    { stdout },
+  );
+  assert.equal(code, 0);
+  assert.equal(stdout.get(), "");
+});
+
+test("invalid --jq filter fails closed with exit 2 and a stderr envelope", async () => {
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const code = await runReadCommandCli(
+    { parse: makeParse({ jq: "bogus!!" }), operate: async () => ({ ok: true }), usage: USAGE },
+    [],
+    { stdout, stderr },
+  );
+  assert.equal(code, 2);
+  assert.equal(stdout.get(), "");
+  assert.match(stderr.get(), /--jq/);
+});
+
+test("runtime/operation error: plain {ok:false,error} envelope, exit 1, no usage/retry hint", async () => {
+  const stdout = captureStream();
+  const stderr = captureStream();
+  const code = await runReadCommandCli(
+    { parse: makeParse(), operate: async () => { throw new Error("gh pr view failed: nope"); }, usage: USAGE },
+    [],
+    { stdout, stderr },
+  );
+  assert.equal(code, 1);
+  assert.equal(stdout.get(), "");
+  const envelope = JSON.parse(stderr.get().trim());
+  // Exact shape: no `hint` field. A runtime failure must NOT carry the
+  // parse-error retry hint — otherwise the top-level launcher could mistake it
+  // for a retryable parse error.
+  assert.deepEqual(envelope, { ok: false, error: "gh pr view failed: nope" });
+});
+
+test("parse error: routes through formatCliError (carries the usage/retry hint), exit 1, distinct from runtime path", async () => {
+  const stdout = captureStream();
+  const stderr = captureStream();
+  let operated = false;
+  const code = await runReadCommandCli(
+    { parse: makeParse({ throwOn: "--boom" }), operate: async () => { operated = true; return { ok: true }; }, usage: USAGE },
+    ["--boom"],
+    { stdout, stderr },
+  );
+  assert.equal(code, 1);
+  assert.equal(operated, false, "operation must not run when parsing fails");
+  const envelope = JSON.parse(stderr.get().trim());
+  // Parse errors carry the retry hint; runtime errors do not. This is the
+  // distinction the shell must preserve.
+  assert.deepEqual(envelope, { ok: false, error: "bad argument", hint: "run with --help for usage" });
+});


### PR DESCRIPTION
## Summary

`view-issue.mjs`, `view-pr.mjs`, and `list-issues.mjs` carried a byte-identical `runCli` execution shell that differed only in its parser, domain operation, and usage text. This consolidates that one `parse -> help -> operate -> emit` shell into the existing output-helper seam (`scripts/lib/jq-output.mjs`) as `runReadCommandCli`. Each command passes in its own parser, operation, and usage text and keeps everything else command-owned.

## What changed

- New `runReadCommandCli({ parse, operate, usage }, argv, io)` in `scripts/lib/jq-output.mjs` — the shared shell, reusing the canonical `emitResult`, the `formatCliError` error formatter, and each command's `isDirectCliRun` direct-run facility.
- `view-issue.mjs`, `view-pr.mjs`, `list-issues.mjs`: `runCli` now delegates to the shared shell in one line each. Parsers, domain operations, default field sets, `--json` validation, public exports, and injection signatures are unchanged.
- Net production code is smaller after counting the shared helper (54 insertions, 75 deletions in `scripts/`).

## Preserved result / equivalence evidence

- Old machinery: three copies of the same `runCli` body (parse -> `formatCliError` on parse error -> help print -> operate -> runtime-error envelope -> `emitResult`).
- Smaller replacement: one `runReadCommandCli` in the seam already imported by all three.
- The two catch arms stay deliberately distinct: a parse error routes through `formatCliError` (carrying the `run with --help for usage` retry hint), while a runtime/operation error emits the plain `{ ok: false, error }` envelope — so the top-level launcher cannot mistake a runtime failure for a retryable parse error.
- `env` / `ghCommand` / `run` are threaded through to the operation exactly as before (injected stubs still work); `run` is left undefined when not injected so each operation's own `runChild` default applies.
- Accepted/rejected arguments, defaults, repeated-flag behavior, help/validation precedence, exact stdout/stderr bytes, JSON shape, `--jq`/`--silent` behavior, and exit codes are unchanged.

## In scope

- The byte-identical `runCli` execution shell in `scripts/github/view-issue.mjs`, `view-pr.mjs`, and `list-issues.mjs`.
- One shared `runReadCommandCli` helper in the existing `scripts/lib/jq-output.mjs` seam, plus the three thin call-site adapters.
- The JSON-output discovery guard update so the migrated commands stay in coverage.
- Test consolidation: one authoritative shared-shell test plus trimmed per-command tests.

## Acceptance criteria

- [x] Scope limited to the duplicated shell in the three named commands; parsers, operations, exports, and injection signatures stay command-owned. Production code is smaller; no new framework/parser/schema/emitter/helper-layer added.
- [x] Each migrated command preserves accepted/rejected args, defaults, repeated-flag behavior, help/validation precedence, exact stdout/stderr bytes, JSON shape, `--jq`/`--silent` behavior, and exit status. Existing command and jq suites remain green. One authoritative shared-shell test (`test/lib/run-read-command-cli.test.mjs`) covers parse/help, success, runtime failure, filtering, and invalid-filter refusal; command tests retain only distinct parser/payload/wiring behavior.
- [x] Operation/output ordering unchanged; parse errors carrying a retry hint stay distinguished from runtime/filter errors; no added call or launcher retry.
- [x] Importing a command does not execute it; direct/symlinked invocation retains result/status behavior; the dependency-free launcher stays independent of core (`jq-output.mjs` is outside the deps-less launcher graph — `cli/index.mjs` + `lib/dev-loops-core.mjs` only).
- [x] The JSON-output discovery guard is updated to recognize the shared execution path and still reports the same migrated command set; extraction cannot make it pass vacuously (an added assertion pins the three commands as discovered).
- [x] Public command names and invocation forms unchanged; `bun run verify` passes on the pinned toolchain.

## Definition of done

- [x] `runReadCommandCli` extracted into `scripts/lib/jq-output.mjs`; all three commands delegate to it with parsers/operations/usage passed in.
- [x] Parse-error path (retry hint via `formatCliError`) stays distinct from the runtime-error envelope.
- [x] Existing command and jq suites remain green; one authoritative shared-shell test added; per-command tests trimmed to distinct parser/payload/wiring.
- [x] JSON-output discovery guard recognizes the shared shell and pins the three commands as still discovered (non-vacuous).
- [x] Net production code smaller (54 insertions, 75 deletions in `scripts/`).
- [x] `bun run verify` green on the pinned toolchain (8228 pass, 0 fail).

## Non-goals

- No repository-wide parser migration, universal command runner, CLI DSL/schema, new dependency, or new public export.
- No normalizing of command semantics, messages, exit codes, retry policy, aliases, guards, jq grammar, or help formatting.
- No changes to mutation commands, Projects policy/pagination, PR lifecycle/watch orchestration, or broad runtime primitives.
- No unifying of `runChild` with `runCommand`, streaming with buffered execution, or other semantically different subprocess paths.

## Validation

`bun run verify` green: 8228 pass, 35 skip, 0 fail across 353 files, plus docs and workflow lint.

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUDbPdYNy5EiLvGFuS9sbK
