### PR TITLE
fix(loop): integrate base FIRST on PR pickup; never CI-wait while DIRTY (#2096)

### DIFF
--- a/.claude/skills/docs/public-dev-loop-contract.md
+++ b/.claude/skills/docs/public-dev-loop-contract.md
@@ -407,6 +407,14 @@ When an open linked PR reports merge conflict against `main`, treat this as an e
 4. only when that context is complete for one current head, resolve the conflict locally on the PR branch
 5. <!-- rule: FACADE-CONFLICT-REVALIDATE-NEW-HEAD --> `FACADE-CONFLICT-REVALIDATE-NEW-HEAD`: after conflict resolution, orchestration MUST rerun required local validation, gate checks, and required CI checks for the new head before approval/merge evaluation
 
+### Base integration is the deterministic FIRST action of PR pickup
+
+<!-- rule: FACADE-PICKUP-INTEGRATE-BASE-FIRST -->
+`FACADE-PICKUP-INTEGRATE-BASE-FIRST`: when the deterministic pickup path (the `loop handoff` / startup-continue route) picks up an existing PR, the FIRST action — before any gate run or CI-wait — is to read the PR's `mergeable` / `mergeStateStatus` and, when the branch is behind base or `CONFLICTING`/`DIRTY`, integrate `origin/<base>` (merge, or the sanctioned `resolve-pr-conflicts.mjs` additive-conflict resolver) and push. Only after the branch is mergeable-clean and re-based on the current base do gates / CI-wait proceed. This rule lives in the sanctioned pickup path (`scripts/loop/copilot-pr-handoff.mjs` `runBasePickupPreflight`), so every coordinator does it the same way without re-deriving it.
+
+<!-- rule: FACADE-NEVER-CI-WAIT-WHILE-DIRTY -->
+`FACADE-NEVER-CI-WAIT-WHILE-DIRTY`: the pickup path MUST NEVER enter a CI-wait (or Copilot-review wait) while `mergeStateStatus` is `DIRTY` / `mergeable` is `CONFLICTING`. GitHub does not dispatch `pull_request` CI on a conflicted branch, so a wait there never ends — the deadlock (observed on PR #2028). A conflicted PR is resolved first (integrate the base), or the loop fails closed with a clear actionable stop; it never waits for CI that can never dispatch. After integration the loop re-gates at the new head (`FACADE-CONFLICT-REVALIDATE-NEW-HEAD`).
+
 ## `auto dev loop` durable auto contract
 
 When the public intent is `auto dev loop`, the router MUST:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,34 @@ All notable changes to this project will be documented in this file.
   idempotent (a re-run over an already-stamped CHANGELOG is a no-op), and stages
   `CHANGELOG.md` among the enumerated release files.
 
+### Fixed
+
+- **PR pickup integrates the base branch FIRST and never CI-waits on a
+  `CONFLICTING`/`DIRTY` branch (issue [2096](https://github.com/mfittko/dev-loops/issues/2096)).**
+  Closes a hard deadlock: GitHub does not dispatch `pull_request` CI on a
+  conflicted PR, so a loop that picked up a behind/diverged PR and proceeded to
+  wait for CI waited forever (observed picking up a PR left behind post-epic
+  `main`). The deterministic pickup preflight (`runBasePickupPreflight` in
+  `scripts/loop/copilot-pr-handoff.mjs`) now reads the PR's
+  `mergeable`/`mergeStateStatus` as the FIRST action — before any gate or
+  CI-wait — and, when the branch is behind base or `CONFLICTING`/`DIRTY`,
+  integrates `origin/<base>` via the sanctioned `resolve-pr-conflicts.mjs`
+  (merge, additive-CHANGELOG auto-resolve, or fail closed) and pushes, then
+  re-baselines at the new head so the gate/CI re-runs there. It NEVER enters a
+  CI/review wait while `mergeStateStatus` is `DIRTY` / `mergeable` is
+  `CONFLICTING`: it either integrates the base first or stops with a clear
+  actionable message, and a fail-closed backstop at the watch decision refuses
+  to route a conflicted head to a wait. A watch-refresh re-entry never
+  auto-merges on every poll but still refuses to re-enter a wait while
+  conflicting. `detect-copilot-loop-state.mjs` carries `mergeable`,
+  `mergeStateStatus`, and `baseRefName` on the snapshot to drive it. The rule is
+  documented in `skills/docs/public-dev-loop-contract.md`
+  (`FACADE-PICKUP-INTEGRATE-BASE-FIRST`, `FACADE-NEVER-CI-WAIT-WHILE-DIRTY`).
+  Proven by `test/loop/copilot-pr-handoff.test.mjs` (dirty-state rehearsal
+  asserting no CI-wait is entered while `DIRTY`, base-integrated-first,
+  behind-integration, fail-closed-on-unresolvable, and watch-refresh
+  no-auto-merge paths). Generated `.claude/` mirror regenerated in lockstep.
+
 ## 1.0.2-slim.0
 
 ### Added

--- a/docs/decisions/0066-pr-pickup-integrate-base-first-never-ci-wait-dirty.md
+++ b/docs/decisions/0066-pr-pickup-integrate-base-first-never-ci-wait-dirty.md
@@ -1,0 +1,27 @@
+# 0066. PR pickup integrates the base branch FIRST; never CI-wait on a CONFLICTING/DIRTY branch
+
+## Status
+
+Accepted — 2026-09-09 ([issue #2096](https://github.com/mfittko/dev-loops/issues/2096), [PR 2104](https://github.com/mfittko/dev-loops/pull/2104))
+
+Adds two rules to the "Conflict reconciliation path" of `skills/docs/public-dev-loop-contract.md`: `FACADE-PICKUP-INTEGRATE-BASE-FIRST` and `FACADE-NEVER-CI-WAIT-WHILE-DIRTY`. Complements `FACADE-CONFLICT-REVALIDATE-NEW-HEAD` (re-gate at the new head) without changing it.
+
+## Context
+
+When a dev-loop picks up an existing PR (continue / fix / merge route), the loop interpreted state and could route to a Copilot-review / CI wait without ever reading the PR's `mergeable` / `mergeStateStatus`. GitHub does not dispatch `pull_request` CI on a conflicted PR: a PR that is behind or diverged from its base reports `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY`, and no CI run is ever created. A loop that proceeds to wait for CI on such a branch waits forever with no signal and no progress — a hard deadlock, observed picking up a PR left behind post-epic `main`.
+
+The pre-flight PR handoff existed but did not deterministically (a) integrate the base first and (b) refuse to CI-wait on a branch whose merge state means CI can never dispatch. The snapshot the loop interprets did not even carry merge state.
+
+## Decision
+
+Base-branch integration is the deterministic FIRST action of the PR-pickup preflight, ahead of any gate run or CI-wait. The rule lives in the sanctioned pickup path (`runBasePickupPreflight` in `scripts/loop/copilot-pr-handoff.mjs`), so every coordinator does it the same way without re-deriving it:
+
+1. Read the PR's `mergeable` / `mergeStateStatus` (carried on the snapshot by `detect-copilot-loop-state.mjs`, from the existing `gh pr view`).
+2. When the branch is behind base or `CONFLICTING`/`DIRTY`, integrate `origin/<base>` via the sanctioned `resolve-pr-conflicts.mjs` (merge, additive-CHANGELOG auto-resolve, else fail closed) and push, then re-baseline the snapshot at the new head so the gate/CI re-runs there.
+3. NEVER enter a CI/review wait while `mergeStateStatus` is `DIRTY` / `mergeable` is `CONFLICTING`. The preflight integrates first, or fails closed with a clear actionable stop; a fail-closed backstop at the watch decision refuses to route a conflicted head to a wait. A watch-refresh re-entry never auto-merges on every poll but still refuses to re-enter a wait while conflicting.
+
+`FACADE-PICKUP-INTEGRATE-BASE-FIRST` and `FACADE-NEVER-CI-WAIT-WHILE-DIRTY` are registered in `skills/docs/required-rules.json` and runtime-enforced (their IDs appear in the preflight refusal messages).
+
+## Consequences
+
+The pickup deadlock is closed: a conflicted or behind PR is integrated and re-gated at the new head, or the loop stops with an actionable message, instead of waiting on CI that can never dispatch. Integration reuses the existing sanctioned resolver, so semantic conflicts that need human judgment still fail closed (no new auto-resolution). CI configuration/dispatch, force-push semantics, and the gate/merge base-resolution are unchanged. The seam is a single chokepoint (`runHandoff`) plus three passthrough snapshot fields; the contract prose and generated `.claude/` mirror are updated in lockstep, and a rehearsal in `test/loop/copilot-pr-handoff.test.mjs` asserts no CI-wait is entered while `DIRTY` (plus base-integrated-first, behind-integration, fail-closed-on-unresolvable, and watch-refresh no-auto-merge paths).

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -376,6 +376,12 @@ export async function runBasePickupPreflight(
   const conflicting = isConflictingMergeState(snapshot);
   const behind = isBehindBaseMergeState(snapshot);
   if (!conflicting && !behind) {
+    // ponytail: UNKNOWN/null merge state (GitHub still computing it, common
+    // right after a push) reads as non-conflicting here and proceeds. This is
+    // bounded and self-correcting, not a re-opened deadlock: once GitHub
+    // computes DIRTY, the very next watch-refresh cycle hits the conflicting
+    // guard below and blocks. Add an explicit UNKNOWN re-poll only if that
+    // one-cycle window is ever shown to matter in practice.
     return { action: "none", integrated: false, mergeStateStatus: snapshot.mergeStateStatus ?? null };
   }
   const base = snapshot.baseRefName ?? "main";

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -384,7 +384,12 @@ export async function runBasePickupPreflight(
     // one-cycle window is ever shown to matter in practice.
     return { action: "none", integrated: false, mergeStateStatus: snapshot.mergeStateStatus ?? null };
   }
-  const base = snapshot.baseRefName ?? "main";
+  // Pass the PR's actual base through; when it is unknown (null) let
+  // resolve-pr-conflicts derive it from `gh pr view` rather than defaulting to
+  // "main" — a repo whose base is not main must never merge the wrong branch.
+  // baseLabel is display-only (messages), where "main" is a readable fallback.
+  const base = snapshot.baseRefName ?? null;
+  const baseLabel = base ?? "main";
   // A watch-refresh re-entry polls the same head; it MUST NOT auto-integrate
   // (that would merge/push on every poll) but MUST still refuse to re-enter a
   // CI-wait while conflicting.
@@ -393,10 +398,10 @@ export async function runBasePickupPreflight(
       return {
         action: "blocked",
         integrated: false,
-        base,
+        base: baseLabel,
         conflicting: true,
         mergeStateStatus: snapshot.mergeStateStatus ?? null,
-        message: `PR #${pr} is CONFLICTING/DIRTY against ${base}; GitHub cannot dispatch CI on a conflicted branch, so no CI-wait is entered (FACADE-NEVER-CI-WAIT-WHILE-DIRTY). Integrate origin/${base} first (resolve-pr-conflicts.mjs) and re-gate (FACADE-PICKUP-INTEGRATE-BASE-FIRST).`,
+        message: `PR #${pr} is CONFLICTING/DIRTY against ${baseLabel}; GitHub cannot dispatch CI on a conflicted branch, so no CI-wait is entered (FACADE-NEVER-CI-WAIT-WHILE-DIRTY). Integrate origin/${baseLabel} first (resolve-pr-conflicts.mjs) and re-gate (FACADE-PICKUP-INTEGRATE-BASE-FIRST).`,
       };
     }
     return { action: "none", integrated: false, mergeStateStatus: snapshot.mergeStateStatus ?? null };
@@ -406,7 +411,7 @@ export async function runBasePickupPreflight(
     return {
       action: "integrated",
       integrated: true,
-      base,
+      base: res?.base ?? baseLabel,
       resolveAction: res?.action ?? null,
       pushed: Boolean(res?.pushed),
     };
@@ -414,11 +419,11 @@ export async function runBasePickupPreflight(
     return {
       action: "blocked",
       integrated: false,
-      base,
+      base: baseLabel,
       conflicting,
       mergeStateStatus: snapshot.mergeStateStatus ?? null,
       conflictFiles: Array.isArray(error?.conflictFiles) ? error.conflictFiles : undefined,
-      message: `PR #${pr} cannot enter a CI-wait: it could not be integrated with origin/${base}: ${error instanceof Error ? error.message : String(error)}. Resolve the conflict, push, and re-gate at the new head (FACADE-PICKUP-INTEGRATE-BASE-FIRST / FACADE-NEVER-CI-WAIT-WHILE-DIRTY).`,
+      message: `PR #${pr} cannot enter a CI-wait: it could not be integrated with origin/${baseLabel}: ${error instanceof Error ? error.message : String(error)}. Resolve the conflict, push, and re-gate at the new head (FACADE-PICKUP-INTEGRATE-BASE-FIRST / FACADE-NEVER-CI-WAIT-WHILE-DIRTY).`,
     };
   }
 }

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -2,6 +2,7 @@
 import { buildParseError, formatCliError, isCopilotLogin, isDirectCliRun, normalizeTimestamp, parseJsonText } from "../_core-helpers.mjs";
 import { parsePrNumber, requireTokenValue, runChild as defaultRunChild } from "../_cli-primitives.mjs";
 import { detectPostConvergenceSignificantChange } from "./_post-convergence-change.mjs";
+import { resolvePrConflicts } from "./resolve-pr-conflicts.mjs";
 import { detectRepoSlug, parseRepoSlug } from "@dev-loops/core/github/repo-slug";
 import { resolveRunId } from "@dev-loops/core/loop/run-context";
 import { loadDevLoopConfig, resolveEffectiveCopilotRoundCap, resolveRefinement } from "@dev-loops/core/config";
@@ -336,7 +337,84 @@ async function fetchReopenCycleFacts({ repo, pr }, { env = process.env, ghComman
   }
 }
 
-export async function runHandoff(options, { env = process.env, ghCommand = "gh", runChild = defaultRunChild, repoRoot } = {}) {
+// A PR whose base has diverged into a merge conflict reports mergeable
+// CONFLICTING / mergeStateStatus DIRTY. GitHub does NOT dispatch pull_request CI
+// on such a branch, so any loop that proceeds to a CI/review wait there waits
+// forever (the deadlock). BEHIND is not itself a deadlock, but pickup integrates
+// the base then too so the branch re-gates current.
+export function isConflictingMergeState(snapshot) {
+  return snapshot?.mergeStateStatus === "DIRTY" || snapshot?.mergeable === "CONFLICTING";
+}
+export function isBehindBaseMergeState(snapshot) {
+  return snapshot?.mergeStateStatus === "BEHIND";
+}
+
+// Default base integration: the sanctioned resolve-pr-conflicts.mjs fetches
+// origin/<base>, merges (auto-resolving ONLY the safe additive CHANGELOG case,
+// else fail-closed), verifies docs, and pushes. Injected in tests.
+async function defaultIntegrateBase({ repoRoot, base }, { env = process.env } = {}) {
+  return resolvePrConflicts(
+    { repoRoot, base: base ?? null, verify: true, push: true, json: true },
+    { env },
+  );
+}
+
+// Deterministic PR-pickup preflight (#deadlock): integrate the base branch FIRST,
+// before any gate or CI-wait, and NEVER enter a CI-wait on a CONFLICTING/DIRTY
+// branch. Returns `integrated` (head advanced → re-baseline and re-gate),
+// `blocked` (fail closed — resolve the conflict before gating), or `none`.
+export async function runBasePickupPreflight(
+  { repo, pr, snapshot, repoRoot, watchStatus },
+  { env = process.env, integrateBase = defaultIntegrateBase } = {},
+) {
+  if (!snapshot?.prExists || snapshot.prMerged || snapshot.prClosed) {
+    return { action: "none", integrated: false, reason: "no_open_pr" };
+  }
+  const conflicting = isConflictingMergeState(snapshot);
+  const behind = isBehindBaseMergeState(snapshot);
+  if (!conflicting && !behind) {
+    return { action: "none", integrated: false, mergeStateStatus: snapshot.mergeStateStatus ?? null };
+  }
+  const base = snapshot.baseRefName ?? "main";
+  // A watch-refresh re-entry polls the same head; it MUST NOT auto-integrate
+  // (that would merge/push on every poll) but MUST still refuse to re-enter a
+  // CI-wait while conflicting.
+  if (watchStatus !== undefined) {
+    if (conflicting) {
+      return {
+        action: "blocked",
+        integrated: false,
+        base,
+        conflicting: true,
+        mergeStateStatus: snapshot.mergeStateStatus ?? null,
+        message: `PR #${pr} is CONFLICTING/DIRTY against ${base}; GitHub cannot dispatch CI on a conflicted branch, so no CI-wait is entered (FACADE-NEVER-CI-WAIT-WHILE-DIRTY). Integrate origin/${base} first (resolve-pr-conflicts.mjs) and re-gate (FACADE-PICKUP-INTEGRATE-BASE-FIRST).`,
+      };
+    }
+    return { action: "none", integrated: false, mergeStateStatus: snapshot.mergeStateStatus ?? null };
+  }
+  try {
+    const res = await integrateBase({ repoRoot, base }, { env });
+    return {
+      action: "integrated",
+      integrated: true,
+      base,
+      resolveAction: res?.action ?? null,
+      pushed: Boolean(res?.pushed),
+    };
+  } catch (error) {
+    return {
+      action: "blocked",
+      integrated: false,
+      base,
+      conflicting,
+      mergeStateStatus: snapshot.mergeStateStatus ?? null,
+      conflictFiles: Array.isArray(error?.conflictFiles) ? error.conflictFiles : undefined,
+      message: `PR #${pr} cannot enter a CI-wait: it could not be integrated with origin/${base}: ${error instanceof Error ? error.message : String(error)}. Resolve the conflict, push, and re-gate at the new head (FACADE-PICKUP-INTEGRATE-BASE-FIRST / FACADE-NEVER-CI-WAIT-WHILE-DIRTY).`,
+    };
+  }
+}
+
+export async function runHandoff(options, { env = process.env, ghCommand = "gh", runChild = defaultRunChild, repoRoot, integrateBase } = {}) {
   // Single resolved repo root for config + runner-coordination reads/writes.
   // Defaults to the checkout's git toplevel (production); an injected repoRoot
   // keeps the whole cascade hermetic when driven in-process.
@@ -382,6 +460,55 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
     { repo: options.repo, pr: options.pr },
     { env, ghCommand, runChild },
   );
+  // Deterministic PR-pickup preflight (#deadlock): integrate the base branch
+  // FIRST — before any gate or CI-wait — and never enter a CI-wait on a
+  // CONFLICTING/DIRTY branch (GitHub cannot dispatch CI there, so the wait never
+  // ends). Runs ahead of loop interpretation so integration precedes gate/CI.
+  const basePickup = await runBasePickupPreflight(
+    { repo: options.repo, pr: options.pr, snapshot, repoRoot: resolvedRepoRoot, watchStatus: options.watchStatus },
+    { env, integrateBase },
+  );
+  if (basePickup.action === "blocked") {
+    const runnerRelease = await releaseAsyncRunnerOwnership({
+      repo: options.repo,
+      pr: options.pr,
+      env,
+      cwd: resolvedRepoRoot,
+    });
+    return {
+      ok: true,
+      action: "stop",
+      state: STATE.BLOCKED_NEEDS_USER_DECISION,
+      allowedTransitions: [],
+      nextAction: basePickup.message,
+      autoRerequestEligible: false,
+      sameHeadCleanConverged: false,
+      roundCapCleanEligible: false,
+      loopDisposition: "blocked",
+      terminal: true,
+      snapshot,
+      runnerOwnership,
+      ...(runnerRelease.status !== "skipped_no_async_run_id" ? { runnerRelease } : {}),
+      basePickupPreflight: basePickup,
+      requestWatchContract: {
+        action: "stop",
+        nextAction: basePickup.message,
+        requestStatus: "none",
+        routingState: "non_ready_state",
+        watchEntryConfirmed: false,
+        watchArgs: null,
+        stopState: "blocked",
+      },
+    };
+  }
+  if (basePickup.integrated) {
+    // The base integration advanced the head; re-baseline at the new head so the
+    // gate / CI re-runs there (re-gate-on-new-head).
+    snapshot = await autoDetectSnapshot(
+      { repo: options.repo, pr: options.pr },
+      { env, ghCommand, runChild },
+    );
+  }
   const config = await loadDevLoopConfig({ repoRoot: resolvedRepoRoot });
   if (config.errors?.length > 0) {
     console.error("[copilot-pr-handoff] config warnings:", JSON.stringify(config.errors));
@@ -627,6 +754,20 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
     action = "fix";
   } else {
     action = "stop";
+  }
+  // Fail-closed backstop (#deadlock): a CONFLICTING/DIRTY head can never route to
+  // a CI/review wait — GitHub cannot dispatch CI there. The pickup preflight
+  // above integrates or blocks a conflicted branch first, so this guards the
+  // watch decision itself as defense-in-depth.
+  if (action === "watch" && isConflictingMergeState(snapshot)) {
+    const conflictBase = snapshot.baseRefName ?? "main";
+    action = "stop";
+    interpretation = {
+      ...interpretation,
+      state: STATE.BLOCKED_NEEDS_USER_DECISION,
+      nextAction: `PR #${options.pr} is CONFLICTING/DIRTY against ${conflictBase}; GitHub cannot dispatch CI on a conflicted branch, so no CI-wait is entered (FACADE-NEVER-CI-WAIT-WHILE-DIRTY). Integrate origin/${conflictBase} first (resolve-pr-conflicts.mjs), push, and re-gate at the new head (FACADE-PICKUP-INTEGRATE-BASE-FIRST).`,
+      allowedTransitions: [],
+    };
   }
   const result = {
     ok: true,

--- a/scripts/loop/copilot-pr-handoff.mjs
+++ b/scripts/loop/copilot-pr-handoff.mjs
@@ -351,10 +351,13 @@ export function isBehindBaseMergeState(snapshot) {
 
 // Default base integration: the sanctioned resolve-pr-conflicts.mjs fetches
 // origin/<base>, merges (auto-resolving ONLY the safe additive CHANGELOG case,
-// else fail-closed), verifies docs, and pushes. Injected in tests.
+// else fail-closed), verifies docs, and pushes. It operates on repoRoot's
+// checked-out branch, so repoRoot MUST be the PR head's worktree (the sanctioned
+// per-PR pickup checkout) — the same assumption the resolve-pr-conflicts CLI
+// carries. Injected in tests.
 async function defaultIntegrateBase({ repoRoot, base }, { env = process.env } = {}) {
   return resolvePrConflicts(
-    { repoRoot, base: base ?? null, verify: true, push: true, json: true },
+    { repoRoot, base: base ?? null, verify: true, push: true },
     { env },
   );
 }
@@ -740,7 +743,7 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
       };
     }
   }
-  const interpretationSummary = summarizeLoopInterpretation(interpretation, refinementConfig);
+  let interpretationSummary = summarizeLoopInterpretation(interpretation, refinementConfig);
   const effectiveReviewRequestStatus = reviewRequestStatus
     ?? (snapshot.copilotReviewRequestStatus === "requested" || snapshot.copilotReviewRequestStatus === "already-requested"
       ? snapshot.copilotReviewRequestStatus
@@ -768,6 +771,10 @@ export async function runHandoff(options, { env = process.env, ghCommand = "gh",
       nextAction: `PR #${options.pr} is CONFLICTING/DIRTY against ${conflictBase}; GitHub cannot dispatch CI on a conflicted branch, so no CI-wait is entered (FACADE-NEVER-CI-WAIT-WHILE-DIRTY). Integrate origin/${conflictBase} first (resolve-pr-conflicts.mjs), push, and re-gate at the new head (FACADE-PICKUP-INTEGRATE-BASE-FIRST).`,
       allowedTransitions: [],
     };
+    // Re-derive the summary from the blocked interpretation so terminal /
+    // loopDisposition reflect the stop (BLOCKED is terminal); the terminal
+    // release path below then frees the async-runner claim.
+    interpretationSummary = summarizeLoopInterpretation(interpretation, refinementConfig);
   }
   const result = {
     ok: true,

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -142,7 +142,7 @@ export function parseDetectCliArgs(argv) {
 async function fetchPrView({ repo, pr }, { env, ghCommand, runChild = defaultRunChild }) {
   const result = await runChild(
     ghCommand,
-    ["pr", "view", String(pr), "--repo", repo, "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup"],
+    ["pr", "view", String(pr), "--repo", repo, "--json", "headRefOid,isDraft,state,number,reviews,statusCheckRollup,mergeable,mergeStateStatus,baseRefName"],
     env,
   );
   if (result.code !== 0) {
@@ -327,7 +327,7 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
       currentHeadCiStatus = "crediblyGreen";
     }
   }
-  return buildSnapshotFromPrFacts({
+  const snapshot = buildSnapshotFromPrFacts({
     prData,
     prNumber: pr,
     copilotReviewRequestStatus,
@@ -341,6 +341,17 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
     failureDetails,
     excludedFailureDetails,
   });
+  // Merge-state facts drive the base-integration preflight (never CI-wait on a
+  // CONFLICTING/DIRTY branch — GitHub cannot dispatch CI there). Carried as
+  // passthrough fields the loop interpreter ignores; only the pickup preflight reads them.
+  return {
+    ...snapshot,
+    mergeable: typeof prData.mergeable === "string" ? prData.mergeable : null,
+    mergeStateStatus: typeof prData.mergeStateStatus === "string" ? prData.mergeStateStatus : null,
+    baseRefName: typeof prData.baseRefName === "string" && prData.baseRefName.trim().length > 0
+      ? prData.baseRefName.trim()
+      : null,
+  };
 }
 export async function runCli(
   argv = process.argv.slice(2),

--- a/scripts/loop/detect-copilot-loop-state.mjs
+++ b/scripts/loop/detect-copilot-loop-state.mjs
@@ -254,6 +254,15 @@ function hasSubmittedCopilotReviewOffCurrentHead(reviewSummary, currentHeadSha) 
 }
 
 
+// GitHub returns mergeable/mergeStateStatus as canonical uppercase GraphQL
+// enums, but normalize defensively (trim + uppercase, empty → null) so the
+// pickup preflight's exact string guards can never miss a conflicted state.
+function normalizeMergeEnum(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
 export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride, localValidationHeadSha, draftGateResetAtMs }, { env = process.env, ghCommand = "gh", runChild = defaultRunChild } = {}) {
   const prData = await fetchPrView({ repo, pr }, { env, ghCommand, runChild });
   if (prData === null) {
@@ -343,11 +352,14 @@ export async function autoDetectSnapshot({ repo, pr, reviewRequestStatusOverride
   });
   // Merge-state facts drive the base-integration preflight (never CI-wait on a
   // CONFLICTING/DIRTY branch — GitHub cannot dispatch CI there). Carried as
-  // passthrough fields the loop interpreter ignores; only the pickup preflight reads them.
+  // passthrough fields the loop interpreter ignores; only the pickup preflight
+  // reads them. Normalize the two enum fields to trimmed-uppercase (empty → null)
+  // so the preflight's exact DIRTY/CONFLICTING/BEHIND matches can never miss a
+  // conflicted state on a casing/whitespace variance and re-open the deadlock.
   return {
     ...snapshot,
-    mergeable: typeof prData.mergeable === "string" ? prData.mergeable : null,
-    mergeStateStatus: typeof prData.mergeStateStatus === "string" ? prData.mergeStateStatus : null,
+    mergeable: normalizeMergeEnum(prData.mergeable),
+    mergeStateStatus: normalizeMergeEnum(prData.mergeStateStatus),
     baseRefName: typeof prData.baseRefName === "string" && prData.baseRefName.trim().length > 0
       ? prData.baseRefName.trim()
       : null,

--- a/skills/docs/public-dev-loop-contract.md
+++ b/skills/docs/public-dev-loop-contract.md
@@ -407,6 +407,14 @@ When an open linked PR reports merge conflict against `main`, treat this as an e
 4. only when that context is complete for one current head, resolve the conflict locally on the PR branch
 5. <!-- rule: FACADE-CONFLICT-REVALIDATE-NEW-HEAD --> `FACADE-CONFLICT-REVALIDATE-NEW-HEAD`: after conflict resolution, orchestration MUST rerun required local validation, gate checks, and required CI checks for the new head before approval/merge evaluation
 
+### Base integration is the deterministic FIRST action of PR pickup
+
+<!-- rule: FACADE-PICKUP-INTEGRATE-BASE-FIRST -->
+`FACADE-PICKUP-INTEGRATE-BASE-FIRST`: when the deterministic pickup path (the `loop handoff` / startup-continue route) picks up an existing PR, the FIRST action — before any gate run or CI-wait — is to read the PR's `mergeable` / `mergeStateStatus` and, when the branch is behind base or `CONFLICTING`/`DIRTY`, integrate `origin/<base>` (merge, or the sanctioned `resolve-pr-conflicts.mjs` additive-conflict resolver) and push. Only after the branch is mergeable-clean and re-based on the current base do gates / CI-wait proceed. This rule lives in the sanctioned pickup path (`scripts/loop/copilot-pr-handoff.mjs` `runBasePickupPreflight`), so every coordinator does it the same way without re-deriving it.
+
+<!-- rule: FACADE-NEVER-CI-WAIT-WHILE-DIRTY -->
+`FACADE-NEVER-CI-WAIT-WHILE-DIRTY`: the pickup path MUST NEVER enter a CI-wait (or Copilot-review wait) while `mergeStateStatus` is `DIRTY` / `mergeable` is `CONFLICTING`. GitHub does not dispatch `pull_request` CI on a conflicted branch, so a wait there never ends — the deadlock (observed on PR #2028). A conflicted PR is resolved first (integrate the base), or the loop fails closed with a clear actionable stop; it never waits for CI that can never dispatch. After integration the loop re-gates at the new head (`FACADE-CONFLICT-REVALIDATE-NEW-HEAD`).
+
 ## `auto dev loop` durable auto contract
 
 When the public intent is `auto dev loop`, the router MUST:

--- a/skills/docs/required-rules.json
+++ b/skills/docs/required-rules.json
@@ -176,6 +176,12 @@
       "id": "FACADE-LINKED-PR-SINGLE-ARTIFACT"
     },
     {
+      "id": "FACADE-NEVER-CI-WAIT-WHILE-DIRTY"
+    },
+    {
+      "id": "FACADE-PICKUP-INTEGRATE-BASE-FIRST"
+    },
+    {
       "id": "FACADE-STATUS-AUTHORITATIVE-FAIL-CLOSED"
     },
     {

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -2980,3 +2980,46 @@ test("runHandoff backstop: integrated but head still DIRTY never watches, stays 
     process.env.PATH = originalPath;
   }
 });
+
+test("runHandoff integrates a DIRTY head, re-baselines at the CLEAN new head, and proceeds to gate/watch", async () => {
+  // AC3 positive path: after integration the loop must re-read at the advanced
+  // head. A CLEAN re-baseline proceeds to normal routing (here: watch) — proving
+  // the fresh snapshot is used, not a stale DIRTY one that would hit the backstop.
+  const dirtyPrView = JSON.stringify({
+    headRefOid: "oldsha", isDraft: false, state: "OPEN", number: 17, reviews: [],
+    statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+    mergeable: "CONFLICTING", mergeStateStatus: "DIRTY", baseRefName: "main",
+  });
+  const cleanPrView = JSON.stringify({
+    headRefOid: "newsha", isDraft: false, state: "OPEN", number: 17, reviews: [],
+    statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+    mergeable: "MERGEABLE", mergeStateStatus: "CLEAN", baseRefName: "main",
+  });
+  const { runChild } = makeGhMock([
+    { assertArgs: ["pr", "view", "17", "--repo", "owner/repo"], stdout: dirtyPrView + "\n" },
+    { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+    { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+    { assertArgs: ["pr", "view", "17", "--repo", "owner/repo"], stdout: cleanPrView + "\n" },
+    { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' },
+    { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+  ], { matchMode: "claims" });
+  const parsed = parseHandoffCliArgs(["--repo", "owner/repo", "--pr", "17"]);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${gitStubDir}${path.delimiter}${originalPath}`;
+  try {
+    let integrated = false;
+    const result = await runHandoff(parsed, {
+      env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }),
+      ghCommand: "gh",
+      runChild,
+      repoRoot: capFixtureRepoRoot,
+      integrateBase: async () => { integrated = true; return { ok: true, action: "clean_merge", pushed: true }; },
+    });
+    assert.equal(integrated, true, "a DIRTY head must be integrated first");
+    assert.equal(result.action, "watch", "a CLEAN re-baseline must proceed to normal routing, not the DIRTY backstop stop");
+    assert.equal(result.snapshot.mergeStateStatus, "CLEAN", "the re-baselined (fresh) snapshot must be used");
+    assert.ok(result.watchArgs, "expected watchArgs on the proceed path");
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -8,7 +8,7 @@ import { afterAll as after, beforeAll as before, test } from "bun:test";
 import { makeGhMock, runIdFreeEnv, runNode as runNodeHelper, writeGhStub as writeGhStubHelper, writeJson as writeJsonHelper } from "../_helpers.mjs";
 
 import { formatCliError } from "../../scripts/_core-helpers.mjs";
-import { parseHandoffCliArgs, runHandoff } from "../../scripts/loop/copilot-pr-handoff.mjs";
+import { isBehindBaseMergeState, isConflictingMergeState, parseHandoffCliArgs, runBasePickupPreflight, runHandoff } from "../../scripts/loop/copilot-pr-handoff.mjs";
 import { STATE } from "../../packages/core/src/loop/copilot-loop-state.mjs";
 import { claimRunnerOwnership, loadRunnerCoordinationState, recordExitSignalForRunner } from "../../scripts/loop/_pr-runner-coordination.mjs";
 import { EXTERNAL_HEALTHY_WAIT_TIMEOUT_POLICY } from "../../packages/core/src/loop/timeout-policy.mjs";
@@ -868,7 +868,7 @@ if (args[0] === "api" && args[1] === "repos/owner/repo/commits/newsha/status?per
   process.exit(0);
 }
 
-if (args[0] === "pr" && args[1] === "view" && args.includes("--json") && args.includes("headRefOid,isDraft,state,number,reviews,statusCheckRollup")) {
+if (args[0] === "pr" && args[1] === "view" && args.includes("--json") && args.some((a) => a.startsWith("headRefOid,isDraft,state,number,reviews,statusCheckRollup"))) {
   write({
     headRefOid: "newsha",
     isDraft: false,
@@ -1173,7 +1173,7 @@ if (args[0] === "api" && args[1] === "repos/owner/repo/commits/newsha/status?per
   process.exit(0);
 }
 
-if (args[0] === "pr" && args[1] === "view" && args.includes("--json") && args.includes("headRefOid,isDraft,state,number,reviews,statusCheckRollup")) {
+if (args[0] === "pr" && args[1] === "view" && args.includes("--json") && args.some((a) => a.startsWith("headRefOid,isDraft,state,number,reviews,statusCheckRollup"))) {
   write({
     headRefOid: "newsha",
     isDraft: false,
@@ -2798,5 +2798,139 @@ test("copilot-pr-handoff skips internal detection when GH_SEQUENCE_PATH is set (
     assert.equal(output.internalOnlySkipCopilot, undefined);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PR-pickup base-integration preflight (#deadlock): integrate base FIRST;
+// never CI-wait on a CONFLICTING/DIRTY branch.
+// ---------------------------------------------------------------------------
+
+const OPEN_SNAPSHOT = {
+  prExists: true,
+  prNumber: 17,
+  prDraft: false,
+  prMerged: false,
+  prClosed: false,
+};
+
+test("isConflictingMergeState / isBehindBaseMergeState classify merge state", () => {
+  assert.equal(isConflictingMergeState({ mergeStateStatus: "DIRTY" }), true);
+  assert.equal(isConflictingMergeState({ mergeable: "CONFLICTING" }), true);
+  assert.equal(isConflictingMergeState({ mergeStateStatus: "CLEAN", mergeable: "MERGEABLE" }), false);
+  assert.equal(isConflictingMergeState({}), false);
+  assert.equal(isBehindBaseMergeState({ mergeStateStatus: "BEHIND" }), true);
+  assert.equal(isBehindBaseMergeState({ mergeStateStatus: "DIRTY" }), false);
+});
+
+test("runBasePickupPreflight is a no-op on a mergeable-clean branch", async () => {
+  let called = false;
+  const result = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", baseRefName: "main" }, repoRoot: "/tmp/x" },
+    { integrateBase: async () => { called = true; return { ok: true }; } },
+  );
+  assert.equal(result.action, "none");
+  assert.equal(result.integrated, false);
+  assert.equal(called, false, "integrateBase must not run on a clean branch");
+});
+
+test("runBasePickupPreflight integrates the base FIRST on a DIRTY branch (pickup)", async () => {
+  const calls = [];
+  const result = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "DIRTY", mergeable: "CONFLICTING", baseRefName: "main" }, repoRoot: "/tmp/wt" },
+    { integrateBase: async (args) => { calls.push(args); return { ok: true, action: "clean_merge", pushed: true }; } },
+  );
+  assert.equal(result.action, "integrated");
+  assert.equal(result.integrated, true);
+  assert.equal(result.base, "main");
+  assert.equal(result.pushed, true);
+  assert.deepEqual(calls, [{ repoRoot: "/tmp/wt", base: "main" }]);
+});
+
+test("runBasePickupPreflight integrates a BEHIND branch too", async () => {
+  let called = false;
+  const result = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "BEHIND", mergeable: "MERGEABLE", baseRefName: "main" }, repoRoot: "/tmp/wt" },
+    { integrateBase: async () => { called = true; return { ok: true, action: "clean_merge", pushed: true }; } },
+  );
+  assert.equal(result.action, "integrated");
+  assert.equal(called, true);
+});
+
+test("runBasePickupPreflight fails closed (blocked) on an unresolvable DIRTY conflict — never CI-wait", async () => {
+  const result = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "DIRTY", mergeable: "CONFLICTING", baseRefName: "main" }, repoRoot: "/tmp/wt" },
+    { integrateBase: async () => { const e = new Error("Unresolvable merge conflict"); e.conflictFiles = ["src/a.js"]; throw e; } },
+  );
+  assert.equal(result.action, "blocked");
+  assert.equal(result.integrated, false);
+  assert.deepEqual(result.conflictFiles, ["src/a.js"]);
+  assert.match(result.message, /re-gate at the new head/);
+});
+
+test("runBasePickupPreflight refuses to auto-integrate on a watch-refresh but still blocks a DIRTY branch", async () => {
+  let called = false;
+  const blocked = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "DIRTY", mergeable: "CONFLICTING", baseRefName: "main" }, repoRoot: "/tmp/wt", watchStatus: "idle" },
+    { integrateBase: async () => { called = true; return { ok: true }; } },
+  );
+  assert.equal(blocked.action, "blocked");
+  assert.equal(called, false, "a watch-refresh must not merge/push on every poll");
+  assert.match(blocked.message, /CONFLICTING\/DIRTY/);
+
+  const behind = await runBasePickupPreflight(
+    { repo: "owner/repo", pr: 17, snapshot: { ...OPEN_SNAPSHOT, mergeStateStatus: "BEHIND", baseRefName: "main" }, repoRoot: "/tmp/wt", watchStatus: "idle" },
+    { integrateBase: async () => { called = true; return { ok: true }; } },
+  );
+  assert.equal(behind.action, "none");
+  assert.equal(called, false);
+});
+
+test("runBasePickupPreflight is a no-op when the PR is merged/closed", async () => {
+  for (const snap of [{ prExists: false }, { prExists: true, prMerged: true }, { prExists: true, prClosed: true }]) {
+    const result = await runBasePickupPreflight(
+      { repo: "owner/repo", pr: 17, snapshot: { ...snap, mergeStateStatus: "DIRTY" }, repoRoot: "/tmp/wt" },
+      { integrateBase: async () => { throw new Error("must not run"); } },
+    );
+    assert.equal(result.action, "none");
+  }
+});
+
+test("runHandoff never enters a CI-wait on a DIRTY branch — stops, integration blocked", async () => {
+  const dirtyPrView = JSON.stringify({
+    isDraft: false,
+    state: "OPEN",
+    number: 17,
+    reviews: [],
+    statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+    mergeable: "CONFLICTING",
+    mergeStateStatus: "DIRTY",
+    baseRefName: "main",
+  });
+  const { runChild } = makeGhMock([
+    { assertArgs: ["pr", "view", "17", "--repo", "owner/repo"], stdout: dirtyPrView + "\n" },
+    { assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[],"teams":[]}\n' },
+    { assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" },
+  ], { matchMode: "claims" });
+  const parsed = parseHandoffCliArgs(["--repo", "owner/repo", "--pr", "17"]);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${gitStubDir}${path.delimiter}${originalPath}`;
+  try {
+    const result = await runHandoff(parsed, {
+      env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }),
+      ghCommand: "gh",
+      runChild,
+      repoRoot: capFixtureRepoRoot,
+      integrateBase: async () => { const e = new Error("Unresolvable merge conflict"); e.conflictFiles = ["src/a.js"]; throw e; },
+    });
+    assert.notEqual(result.action, "watch", "must NOT enter a CI-wait while DIRTY");
+    assert.equal(result.action, "stop");
+    assert.equal(result.basePickupPreflight.action, "blocked");
+    assert.equal(result.watchArgs, undefined);
+    assert.equal(result.requestWatchContract.watchEntryConfirmed, false);
+    assert.match(result.nextAction, /cannot enter a CI-wait/);
+    assert.match(result.nextAction, /FACADE-NEVER-CI-WAIT-WHILE-DIRTY/);
+  } finally {
+    process.env.PATH = originalPath;
   }
 });

--- a/test/loop/copilot-pr-handoff.test.mjs
+++ b/test/loop/copilot-pr-handoff.test.mjs
@@ -2934,3 +2934,49 @@ test("runHandoff never enters a CI-wait on a DIRTY branch — stops, integration
     process.env.PATH = originalPath;
   }
 });
+
+test("runHandoff backstop: integrated but head still DIRTY never watches, stays terminal, releases ownership", async () => {
+  // Merge-state lag: integrateBase succeeds and pushes, but GitHub's cached
+  // mergeStateStatus is still DIRTY on the re-baseline read. The would-be watch
+  // must be downgraded to a terminal stop (not a leaked non-terminal watch).
+  const dirtyReadyPrView = JSON.stringify({
+    headRefOid: "newsha",
+    isDraft: false,
+    state: "OPEN",
+    number: 17,
+    reviews: [],
+    statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS", name: "ci" }],
+    mergeable: "CONFLICTING",
+    mergeStateStatus: "DIRTY",
+    baseRefName: "main",
+  });
+  const entries = [];
+  for (let i = 0; i < 2; i += 1) {
+    entries.push({ assertArgs: ["pr", "view", "17", "--repo", "owner/repo"], stdout: dirtyReadyPrView + "\n" });
+    entries.push({ assertArgs: ["api", "repos/owner/repo/pulls/17/requested_reviewers"], stdout: '{"users":[{"login":"Copilot"}],"teams":[]}\n' });
+    entries.push({ assertArgs: ["api", "graphql"], stdout: EMPTY_THREADS + "\n" });
+  }
+  const { runChild } = makeGhMock(entries, { matchMode: "claims" });
+  const parsed = parseHandoffCliArgs(["--repo", "owner/repo", "--pr", "17"]);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${gitStubDir}${path.delimiter}${originalPath}`;
+  try {
+    let integrated = false;
+    const result = await runHandoff(parsed, {
+      env: runIdFreeEnv({ DEVLOOPS_RUN_ID: "" }),
+      ghCommand: "gh",
+      runChild,
+      repoRoot: capFixtureRepoRoot,
+      integrateBase: async () => { integrated = true; return { ok: true, action: "clean_merge", pushed: true }; },
+    });
+    assert.equal(integrated, true, "preflight must integrate the DIRTY branch first");
+    assert.notEqual(result.action, "watch", "a still-DIRTY head must never enter a CI-wait");
+    assert.equal(result.action, "stop");
+    assert.equal(result.terminal, true, "backstop stop must be terminal (no leaked non-terminal watch)");
+    assert.equal(result.loopDisposition, "blocked");
+    assert.equal(result.watchArgs, undefined);
+    assert.match(result.nextAction, /FACADE-NEVER-CI-WAIT-WHILE-DIRTY/);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
## Objective

When a dev-loop picks up an existing PR that is behind or diverged from its base, GitHub reports it `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` and does NOT dispatch `pull_request` CI on it. A loop that proceeds to "wait for CI" on such a branch waits forever — the CI it waits for can never run — a hard deadlock with no signal and no progress. This PR makes base-branch integration the deterministic FIRST action of PR pickup and refuses to enter a CI-wait while the branch is conflicted, closing that deadlock.

## In scope

Make base-branch integration the deterministic FIRST action of the PR-pickup preflight, ahead of any gate or CI-wait, and never enter a CI-wait on a `CONFLICTING`/`DIRTY` branch.

- `runBasePickupPreflight` (in `scripts/loop/copilot-pr-handoff.mjs`) reads the PR's `mergeable`/`mergeStateStatus` as the first action of pickup. When the branch is behind base or `CONFLICTING`/`DIRTY`, it integrates `origin/<base>` via the sanctioned `resolve-pr-conflicts.mjs` (merge, additive-CHANGELOG auto-resolve, else fail closed) and pushes, then re-baselines at the new head so the gate/CI re-runs there.
- The loop NEVER enters a CI/review wait while `mergeStateStatus` is `DIRTY` / `mergeable` is `CONFLICTING`: it integrates first or stops with a clear actionable message, and a fail-closed backstop at the watch decision refuses to route a conflicted head to a wait (downgrading to a terminal stop that releases runner ownership).
- A watch-refresh re-entry never auto-merges on every poll but still refuses to re-enter a wait while conflicting.
- `detect-copilot-loop-state.mjs` carries `mergeable`, `mergeStateStatus`, and `baseRefName` on the snapshot to drive the preflight (no new gh call — extra fields on the existing `gh pr view`).
- Documented in `skills/docs/public-dev-loop-contract.md` as `FACADE-PICKUP-INTEGRATE-BASE-FIRST` and `FACADE-NEVER-CI-WAIT-WHILE-DIRTY` (registered in `required-rules.json`, runtime-enforced via the refusal messages) and recorded in ADR 0066.

## Acceptance criteria

- [x] Picking up an existing PR integrates the base branch as the first step, before any gate or CI wait.
- [x] A `CONFLICTING`/`DIRTY` PR is resolved before any CI-wait; the loop never waits for CI that cannot dispatch (integrate first, or stop with a clear actionable message).
- [x] After integration the loop re-gates at the new head (head SHA advances; snapshot re-baselined).
- [x] The behavior is deterministic across coordinators — the rule lives in the sanctioned pickup path and the contract documents it; `bun run verify` green.

## Definition of done

- [x] The pickup route fetches origin and integrates `origin/<base>` (merge or sanctioned resolver) before dispatching a gate or waiting on CI; a rehearsal shows base integration precedes gate/CI.
- [x] A test/rehearsal covers the dirty-state path and asserts no CI-wait is entered while `DIRTY` (`test/loop/copilot-pr-handoff.test.mjs`): dirty-state stop, base-integrated-first, behind-integration, fail-closed-on-unresolvable, watch-refresh no-auto-merge, the integrate→still-DIRTY backstop, and the integrate→clean-rebaseline→proceed path.
- [x] Existing re-gate-on-new-head behavior is preserved (re-baseline snapshot after integration).
- [x] `bun run verify` green; generated `.claude/` mirror regenerated in lockstep; CHANGELOG updated; ADR 0066 recorded.

## Non-goals

- Changing how CI itself is configured or dispatched.
- Force-push semantics beyond the existing `--force-with-lease` integration rules.
- The gate/merge base-resolution (already reads the PR's actual base).
- Auto-resolving semantic merge conflicts that need human judgment (surface a clear stop instead).

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUDbPdYNy5EiLvGFuS9sbK
