### PR TITLE
feat(release): stamp CHANGELOG as bump-version.mjs sixth surface

### DIFF
--- a/.claude/skills/docs/release-runbook.md
+++ b/.claude/skills/docs/release-runbook.md
@@ -16,13 +16,16 @@ Everything after the tag is hands-off.
    ```
 
    `<version>` is a bare full semver token including any prerelease suffix
-   (`1.0.2`, `1.0.2-slim.0`, `1.0.0-rc.7`). One invocation sets all five
+   (`1.0.2`, `1.0.2-slim.0`, `1.0.0-rc.7`). One invocation sets all six
    surfaces in lockstep — root `package.json` `version`,
    `packages/core/package.json` `version`, the root `@dev-loops/core` range
    (`^<version>`), `bun.lock` (`bun install --lockfile-only`, proven with
-   `bun install --frozen-lockfile`), and the generated `.claude` tree (the
+   `bun install --frozen-lockfile`), the generated `.claude` tree (the
    plugin manifest `version` plus every pinned `npx dev-loops@<version>`
-   call-site, via `generate-claude-assets.mjs`). It then runs the drift guards
+   call-site, via `generate-claude-assets.mjs`), and `CHANGELOG.md` (the
+   `## Unreleased` heading is stamped to `## <version>`, leaving its entries
+   intact, so `extract-changelog-section.mjs` finds the release section). It
+   then runs the drift guards
    (`assert-core-dependency-version.mjs` and `generate-claude-assets.mjs
    --check`), fails closed on any residual drift, and stages exactly those
    release files (never `git add -A`). It is idempotent and bump-only — it
@@ -30,10 +33,10 @@ Everything after the tag is hands-off.
    where the root manifest was bumped while the committed `.claude` tree or
    lockfile stayed on the prior prerelease (`1.0.2-slim.0` did).
 
-   Then add the matching `## <version> - <date>` section to `CHANGELOG.md` (the
-   empty `## Unreleased` heading stays above the latest version; the bump script
-   deliberately does not touch `CHANGELOG.md`) and stage it with the release
-   files. `release.yml`'s lockstep guard
+   Land the release changes under `## Unreleased` in `CHANGELOG.md` **before**
+   bumping — the bump stamps that heading to `## <version>` and fails closed if
+   there is no Unreleased content to stamp, so an undocumented release cannot
+   proceed. `release.yml`'s lockstep guard
    (`scripts/release/assert-core-dependency-version.mjs`) also fails the release
    workflow before the GitHub Release is created if the lockfile is out of
    lockstep, so the documented tag-push path can never ship a stale lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- **`bump-version.mjs` stamps the CHANGELOG as a sixth release surface.** The
+  sanctioned bump now rewrites the `## Unreleased` heading to `## <version>`
+  (leaving its entries intact) so `extract-changelog-section.mjs` finds the
+  release section, closing the gap that broke the manual `v1.0.2-slim.0` release
+  at the extract-changelog guard. It fails closed when there is no Unreleased
+  content to stamp (an undocumented release cannot proceed), stays bump-only and
+  idempotent (a re-run over an already-stamped CHANGELOG is a no-op), and stages
+  `CHANGELOG.md` among the enumerated release files.
+
 ## 1.0.2-slim.0
 
 ### Added

