### PR TITLE
feat(cli): auto-detect repo from git origin for queue/project list (#1952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Narrow `wait_watch` startup reading to the public routing contract and a short watch procedure. Re-entry loads the freshly selected route's contracts before acting; watch budgets, gates, authorization, and Pi/Claude continuation behavior remain unchanged.
+- **`dev-loops queue list` / `dev-loops project list` auto-detect the repo from the git origin remote when `--repo` is omitted (issue [1952](https://github.com/mfittko/dev-loops/issues/1952)).** Explicit `--repo` still wins. A non-GitHub or absent origin remote fails closed with `INVALID_REPO`, naming both the git-remote fallback and `--repo`. The shared `detectRepoSlug` helper is hardened to only resolve `github.com` hosts (SSH scp, `ssh://`, and HTTPS forms), returning `null` for any other host.
 
 ### Added
 

--- a/packages/core/src/github/repo-slug.mjs
+++ b/packages/core/src/github/repo-slug.mjs
@@ -83,10 +83,33 @@ export function dedupeRepoSlugOptions(options) {
   }
   return uniqueOptions;
 }
+// Parses a git remote URL into an <owner/name> slug, but only for github.com
+// remotes. The URI form (scheme://[user@]host[:port]/path) is checked before
+// the scp form (host:path), because the scp regex also matches URIs like
+// https://... — checking scp first would misparse the host out of the scheme.
+function parseGitHubRemoteSlug(url) {
+  let host, path;
+  const uri = url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?\/(.+)$/);
+  const scp = url.match(/^(?:[^@/]+@)?([^/:]+):(.+)$/);
+  if (uri) {
+    host = uri[1];
+    path = uri[2];
+  } else if (scp) {
+    host = scp[1];
+    path = scp[2];
+  } else {
+    return null;
+  }
+  if (host.toLowerCase() !== "github.com") return null;
+  const seg = path.match(/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (!seg) return null;
+  return `${seg[1]}/${seg[2]}`;
+}
+
 /**
  * Auto-detect <owner/name> from `git remote get-url origin`.
  * Returns the slug string on success, or null when detection fails
- * (no origin remote, not a git repo, or unparseable URL).
+ * (no origin remote, not a git repo, non-github.com host, or unparseable URL).
  * Does NOT throw — callers should add their own context-specific error messages.
  */
 export function detectRepoSlug(cwd) {
@@ -96,9 +119,7 @@ export function detectRepoSlug(cwd) {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     }).trim();
-    const match = url.match(/[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
-    if (!match) return null;
-    return `${match[1]}/${match[2]}`;
+    return parseGitHubRemoteSlug(url);
   } catch {
     return null;
   }

--- a/packages/core/test/repo-slug.test.mjs
+++ b/packages/core/test/repo-slug.test.mjs
@@ -228,6 +228,18 @@ test("detectRepoSlug returns null for unparseable remote URL", () => {
   }
 });
 
+test("detectRepoSlug returns owner/repo from an HTTPS github.com remote without a .git suffix", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "https://github.com/owner/name"]);
+    const slug = detectRepoSlug(tmpDir);
+    assert.equal(slug, "owner/name");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("detectRepoSlug returns owner/repo from an SSH scp-style github.com remote", () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
   try {

--- a/packages/core/test/repo-slug.test.mjs
+++ b/packages/core/test/repo-slug.test.mjs
@@ -227,3 +227,51 @@ test("detectRepoSlug returns null for unparseable remote URL", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test("detectRepoSlug returns owner/repo from an SSH scp-style github.com remote", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "git@github.com:owner/name.git"]);
+    const slug = detectRepoSlug(tmpDir);
+    assert.equal(slug, "owner/name");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRepoSlug returns owner/repo from an ssh:// github.com remote", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "ssh://git@github.com/owner/name.git"]);
+    const slug = detectRepoSlug(tmpDir);
+    assert.equal(slug, "owner/name");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRepoSlug returns null for a non-github.com HTTPS remote", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "https://gitlab.com/owner/repo.git"]);
+    const slug = detectRepoSlug(tmpDir);
+    assert.equal(slug, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("detectRepoSlug returns null for a non-github.com scp-style remote", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-slug-test-"));
+  try {
+    execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+    execFileSync("git", ["-C", tmpDir, "remote", "add", "origin", "git@bitbucket.org:owner/name.git"]);
+    const slug = detectRepoSlug(tmpDir);
+    assert.equal(slug, null);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -4,6 +4,7 @@ import { applyDevloopsBoard } from "./_resolve-project.mjs";
 import { parseArgs } from "node:util";
 import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToken } from "../lib/jq-output.mjs";
 import { main, classifyExitCode } from "@dev-loops/core/projects/list-queue-items";
+import { detectRepoSlug } from "@dev-loops/core/github/repo-slug";
 
 const USAGE = `Usage: dev-loops queue list --repo <owner/name> [--project <number|id>] [--column <name>] [--limit <n>]
        dev-loops queue list --repo <owner/name> [--project <number|id>] --summary [--done-limit <n>]
@@ -13,7 +14,9 @@ List GitHub Projects V2 items filtered by Status column, ordered by position
 ascending. Returns machine-readable JSON.
 
 Options:
-  --repo <owner/name>     Required. Repository to scope the project search.
+  --repo <owner/name>     Repository to scope the project search. Auto-detected
+                          from the git origin remote (github.com only) when
+                          omitted; pass explicitly to override.
   --project <number|id>   Project number (integer) or node ID. When omitted,
                           resolved from the .devloops tracker.board
                           number / title.
@@ -194,10 +197,22 @@ async function runCli(argv, { stdout = process.stdout, stderr = process.stderr, 
     return;
   }
 
-  // Resolve the board from .devloops when --project is absent.
-  applyDevloopsBoard(args, cwd);
-
   try {
+    if (!args.repo) {
+      const detected = detectRepoSlug(cwd);
+      if (detected) {
+        args.repo = detected;
+      } else {
+        throw Object.assign(
+          new Error("--repo is required and could not be auto-detected from the git origin remote. Set an origin remote pointing at a github.com repo, or pass --repo <owner/name>."),
+          { code: "INVALID_REPO" },
+        );
+      }
+    }
+
+    // Resolve the board from .devloops when --project is absent.
+    applyDevloopsBoard(args, cwd);
+
     const result = await main(args, { env, runChild });
     if (args.table) {
       stdout.write(renderItemsTable(result.items));

--- a/scripts/projects/list-queue-items.mjs
+++ b/scripts/projects/list-queue-items.mjs
@@ -6,8 +6,8 @@ import { JQ_OUTPUT_PARSE_OPTIONS, JQ_OUTPUT_USAGE, emitResult, matchJqOutputToke
 import { main, classifyExitCode } from "@dev-loops/core/projects/list-queue-items";
 import { detectRepoSlug } from "@dev-loops/core/github/repo-slug";
 
-const USAGE = `Usage: dev-loops queue list --repo <owner/name> [--project <number|id>] [--column <name>] [--limit <n>]
-       dev-loops queue list --repo <owner/name> [--project <number|id>] --summary [--done-limit <n>]
+const USAGE = `Usage: dev-loops queue list [--repo <owner/name>] [--project <number|id>] [--column <name>] [--limit <n>]
+       dev-loops queue list [--repo <owner/name>] [--project <number|id>] --summary [--done-limit <n>]
        (dev-loops project list … is a back-compat alias)
 
 List GitHub Projects V2 items filtered by Status column, ordered by position

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -512,7 +512,11 @@ node "$(dirname "$0")/gh-impl.mjs" "$@"
     // that repoRoot's own github.com origin would now auto-resolve.
     const failure = spawnSync("node", [path.join(repoRoot, "cli/index.mjs"), "project", "list"], {
       cwd: tempRoot,
-      env,
+      // ponytail: tempRoot is never git-init'd, but git still walks parent
+      // directories looking for a .git; cap the walk at tempRoot so a host
+      // whose TMPDIR happens to sit inside a git checkout can't leak an
+      // ancestor's origin remote into this fail-closed assertion.
+      env: { ...env, GIT_CEILING_DIRECTORIES: tempRoot },
       encoding: "utf8",
     });
     assert.equal(failure.status, 1);

--- a/test/dev-loops-cli.test.mjs
+++ b/test/dev-loops-cli.test.mjs
@@ -507,14 +507,17 @@ node "$(dirname "$0")/gh-impl.mjs" "$@"
     assert.equal(payload.items[0].issueNumber, 748);
     assert.equal(payload.items[0].status, "Next Up");
 
-    const failure = spawnSync("node", ["./cli/index.mjs", "project", "list"], {
-      cwd: repoRoot,
+    // cwd has no .git origin, so --repo cannot be auto-detected: this is the
+    // fail-closed INVALID_REPO path, not the (unrelated) --repo-omitted path
+    // that repoRoot's own github.com origin would now auto-resolve.
+    const failure = spawnSync("node", [path.join(repoRoot, "cli/index.mjs"), "project", "list"], {
+      cwd: tempRoot,
       env,
       encoding: "utf8",
     });
     assert.equal(failure.status, 1);
     assert.equal(failure.stdout, "");
-    assert.match(failure.stderr, /--repo is required/);
+    assert.match(failure.stderr, /could not be auto-detected/);
     assert.match(failure.stderr, /"code":"INVALID_REPO"/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -2887,13 +2887,29 @@ async function initLocalOriginRepo(tempDir) {
   execFileSync("git", ["config", "user.name", "Test"], { cwd: tempDir, stdio: "ignore" });
   // "origin" is the real git@github.com:mfittko/dev-loops.git slug (so the
   // hardened, github.com-only detectRepoSlug resolves it, matching the repo
-  // the fixtures below assert against), but pushInsteadOf silently redirects
-  // the actual push transport to a local bare repo, and a fake ssh command
-  // makes any real fetch fail instantly with no network — so this stays
-  // fully hermetic and offline, same as before.
+  // the fixtures below assert against). `url.*.insteadOf`/`pushInsteadOf`
+  // can't redirect the transport without also breaking that: git's URL
+  // rewriting is applied uniformly, so any config that redirects fetch also
+  // makes `git remote get-url origin` report the rewritten (local) URL
+  // instead of the github slug, which is exactly what detectRepoSlug reads.
+  // Instead, `core.sshCommand` points at a fake ssh binary that intercepts
+  // the `git-upload-pack`/`git-receive-pack` command github's ssh transport
+  // would normally run remotely, and runs it against the local bare repo
+  // directly — so both fetch and push stay fully hermetic and offline, while
+  // `origin`'s configured (and reported) URL never changes.
+  const remoteRunnerPath = path.join(remoteRoot, "fake-ssh.sh");
+  const remoteRunnerLines = [
+    "#!/usr/bin/env sh",
+    'eval "last=\\${$#}"',
+    "case \"$last\" in",
+    `  *git-upload-pack*) exec git-upload-pack "${remoteDir}" ;;`,
+    `  *git-receive-pack*) exec git-receive-pack "${remoteDir}" ;;`,
+    "  *) exit 0 ;;",
+    "esac",
+  ];
+  writeFileSync(remoteRunnerPath, `${remoteRunnerLines.join("\n")}\n`, { mode: 0o755 });
   execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
-  execFileSync("git", ["config", `url.${remoteDir}.pushInsteadOf`, "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
-  execFileSync("git", ["config", "core.sshCommand", "false"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["config", "core.sshCommand", remoteRunnerPath], { cwd: tempDir, stdio: "ignore" });
   await writeFile(path.join(tempDir, "README.md"), "init\n", "utf8");
   execFileSync("git", ["add", "-A"], { cwd: tempDir, stdio: "ignore" });
   execFileSync("git", ["commit", "--quiet", "-m", "init"], { cwd: tempDir, stdio: "ignore" });

--- a/test/loop/resolve-dev-loop-startup.test.mjs
+++ b/test/loop/resolve-dev-loop-startup.test.mjs
@@ -2885,7 +2885,15 @@ async function initLocalOriginRepo(tempDir) {
   execFileSync("git", ["checkout", "-b", "main", "--quiet"], { cwd: tempDir, stdio: "ignore" });
   execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir, stdio: "ignore" });
   execFileSync("git", ["config", "user.name", "Test"], { cwd: tempDir, stdio: "ignore" });
-  execFileSync("git", ["remote", "add", "origin", remoteDir], { cwd: tempDir, stdio: "ignore" });
+  // "origin" is the real git@github.com:mfittko/dev-loops.git slug (so the
+  // hardened, github.com-only detectRepoSlug resolves it, matching the repo
+  // the fixtures below assert against), but pushInsteadOf silently redirects
+  // the actual push transport to a local bare repo, and a fake ssh command
+  // makes any real fetch fail instantly with no network — so this stays
+  // fully hermetic and offline, same as before.
+  execFileSync("git", ["remote", "add", "origin", "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["config", `url.${remoteDir}.pushInsteadOf`, "git@github.com:mfittko/dev-loops.git"], { cwd: tempDir, stdio: "ignore" });
+  execFileSync("git", ["config", "core.sshCommand", "false"], { cwd: tempDir, stdio: "ignore" });
   await writeFile(path.join(tempDir, "README.md"), "init\n", "utf8");
   execFileSync("git", ["add", "-A"], { cwd: tempDir, stdio: "ignore" });
   execFileSync("git", ["commit", "--quiet", "-m", "init"], { cwd: tempDir, stdio: "ignore" });

--- a/test/projects/list-queue-items.test.mjs
+++ b/test/projects/list-queue-items.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it } from "bun:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import nodePath from "node:path";
@@ -906,6 +907,80 @@ describe("list-queue-items", () => {
         assert.match(err, /INVALID_PROJECT/);
         process.exitCode = 0; // avoid leaking a failure code into the test runner
       });
+    });
+  });
+});
+
+describe("repo auto-detect from git origin remote (#1952)", () => {
+  function projectListResponses(project) {
+    return [
+      { payload: userPayload() },
+      { payload: listUserProjectsResponse([project]) },
+      { payload: getFieldsResponse([STATUS_FIELD]) },
+      { payload: getItemsResponse([]) },
+    ];
+  }
+
+  function spyRunChild(responses) {
+    const calls = [];
+    const base = mockRunChild(responses);
+    const spy = async (cmd, args, env) => {
+      calls.push({ cmd, args, env });
+      return base(cmd, args, env);
+    };
+    spy.calls = calls;
+    return spy;
+  }
+
+  async function withGitCwd(remoteUrl, fn) {
+    const dir = mkdtempSync(nodePath.join(tmpdir(), "list-queue-git-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+      if (remoteUrl) {
+        execFileSync("git", ["-C", dir, "remote", "add", "origin", remoteUrl]);
+      }
+      await fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("runCli auto-detects --repo from the git origin remote when omitted", async () => {
+    await withGitCwd("https://github.com/owner/repo.git", async (cwd) => {
+      const child = spyRunChild(projectListResponses(EXISTING_PROJECT));
+      await runCli(["--project", "1"], {
+        env: {}, cwd, runChild: child,
+        stdout: { write() {} }, stderr: { write() {} },
+      });
+      assert.equal(process.exitCode, 0);
+      assert.ok(child.calls[0].args.includes("login=owner"));
+    });
+  });
+
+  it("runCli: explicit --repo wins over the git origin auto-detect", async () => {
+    await withGitCwd("https://github.com/other/repo.git", async (cwd) => {
+      const child = spyRunChild(projectListResponses(EXISTING_PROJECT));
+      await runCli(["--repo", "explicit/repo", "--project", "1"], {
+        env: {}, cwd, runChild: child,
+        stdout: { write() {} }, stderr: { write() {} },
+      });
+      assert.equal(process.exitCode, 0);
+      assert.ok(child.calls[0].args.includes("login=explicit"));
+    });
+  });
+
+  it("runCli fails closed (INVALID_REPO, exit 1) when --repo is omitted and no origin remote resolves", async () => {
+    await withGitCwd(null, async (cwd) => {
+      let err = "";
+      await runCli(["--project", "1"], {
+        env: {}, cwd, runChild: mockRunChild([]),
+        stdout: { write() {} }, stderr: { write(s) { err += s; } },
+      });
+      assert.equal(process.exitCode, 1);
+      assert.match(err, /INVALID_REPO/);
+      assert.match(err, /git origin remote/);
+      assert.match(err, /--repo/);
+      process.exitCode = 0; // avoid leaking a failure code into the test runner
     });
   });
 });


### PR DESCRIPTION
## Summary

`dev-loops queue list` / `dev-loops project list` (the same script) previously hard-required `--repo` and failed with `INVALID_REPO` even when run inside a checkout whose `origin` remote already names the repo. This change auto-detects the repo slug from the git `origin` remote when `--repo` is omitted, reusing the existing shared `detectRepoSlug` resolver. Explicit `--repo` still wins. Non-GitHub or absent remotes fail closed with `INVALID_REPO`, naming both the git-remote fallback and `--repo`.

The shared `detectRepoSlug` (`packages/core/src/github/repo-slug.mjs`) is hardened to resolve only when the remote host is exactly `github.com` (case-insensitive); every existing caller inherits the fail-closed fix. No second resolver is added.

Closes #1952

## Scope

In scope: `detectRepoSlug` host-hardening (`packages/core/src/github/repo-slug.mjs`) and the `runCli` auto-detect + INVALID_REPO fail-closed path for `queue list` / `project list` (`scripts/projects/list-queue-items.mjs`), plus the tests, USAGE text, and CHANGELOG entry. Two pre-existing test fixtures that relied on the old host-agnostic parsing are updated to stay hermetic. Out of scope: the items listed under Non-goals below.

## Acceptance criteria

- [x] `dev-loops queue list` inside a GitHub checkout resolves the repo from `origin` and succeeds without `--repo`.
- [x] Same for `dev-loops project list` (identical script via `PROJECT_ROUTES`; covered by construction + CHANGELOG alias note).
- [x] Explicit `--repo <owner/name>` overrides the auto-detected value (auto-detect only runs when `!args.repo`).
- [x] SSH (`git@github.com:owner/name.git`, `ssh://git@github.com/owner/name.git`) and HTTPS (`https://github.com/owner/name(.git)`) origin URLs resolve.
- [x] Outside a git repo, or with no resolvable GitHub remote, the command fails closed with `INVALID_REPO`; the message names both the git-remote fallback and the `--repo` override.
- [x] A single shared resolver is reused, not duplicated: the existing `detectRepoSlug` is imported into the CLI script; zero duplicated git-remote parsing.
- [x] `detectRepoSlug` hardened + unit-tested over SSH / HTTPS / `.git`-suffixed / no-remote / non-GitHub-host inputs.
- [x] CLI help updated: `--repo` no longer claimed unconditionally "Required"; documents the auto-detect fallback.
- [x] `.claude` regenerated (`generate-claude-assets.mjs` produced no diff for this change; nothing to commit there).
- [x] CHANGELOG `## Unreleased` entry added under `### Changed`.

## Definition of done

- `runCli` in `scripts/projects/list-queue-items.mjs` calls `detectRepoSlug(cwd)` when `args.repo` is unset (before `applyDevloopsBoard`/`main`), and fails closed with `INVALID_REPO` (exit 1) when nothing resolves.
- New `runCli` tests: auto-detect from a real `git init` + `origin`, explicit-`--repo`-wins over a different origin, and fail-closed with no origin.
- New `repo-slug` tests: SSH scp / `ssh://` positive cases, non-github.com host negative cases; existing HTTPS/`.git`/no-remote/unparseable cases retained.
- Full `bun run verify` green.

## Non-goals

- Auto-detecting the GitHub Project number/id (board still resolves from `.devloops`); repo slug only.
- Extending auto-detect to the write subcommands (`add`, `move`, `reorder`, `sync-status`, `archive-done`, `ensure`, `resolve-active`, `parked-unrefined`, `reconcile`); scoped to the read-only `list` command.
- Reworking other `scripts/github/*` `--repo` handling.
- GitHub Enterprise / custom-host remotes (`GH_HOST`); the host check is a hard-coded `github.com` comparison, not a configurable allowlist.

## Note for review

Hardening the shared `detectRepoSlug` to fail closed on non-github.com hosts required updating two pre-existing test fixtures that coincidentally relied on the old host-agnostic parsing (`test/dev-loops-cli.test.mjs`, `test/loop/resolve-dev-loop-startup.test.mjs`). Both remain fully hermetic/offline; no product behavior beyond the stated AC changed.
