### PR TITLE
fix(queue): derive In Progress for an open draft linked PR (#2029)

### DIFF
--- a/.claude/skills/docs/projects-queue-contract.md
+++ b/.claude/skills/docs/projects-queue-contract.md
@@ -570,17 +570,19 @@ to a logical column, then to a configured display name.
 
 | Loop / lifecycle state | Logical column | Default display name |
 | --- | --- | --- |
-| `issue_opened`, `issue_intake`, `refinement`, `no_pr`, `pr_draft` | `next_up` | **Next Up** |
-| `implementation`, `local_implementation_active`, `pr_ready_no_feedback`, `waiting_for_copilot_review`, `ready_to_rerequest_review`, `unresolved_feedback_present`, `already_fixed_needs_reply_resolve`, `waiting_for_ci`, `blocked_needs_user_decision`, other in-flight states | `in_progress` | **In Progress** |
+| `issue_opened`, `issue_intake`, `refinement`, `no_pr` | `next_up` | **Next Up** |
+| `pr_draft`, `implementation`, `local_implementation_active`, `pr_ready_no_feedback`, `waiting_for_copilot_review`, `ready_to_rerequest_review`, `unresolved_feedback_present`, `already_fixed_needs_reply_resolve`, `waiting_for_ci`, `blocked_needs_user_decision`, other in-flight states | `in_progress` | **In Progress** |
 | `final_approval_ready`, `pre_approval_gate` | `ready_for_review` | **In Progress** (unless overridden, see below) |
 | `merged`, `issue_closed`, `done`, `merge` | `done` | **Done** |
 | _any unmapped state_ | `in_progress` | **In Progress** (safe default — work is visibly active rather than dropped) |
 
 The mapping is **stateless**: it depends only on the current state, so a reverted
 state moves the column backward automatically. For example, a merged PR that is
-reopened maps back from **Done** to **In Progress**, and a ready PR demoted to a
-draft maps back from **In Progress** to **Next Up**. No "furthest reached" column
-is persisted.
+reopened maps back from **Done** to **In Progress**. A `pr_draft` state stays in
+**In Progress** — an open draft PR means a runner already owns the item, so it is
+no longer advertised in the pickup queue; the item returns to **Next Up** only
+when it reverts all the way to a pre-PR state (`no_pr`). No "furthest reached"
+column is persisted.
 
 #### Configuring column names (opt-in)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **A dev-loop runner no longer leaves an active tracker issue in `Next Up` after creating a draft PR (issue [2029](https://github.com/mfittko/dev-loops/issues/2029)).** The pure board-column derivation in `packages/core/src/loop/queue-board-sync.mjs` treated an open DRAFT linked PR as not-yet-in-flight, so the board advertised actively owned work as pickable: a second queue consumer could select it, and an operator could not tell implementation was underway. `deriveReconcileColumn` moved an open linked PR to In Progress only when `prIsDraft === false` (a draft returned `null`, leaving the item untouched in `Next Up`), and `DEFAULT_STATE_LOGICAL_MAP.pr_draft` mapped the inner `pr_draft` loop state to `NEXT_UP` — both contradicting the outer lifecycle, which already resolves a draft PR to `implementation` (In Progress). Both signals are fixed at the single shared source every board mover reads: `deriveReconcileColumn` now derives `IN_PROGRESS` for any OPEN linked PR regardless of draft state (merged still maps to Done, closed-unmerged and no-linked-PR still leave the item untouched), and `pr_draft` now maps to `IN_PROGRESS`. This converges the startup self-heal reconcile (`scripts/loop/resolve-dev-loop-startup.mjs`), the `dev-loops queue reconcile` command (`scripts/projects/reconcile-queue.mjs`), and any `boardColumnForLoopState` sync on the same invariant: an issue whose linked PR is OPEN (draft or ready) is never advertised in the pickup queue. Pre-PR states (`no_pr`, `issue_opened`, `issue_intake`, `refinement`) stay `NEXT_UP` so genuine pickable work is unchanged. Proven by `packages/core/test/queue-board-sync.test.mjs` (draft linked PR and draft PR item both derive In Progress; `pr_draft` maps to In Progress across the default map, column-name override, revert path, and invalid-override fallback) and `test/projects/reconcile-queue.test.mjs` (a `Next Up` item with an open draft linked PR is planned out of the pickup column).
+
 ## 1.0.2
 
 ### Added

--- a/packages/core/src/loop/queue-board-sync.mjs
+++ b/packages/core/src/loop/queue-board-sync.mjs
@@ -50,9 +50,11 @@ export const DEFAULT_STATE_LOGICAL_MAP = Object.freeze({
   issue_intake: LOGICAL_COLUMN.NEXT_UP,
   refinement: LOGICAL_COLUMN.NEXT_UP,
   no_pr: LOGICAL_COLUMN.NEXT_UP,
-  pr_draft: LOGICAL_COLUMN.NEXT_UP,
 
   // In Progress — active implementation / review / feedback resolution
+  // A draft PR exists, so a runner owns the item; it is no longer pickable.
+  // This reconciles with the outer `implementation` lifecycle mapping.
+  pr_draft: LOGICAL_COLUMN.IN_PROGRESS,
   implementation: LOGICAL_COLUMN.IN_PROGRESS,
   // Tolerated alias for `implementation` (conceptual name);
   // the queue driver passes the real `implementation` lifecycle state.
@@ -125,8 +127,9 @@ export function deriveReconcileColumn(facts = {}) {
   // Merged PR (item is a PR, or issue's linked PR merged) => Done.
   if (prState === "MERGED") return LOGICAL_COLUMN.DONE;
   if (itemKind === "issue" && issueState === "CLOSED") return LOGICAL_COLUMN.DONE;
-  // Open, ready (non-draft) PR => In Progress.
-  if (prState === "OPEN" && prIsDraft === false) return LOGICAL_COLUMN.IN_PROGRESS;
+  // Any OPEN linked PR (draft or ready) => In Progress: a runner owns the item,
+  // so it must never be advertised in the pickup queue.
+  if (prState === "OPEN") return LOGICAL_COLUMN.IN_PROGRESS;
   // Otherwise leave the item untouched (Backlog / Next Up ordering preserved).
   return null;
 }

--- a/packages/core/test/queue-board-sync.test.mjs
+++ b/packages/core/test/queue-board-sync.test.mjs
@@ -206,9 +206,15 @@ test("loadBoardConfig surfaces config read errors", async () => {
 
 // ── boardColumnForLoopState (AC1, AC3, AC5) ──────────────────────────────
 
-test("boardColumnForLoopState maps issue_opened and pr_draft to Next Up (AC1)", () => {
+test("boardColumnForLoopState maps issue_opened / issue_intake / no_pr to Next Up (AC1)", () => {
   assert.equal(boardColumnForLoopState("issue_opened"), "Next Up");
-  assert.equal(boardColumnForLoopState("pr_draft"), "Next Up");
+  assert.equal(boardColumnForLoopState("issue_intake"), "Next Up");
+  assert.equal(boardColumnForLoopState("no_pr"), "Next Up");
+});
+
+test("boardColumnForLoopState maps pr_draft to In Progress (#2029)", () => {
+  // A draft PR exists → a runner is active; the item is no longer pickable.
+  assert.equal(boardColumnForLoopState("pr_draft"), "In Progress");
 });
 
 test("boardColumnForLoopState maps active/feedback states to In Progress (AC1)", () => {
@@ -260,7 +266,8 @@ test("boardColumnForLoopState honors a config-driven column name override (AC3)"
       [LOGICAL_COLUMN.DONE]: "Shipped",
     },
   };
-  assert.equal(boardColumnForLoopState("pr_draft", mapping), "Todo");
+  assert.equal(boardColumnForLoopState("issue_opened", mapping), "Todo");
+  assert.equal(boardColumnForLoopState("pr_draft", mapping), "Doing");
   assert.equal(boardColumnForLoopState("waiting_for_copilot_review", mapping), "Doing");
   assert.equal(boardColumnForLoopState("merged", mapping), "Shipped");
 });
@@ -279,8 +286,10 @@ test("boardColumnForLoopState supports a reverse transition merged->Done then re
   assert.equal(boardColumnForLoopState("merged"), "Done");
   // reverted: PR reopened back to ready -> In Progress (moves backward)
   assert.equal(boardColumnForLoopState("pr_ready_no_feedback"), "In Progress");
-  // ready -> draft reverts further back to Next Up
-  assert.equal(boardColumnForLoopState("pr_draft"), "Next Up");
+  // ready -> draft still stays In Progress: a runner owns the draft PR (#2029)
+  assert.equal(boardColumnForLoopState("pr_draft"), "In Progress");
+  // reverting all the way to no PR returns the item to Next Up (pickable again)
+  assert.equal(boardColumnForLoopState("no_pr"), "Next Up");
 });
 
 // ── loadStateColumnMap (AC2/AC3/AC6) ─────────────────────────────────────
@@ -374,9 +383,9 @@ test("loadStateColumnMap ignores stateColumnMap entries with an unknown logical-
   );
   try {
     const mapping = loadStateColumnMap(dir);
-    // invalid value ignored — pr_draft keeps its default logical column (Next Up)
+    // invalid value ignored — pr_draft keeps its default logical column (In Progress, #2029)
     assert.equal(Object.prototype.hasOwnProperty.call(mapping.stateColumnMap, "pr_draft"), false);
-    assert.equal(boardColumnForLoopState("pr_draft", mapping), "Next Up");
+    assert.equal(boardColumnForLoopState("pr_draft", mapping), "In Progress");
     // valid value applies
     assert.equal(mapping.stateColumnMap["blocked_needs_user_decision"], "next_up");
     assert.equal(boardColumnForLoopState("blocked_needs_user_decision", mapping), "Next Up");
@@ -587,10 +596,18 @@ test("deriveReconcileColumn: open issue with open non-draft linked PR → In Pro
   );
 });
 
-test("deriveReconcileColumn: open issue with draft linked PR → null (untouched)", () => {
+test("deriveReconcileColumn: open issue with draft linked PR → In Progress (#2029)", () => {
+  // A draft PR means a runner already owns the item; it must leave Next Up.
   assert.equal(
     deriveReconcileColumn({ itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: true }),
-    null,
+    LOGICAL_COLUMN.IN_PROGRESS,
+  );
+});
+
+test("deriveReconcileColumn: draft PR item itself → In Progress (#2029)", () => {
+  assert.equal(
+    deriveReconcileColumn({ itemKind: "pr", issueState: null, prState: "OPEN", prIsDraft: true }),
+    LOGICAL_COLUMN.IN_PROGRESS,
   );
 });
 

--- a/skills/docs/projects-queue-contract.md
+++ b/skills/docs/projects-queue-contract.md
@@ -570,17 +570,19 @@ to a logical column, then to a configured display name.
 
 | Loop / lifecycle state | Logical column | Default display name |
 | --- | --- | --- |
-| `issue_opened`, `issue_intake`, `refinement`, `no_pr`, `pr_draft` | `next_up` | **Next Up** |
-| `implementation`, `local_implementation_active`, `pr_ready_no_feedback`, `waiting_for_copilot_review`, `ready_to_rerequest_review`, `unresolved_feedback_present`, `already_fixed_needs_reply_resolve`, `waiting_for_ci`, `blocked_needs_user_decision`, other in-flight states | `in_progress` | **In Progress** |
+| `issue_opened`, `issue_intake`, `refinement`, `no_pr` | `next_up` | **Next Up** |
+| `pr_draft`, `implementation`, `local_implementation_active`, `pr_ready_no_feedback`, `waiting_for_copilot_review`, `ready_to_rerequest_review`, `unresolved_feedback_present`, `already_fixed_needs_reply_resolve`, `waiting_for_ci`, `blocked_needs_user_decision`, other in-flight states | `in_progress` | **In Progress** |
 | `final_approval_ready`, `pre_approval_gate` | `ready_for_review` | **In Progress** (unless overridden, see below) |
 | `merged`, `issue_closed`, `done`, `merge` | `done` | **Done** |
 | _any unmapped state_ | `in_progress` | **In Progress** (safe default — work is visibly active rather than dropped) |
 
 The mapping is **stateless**: it depends only on the current state, so a reverted
 state moves the column backward automatically. For example, a merged PR that is
-reopened maps back from **Done** to **In Progress**, and a ready PR demoted to a
-draft maps back from **In Progress** to **Next Up**. No "furthest reached" column
-is persisted.
+reopened maps back from **Done** to **In Progress**. A `pr_draft` state stays in
+**In Progress** — an open draft PR means a runner already owns the item, so it is
+no longer advertised in the pickup queue; the item returns to **Next Up** only
+when it reverts all the way to a pre-PR state (`no_pr`). No "furthest reached"
+column is persisted.
 
 #### Configuring column names (opt-in)
 

--- a/test/projects/reconcile-queue.test.mjs
+++ b/test/projects/reconcile-queue.test.mjs
@@ -8,8 +8,10 @@ import { main, gatherLiveFacts } from "../../scripts/projects/reconcile-queue.mj
 // Facts consumed by planReconcile via deriveReconcileColumn. A ready open
 // non-draft linked PR on an open issue derives → In Progress.
 const READY_LINKED_PR = { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: false };
-// Nothing to derive (no linked PR / still draft) → untouched.
+// Nothing to derive (no linked PR) → untouched.
 const UNTOUCHED = { itemKind: "issue", issueState: "OPEN", prState: null, prIsDraft: null };
+// An open DRAFT linked PR now derives → In Progress (a runner owns it, #2029).
+const DRAFT_LINKED_PR = { itemKind: "issue", issueState: "OPEN", prState: "OPEN", prIsDraft: true };
 
 // Run main() with fully injected deps so no network / gh / .devloops is needed.
 // cwd omitted → loadStateColumnMap falls back to the AC1 default column names,
@@ -88,6 +90,19 @@ describe("reconcile-queue main (#1069)", () => {
     assert.equal(result.moved, 0);
     assert.equal(result.unchanged, 1);
     assert.equal(moveCalls.length, 0);
+  });
+
+  it("#2029: a Next Up item with an open draft linked PR → one move to In Progress (leaves the pickup column)", async () => {
+    const moveCalls = [];
+    const result = await run({
+      items: [{ itemId: "I_9", issueNumber: 9, prNumber: null, status: "Next Up" }],
+      facts: [["I_9", DRAFT_LINKED_PR]],
+      moveCalls,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.moved, 1);
+    assert.equal(moveCalls.length, 1);
+    assert.equal(moveCalls[0].toColumn, "In Progress");
   });
 
   it("gatherLiveFacts with doneColumn skips a Done-status item (zero gh calls) but still gathers a non-Done item", async () => {


### PR DESCRIPTION
## Summary

An open DRAFT linked PR left its tracker issue in `Next Up`, so the board advertised actively owned work as pickable (a second consumer could select it; an operator could not tell implementation was underway). Fix the single shared board derivation in `packages/core/src/loop/queue-board-sync.mjs` so every mover (startup self-heal reconcile, `queue reconcile`, and `boardColumnForLoopState` sync) converges the same way.

Invariant enforced: an issue whose linked PR is OPEN (draft or ready) is never advertised in the pickup queue.

## In scope

- `deriveReconcileColumn`: any OPEN linked PR (draft or ready) derives `IN_PROGRESS`; dropped the `prIsDraft === false` condition. Merged to Done and closed-unmerged to null are unchanged.
- `DEFAULT_STATE_LOGICAL_MAP.pr_draft` to `IN_PROGRESS`, reconciling it with the outer `implementation` lifecycle mapping. `no_pr` / `issue_opened` / `issue_intake` / `refinement` stay `NEXT_UP`.
- Tests, CHANGELOG, and the canonical queue contract doc (+ `.claude/` mirror) updated to match.

## Acceptance criteria

- [x] An open linked DRAFT PR derives In Progress for its tracker issue (existing `queue-board-sync.test.mjs` case flipped from `null`).
- [x] A draft PR that is itself the queue item also derives In Progress (new case).
- [x] `boardColumnForLoopState("pr_draft")` returns `In Progress`; default-map, column-name override, revert path, and invalid-override fallback assertions updated.
- [x] A `Next Up` item with an open draft linked PR is planned out of the pickup column (`reconcile-queue` plan test).
- [x] Ready-open / no-linked-PR / merged / closed-unmerged behavior unchanged.
- [x] Pre-PR states stay pickable in Next Up.
- [x] Full verify gate green (8421 pass).

## Definition of done

- [x] Root cause fixed at the single shared source (`deriveReconcileColumn` + `DEFAULT_STATE_LOGICAL_MAP.pr_draft`); no per-caller patch.
- [x] Tests updated/added in `packages/core/test/queue-board-sync.test.mjs` and `test/projects/reconcile-queue.test.mjs`; all pass.
- [x] Canonical contract doc `skills/docs/projects-queue-contract.md` (and its `.claude/` mirror) updated to match the new mapping.
- [x] CHANGELOG `## Unreleased` entry added.
- [x] `bun run verify` green locally and in CI.

## Non-goals

No lease/heartbeat/reclamation of abandoned draft PRs. No new blocked to Backlog transition. No read-back-and-retry loop in `move-queue-item.mjs`. No change to `resolve-active-board-item.mjs` claim arbitration. No change to pre-PR to Next Up mapping.

Closes #2029

adr-tripwire:allow The `skills/docs/projects-queue-contract.md` edit is a factual doc alignment, not a new architectural decision: it moves `pr_draft` to the In Progress row of the state-to-column table to match the mapping decided and refined in issue #2029 (the decision record). No new contract semantics beyond what that issue's AC/DoD matrix mandates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