--- a/scripts/release/bump-version.mjs
+++ b/scripts/release/bump-version.mjs
@@ -2,12 +2,13 @@
 /**
  * Sanctioned atomic version bump.
  *
- * The project version is a single source of truth fanned out across five
+ * The project version is a single source of truth fanned out across six
  * release surfaces that MUST move together on every bump. A human remembering
  * each one is how a release drifts (a root manifest bumped while the committed
- * `.claude` tree and lockfile stayed on the prior prerelease). This script sets
- * all five to one target in lockstep, regenerates the derived artifacts, stages
- * exactly the enumerated release files, and fails closed on any residual drift.
+ * `.claude` tree and lockfile stayed on the prior prerelease, or the CHANGELOG
+ * left on `## Unreleased`). This script sets all six to one target in lockstep,
+ * regenerates the derived artifacts, stages exactly the enumerated release
+ * files, and fails closed on any residual drift.
  *
  * Surfaces:
  *   1. root `package.json` `version`
@@ -18,6 +19,10 @@
  *   5. the generated `.claude` tree — `.claude/.claude-plugin/plugin.json`
  *      `version` and every pinned `npx dev-loops@<version>` call-site
  *      (produced by `scripts/claude/generate-claude-assets.mjs`)
+ *   6. `CHANGELOG.md` — the `## Unreleased` heading is stamped to `## <version>`
+ *      (entries left intact) so `extract-changelog-section.mjs` finds the
+ *      release section; fails closed when there is no Unreleased content to
+ *      stamp (an undocumented release must not proceed)
  *
  * Bump-only: it never commits, tags, pushes, or publishes. Commit + tag + push
  * and the stable-release approval gate remain operator/runbook-owned.
@@ -39,6 +44,7 @@ import { fileURLToPath } from "node:url";
 import { isDirectCliRun } from "../lib/direct-run.mjs";
 import { emitResult } from "../lib/jq-output.mjs";
 import { extractFullVersion } from "./assert-core-dependency-version.mjs";
+import { extractChangelogSection } from "./extract-changelog-section.mjs";
 
 const CORE_DEP = "@dev-loops/core";
 // A bare full semver token, optionally with a prerelease suffix. Build metadata
@@ -85,6 +91,52 @@ export function writeManifestSurfaces(repoRoot, version) {
   writeJson(corePath, core);
 
   return [rootPath, corePath];
+}
+
+/**
+ * Stamp the CHANGELOG's `## Unreleased` heading to `## <version>` so the
+ * release-time guard (`extract-changelog-section.mjs`) finds the section. The
+ * entries under the heading are left intact; only the heading line changes.
+ *
+ * Fails closed when there is no Unreleased content to stamp and the version is
+ * not already stamped — an undocumented release must not proceed silently.
+ * Idempotent: a tree already stamped at <version> (the Unreleased heading is
+ * gone and a populated `## <version>` section is present) is a no-op.
+ *
+ * @param {string} changelog - Full CHANGELOG.md contents.
+ * @param {string} version - Bare full version token to stamp.
+ * @returns {{ changelog: string, changed: boolean }}
+ */
+export function stampChangelog(changelog, version) {
+  const lines = changelog.split("\n");
+  const headingIdx = lines.findIndex((line) => /^##\s+Unreleased\b/i.test(line));
+
+  if (headingIdx !== -1) {
+    // Body = entries until the next "## " heading. Empty body means an
+    // undocumented release — fail closed.
+    const body = [];
+    for (let i = headingIdx + 1; i < lines.length; i += 1) {
+      if (/^##\s/.test(lines[i])) break;
+      body.push(lines[i]);
+    }
+    if (body.join("").trim() === "") {
+      throw new Error(
+        `CHANGELOG.md "## Unreleased" section is empty — nothing to stamp for ${version}; document the release before bumping`,
+      );
+    }
+    lines[headingIdx] = `## ${version}`;
+    return { changelog: lines.join("\n"), changed: true };
+  }
+
+  // No Unreleased heading: a no-op only when <version> is already stamped with
+  // content (the idempotent re-run). extractChangelogSection returns a non-empty
+  // string only for a populated matching section.
+  if (extractChangelogSection(changelog, version)) {
+    return { changelog, changed: false };
+  }
+  throw new Error(
+    `CHANGELOG.md has no "## Unreleased" section to stamp for ${version} (and no existing "## ${version}" section); document the release before bumping`,
+  );
 }
 
 /**
@@ -141,6 +193,13 @@ export function bumpVersion({ repoRoot, version, stage = true, run: runChild = r
     throw new Error(`target "${version}" is not a bare full version token (parsed as "${full}")`);
   }
 
+  // Surface 6: stamp the CHANGELOG first, so an undocumented release fails
+  // closed before any manifest/lockfile/.claude mutation. Hand-edited like
+  // surfaces 1-3; independent of the regen subprocesses.
+  const changelogPath = path.join(repoRoot, "CHANGELOG.md");
+  const { changelog: stampedChangelog } = stampChangelog(readFileSync(changelogPath, "utf8"), version);
+  writeFileSync(changelogPath, stampedChangelog);
+
   // Surfaces 1-3: hand-edited manifests.
   const manifestPaths = writeManifestSurfaces(repoRoot, version);
 
@@ -170,8 +229,19 @@ export function bumpVersion({ repoRoot, version, stage = true, run: runChild = r
     );
   }
 
+  // Confirm the release section is now extractable — the whole point of the
+  // CHANGELOG surface is that extract-changelog-section.mjs finds it.
+  if (!extractChangelogSection(readFileSync(changelogPath, "utf8"), version)) {
+    throw new Error(`CHANGELOG.md has no extractable "## ${version}" section after stamping`);
+  }
+
   // Stage only the enumerated release paths — never `git add -A` / `git add .`.
-  const stagedPaths = [...manifestPaths, path.join(repoRoot, "bun.lock"), path.join(repoRoot, ".claude")];
+  const stagedPaths = [
+    ...manifestPaths,
+    changelogPath,
+    path.join(repoRoot, "bun.lock"),
+    path.join(repoRoot, ".claude"),
+  ];
   if (stage) runChild("git", ["add", "--", ...stagedPaths], repoRoot);
 
   return { ok: true, version, surfaces, staged: stagedPaths };

--- a/skills/docs/release-runbook.md
+++ b/skills/docs/release-runbook.md
@@ -16,13 +16,16 @@ Everything after the tag is hands-off.
    ```
 
    `<version>` is a bare full semver token including any prerelease suffix
-   (`1.0.2`, `1.0.2-slim.0`, `1.0.0-rc.7`). One invocation sets all five
+   (`1.0.2`, `1.0.2-slim.0`, `1.0.0-rc.7`). One invocation sets all six
    surfaces in lockstep — root `package.json` `version`,
    `packages/core/package.json` `version`, the root `@dev-loops/core` range
    (`^<version>`), `bun.lock` (`bun install --lockfile-only`, proven with
-   `bun install --frozen-lockfile`), and the generated `.claude` tree (the
+   `bun install --frozen-lockfile`), the generated `.claude` tree (the
    plugin manifest `version` plus every pinned `npx dev-loops@<version>`
-   call-site, via `generate-claude-assets.mjs`). It then runs the drift guards
+   call-site, via `generate-claude-assets.mjs`), and `CHANGELOG.md` (the
+   `## Unreleased` heading is stamped to `## <version>`, leaving its entries
+   intact, so `extract-changelog-section.mjs` finds the release section). It
+   then runs the drift guards
    (`assert-core-dependency-version.mjs` and `generate-claude-assets.mjs
    --check`), fails closed on any residual drift, and stages exactly those
    release files (never `git add -A`). It is idempotent and bump-only — it
@@ -30,10 +33,10 @@ Everything after the tag is hands-off.
    where the root manifest was bumped while the committed `.claude` tree or
    lockfile stayed on the prior prerelease (`1.0.2-slim.0` did).
 
-   Then add the matching `## <version> - <date>` section to `CHANGELOG.md` (the
-   empty `## Unreleased` heading stays above the latest version; the bump script
-   deliberately does not touch `CHANGELOG.md`) and stage it with the release
-   files. `release.yml`'s lockstep guard
+   Land the release changes under `## Unreleased` in `CHANGELOG.md` **before**
+   bumping — the bump stamps that heading to `## <version>` and fails closed if
+   there is no Unreleased content to stamp, so an undocumented release cannot
+   proceed. `release.yml`'s lockstep guard
    (`scripts/release/assert-core-dependency-version.mjs`) also fails the release
    workflow before the GitHub Release is created if the lockfile is out of
    lockstep, so the documented tag-push path can never ship a stale lockfile

--- a/test/release/bump-version.test.mjs
+++ b/test/release/bump-version.test.mjs
@@ -22,7 +22,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bumpVersion, inspectSurfaces, writeManifestSurfaces } from "../../scripts/release/bump-version.mjs";
+import { bumpVersion, inspectSurfaces, stampChangelog, writeManifestSurfaces } from "../../scripts/release/bump-version.mjs";
+import { extractChangelogSection } from "../../scripts/release/extract-changelog-section.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CORE_DEP = "@dev-loops/core";
@@ -51,6 +52,10 @@ function makeFixture(from) {
   writeJson(path.join(dir, ".claude/.claude-plugin/plugin.json"), { name: "dev-loops", version: from });
   writeFileSync(path.join(dir, ".claude/agents/x.md"), `Run \`npx dev-loops@${from} loop startup\`.\n`);
   writeFileSync(path.join(dir, "bun.lock"), lockfile(from));
+  writeFileSync(
+    path.join(dir, "CHANGELOG.md"),
+    `# Changelog\n\n## Unreleased\n\n### Added\n\n- A documented change awaiting release.\n\n## ${from} - 2026-01-01\n\n- Prior release.\n`,
+  );
   return dir;
 }
 
@@ -149,9 +154,15 @@ test("bumpVersion drives surfaces → guards → staging in order and stages onl
     const stageCall = calls.find((c) => c.startsWith("git add"));
     assert.ok(stageCall.startsWith("git add -- "), stageCall);
     assert.ok(!/git add (-A|\.)/.test(stageCall), `broad add used: ${stageCall}`);
-    for (const p of ["package.json", "packages/core/package.json", "bun.lock", ".claude"]) {
+    for (const p of ["package.json", "packages/core/package.json", "CHANGELOG.md", "bun.lock", ".claude"]) {
       assert.ok(stageCall.includes(path.join(dir, p)), `missing staged path ${p}`);
     }
+
+    // Sixth surface: the CHANGELOG's Unreleased heading is now stamped and the
+    // release section is extractable end-to-end (the release-time guard's input).
+    const changelog = readFileSync(path.join(dir, "CHANGELOG.md"), "utf8");
+    assert.ok(!/^##\s+Unreleased\b/im.test(changelog), "Unreleased heading must be stamped away");
+    assert.match(extractChangelogSection(changelog, PRERELEASE), /documented change awaiting release/);
 
     // Idempotent: a same-target re-run over the already-bumped tree is a no-op —
     // surfaces stay in lockstep, no residual-drift throw, same staged set.
@@ -206,4 +217,34 @@ test("the real lockstep guard accepts a prerelease-token bump and fails closed o
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("stampChangelog rewrites the Unreleased heading to the version and extract-changelog-section then finds it", () => {
+  const changelog = "# Changelog\n\n## Unreleased\n\n### Added\n\n- New thing.\n\n## 1.0.0 - 2026-01-01\n\n- Old.\n";
+  const { changelog: stamped, changed } = stampChangelog(changelog, PRERELEASE);
+  assert.equal(changed, true);
+  assert.ok(!/^##\s+Unreleased\b/im.test(stamped), "Unreleased heading must be gone");
+  assert.match(stamped, new RegExp(`^## ${PRERELEASE.replace(/[.]/g, "\\.")}$`, "m"));
+  // Entries are left intact and the section is extractable end-to-end.
+  assert.equal(extractChangelogSection(stamped, PRERELEASE), "### Added\n\n- New thing.");
+});
+
+test("stampChangelog fails closed when there is no Unreleased content to stamp", () => {
+  // Missing Unreleased section entirely, version not yet stamped.
+  assert.throws(
+    () => stampChangelog("# Changelog\n\n## 1.0.0 - 2026-01-01\n\n- Old.\n", PRERELEASE),
+    /no "## Unreleased" section to stamp/,
+  );
+  // Present-but-empty Unreleased section.
+  assert.throws(
+    () => stampChangelog("# Changelog\n\n## Unreleased\n\n## 1.0.0 - 2026-01-01\n\n- Old.\n", PRERELEASE),
+    /"## Unreleased" section is empty/,
+  );
+});
+
+test("stampChangelog is an idempotent no-op on an already-stamped changelog", () => {
+  const stamped = `# Changelog\n\n## ${PRERELEASE}\n\n### Added\n\n- New thing.\n\n## 1.0.0 - 2026-01-01\n\n- Old.\n`;
+  const result = stampChangelog(stamped, PRERELEASE);
+  assert.equal(result.changed, false);
+  assert.equal(result.changelog, stamped);
 });


### PR DESCRIPTION
## Objective

The sanctioned five-surface bump script did not stamp `CHANGELOG.md`, so a
release still depended on a human remembering to rewrite `## Unreleased` to
`## <version>` — exactly the "forgot a surface" drift the script exists to
prevent. Cutting `v1.0.2-slim.0` hit this: `extract-changelog-section.mjs`
fail-closed and the release needed a manual edit + re-tag. This makes CHANGELOG
stamping a sixth surface of the bump so a single invocation leaves the release
fully documented with no manual step.

## In scope

`scripts/release/bump-version.mjs` now stamps `CHANGELOG.md` as a sixth release
surface. One bump invocation rewrites the `## Unreleased` heading to
`## <version>` (leaving its entries intact) so
`scripts/release/extract-changelog-section.mjs` finds the release section. This
closes the gap that broke the manual `v1.0.2-slim.0` release at the
extract-changelog guard and needed a hand edit + re-tag — the same
incomplete-bump failure class the five-surface script set out to prevent, one
surface short.

Behavior:
- Fails closed when there is no `## Unreleased` content to stamp (missing
  heading and not already stamped, or a present-but-empty Unreleased section) —
  an undocumented release cannot proceed. The stamp runs first, before any
  manifest/lockfile/`.claude` mutation, so an undocumented release aborts early.
- Bump-only and idempotent: a re-run over an already-stamped CHANGELOG (heading
  gone, populated `## <version>` section present) is a no-op; the script still
  never commits/tags/pushes/publishes.
- Stages `CHANGELOG.md` among the enumerated release paths (never `git add -A`).
- A post-stamp assertion confirms the release section is extractable.
- `skills/docs/release-runbook.md` and its generated `.claude` mirror are
  updated (five → six surfaces; land changes under `## Unreleased` before
  bumping).

## Acceptance criteria

- [x] A single bump invocation stamps the CHANGELOG so `extract-changelog-section` finds the target-version section.
- [x] The bump fails closed when there is no documented Unreleased content to stamp.
- [x] CHANGELOG stamping composes with the existing five surfaces atomically and stays bump-only/idempotent.
- [x] The release path no longer needs a manual CHANGELOG edit.

## Definition of done

- [x] After `bump-version.mjs <v>`, `CHANGELOG.md` has `## <v>` and `extractChangelogSection(..., <v>)` returns the section body; a test asserts this end to end (the test drives the real `extract-changelog-section` export against the actually-stamped CHANGELOG).
- [x] Running the bump with no/empty `## Unreleased` section exits non-zero naming the missing changelog content; a test covers both the missing-section and empty-section cases.
- [x] One invocation leaves all six surfaces consistent; a same-target re-run is a no-op with the same staged set; `CHANGELOG.md` is among the enumerated staged files; the script never commits/tags/pushes.
- [x] The stamp→extract chain is proven by the injected-runner integration test and the `stampChangelog` unit tests; `bun run verify` is green apart from unrelated environmental 5000ms test-timeouts (see note below).

## Non-goals

- Committing/tagging/pushing/publishing from the script (stays operator/runbook-owned).
- Changing `extract-changelog-section.mjs` or `release.yml` guards (the script satisfies them).
- Rewriting historical CHANGELOG entries or the entry format.
- Re-seeding a fresh empty `## Unreleased` above the stamped section — skipped deliberately: repo history shows no reseed after a release, and adding it would complicate the idempotent-no-op path.

## Open questions / risks

- Empty-body detection treats an `## Unreleased` section containing only a
  subheading (e.g. `### Added`) with zero list items as non-empty. This is a
  contrived edge beyond the AC (which targets truly undocumented releases) and
  is blocked in practice by `LIFECYCLE-CHANGELOG-COMPLETENESS`, which requires
  a list item under `## Unreleased` on any notable PR. No open blocking risks.

Closes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
